### PR TITLE
ci: revert to actual version number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 sudo: false
 git:
   depth: 5
-node_js: lts/*
+node_js: 10
 cache: yarn
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.12.3


### PR DESCRIPTION
Following the previous build, Travis is note "*" character friendly.
Hence the cache is never found...