### PR TITLE
Lionelb/fix 105 add deeplinking to fiche ministere travail

### DIFF
--- a/packages/code-du-travail-api/src/server/routes/api.js
+++ b/packages/code-du-travail-api/src/server/routes/api.js
@@ -30,7 +30,7 @@ router.get(`${BASE_URL}/suggest`, async ctx => {
       query,
       fragmentSize: 200,
       size: 5,
-      _source: ['title', 'source', 'slug'],
+      _source: ['title', 'source', 'slug', 'anchor'],
     })
   } catch (error) {
     console.trace(error.message)
@@ -48,7 +48,6 @@ router.get(`${BASE_URL}/suggest`, async ctx => {
  * @returns {Object} Result.
  */
 router.get(`${BASE_URL}/items/:source/:slug`, async ctx => {
-  console.log('params', ctx.params)
   try {
     ctx.body = await codeDuTravailNumerique.getSingleItem({
       source: ctx.params.source,

--- a/packages/code-du-travail-data/search/extraction/fiches_ministere_travail/data.py
+++ b/packages/code-du-travail-data/search/extraction/fiches_ministere_travail/data.py
@@ -76,11 +76,15 @@ def populate_fiches_ministere_travail(json_file=JSON_FICHES):
                         section_title = section_title.replace(pattern, '')
                         section_title = section_title[0].upper() + section_title[1:]
 
+                # extract the anchor part from the url '#comment-et-pourquoi'
+                anchor, = re.findall(r'(#.+$)',  section['url'])
+
                 FICHES_MINISTERE_TRAVAIL.append({
                     'title': section_title,
                     'text': section['text'],
                     'html': item.get("html"),
                     'url': section['url'],
+                    'anchor': anchor
                 })
 
     logger.debug('-' * 80)

--- a/packages/code-du-travail-data/search/indexing/create_indexes.py
+++ b/packages/code-du-travail-data/search/indexing/create_indexes.py
@@ -107,6 +107,7 @@ def create_documents(index_name, type_name):
             'source': 'fiches_ministere_travail',
             'slug': slugify(val['title'], to_lower=True),
             'text': val['text'],
+            'anchor': val['anchor'],
             'html': val["html"],
             'title': val['title'],
             'all_text': f"{val['title']} {val['text']}",

--- a/packages/code-du-travail-frontend/src/search/SearchResults.js
+++ b/packages/code-du-travail-frontend/src/search/SearchResults.js
@@ -5,7 +5,7 @@ import { Alert } from "@socialgouv/code-du-travail-ui";
 
 import FeedbackForm from "../common/FeedbackForm.js";
 import SeeAlso from "../common/SeeAlso";
-import { Link } from "../../routes";
+import Link from "next/link";
 
 import { getLabelBySource, getRouteBySource } from "../sources";
 
@@ -40,14 +40,18 @@ const ResultItem = withRouter(({ _id, _source, highlight, router }) => {
   const excerpt = makeExcerpt(highlight);
 
   const route = getRouteBySource(_source.source);
+  const anchor = _source.anchor ? _source.anchor.slice(1) : "";
 
   // internal links
   if (route) {
     return (
       <li className="search-results__item">
         <Link
-          route={route}
-          params={{ slug: _source.slug, q: router.query.q, search: 0 }}
+          href={{
+            pathname: `${route}/${_source.slug}`,
+            hash: anchor,
+            query: { q: router.query.q, search: 0 }
+          }}
         >
           <a className="search-results-link">
             <ContentBody

--- a/packages/code-du-travail-frontend/src/search/Suggester.js
+++ b/packages/code-du-travail-frontend/src/search/Suggester.js
@@ -4,7 +4,7 @@ import Autosuggest from "react-autosuggest";
 import styled from "styled-components";
 
 import AsyncFetch from "../lib/AsyncFetch";
-import { Router } from "../../routes";
+import Router from "next/router";
 import { getLabelBySource, getRouteBySource } from "../sources";
 
 const getSuggestionValue = suggestion =>
@@ -62,10 +62,15 @@ const renderSuggestionsContainer = ({ containerProps, children, query }) => (
 
 const onSuggestionSelected = (e, suggestion, query) => {
   e.preventDefault();
-  Router.pushRoute(getRouteBySource(suggestion.suggestion._source.source), {
-    slug: suggestion.suggestion._source.slug,
-    q: query,
-    search: 0
+  const route = getRouteBySource(suggestion.suggestion._source.source);
+  const anchor = suggestion.suggestion._source.anchor
+    ? suggestion.suggestion._source.anchor.slice(1)
+    : "";
+
+  Router.push({
+    pathname: `/${route}/${suggestion.suggestion._source.slug}`,
+    query: { q: query, search: 0 },
+    hash: anchor
   });
 };
 


### PR DESCRIPTION

extraction des ancres présentent dans les fiches du ministère du travail
j'ai aussi modifié l'api *suggest* retourne un param **anchor** 
coté front-end, j'utilise les `Link` et Router.push de next et non ceux next-routes car il ne supporte pas les `hash`dans les url

J'ai remarqué qu'il y avait une concaténation du titre du document avec le titre correspondant a l'ancre, je trouve ça étrange

fix #105

j'ai testé avec `emplo` pour afficher différents type de resource (avec et sans ancre)