### PR TITLE
test(frontend): add global mock for next/config

### DIFF
--- a/packages/code-du-travail-frontend/src/common/__tests__/convention.service.test.js
+++ b/packages/code-du-travail-frontend/src/common/__tests__/convention.service.test.js
@@ -1,10 +1,5 @@
 import { searchIdcc } from "../convention.service";
 
-jest.mock("next/config", () => () => ({
-  publicRuntimeConfig: {
-    API_URL: "api.url"
-  }
-}));
 const results = {
   hits: {
     hits: [{ title: "foo", url: "bar.url" }]

--- a/packages/code-du-travail-frontend/src/layout/__tests__/Footer.test.js
+++ b/packages/code-du-travail-frontend/src/layout/__tests__/Footer.test.js
@@ -2,16 +2,6 @@ import React from "react";
 import { render } from "react-testing-library";
 import Footer from "../Footer";
 
-jest.mock(
-  "next/config",
-  () => () => ({
-    publicRuntimeConfig: {
-      API_URL: "api.url"
-    }
-  }),
-  { virtual: true }
-);
-
 describe("<Footer />", () => {
   it("should render", () => {
     const { container } = render(<Footer />);

--- a/packages/code-du-travail-frontend/test/jest.setup.js
+++ b/packages/code-du-travail-frontend/test/jest.setup.js
@@ -3,6 +3,12 @@ import "react-testing-library/cleanup-after-each";
 
 global.fetch = jest.fn();
 
+jest.mock("next/config", () => () => ({
+  publicRuntimeConfig: {
+    API_URL: "api.url"
+  }
+}));
+
 // trick to prevent @reach-modal warning if styles are not imported
 // jsdom doesn"t support it for now @see https://github.com/jsdom/jsdom/issues/1895
 document.documentElement.style.setProperty("--reach-modal", "1");


### PR DESCRIPTION
move 'next/config' mock into jest setup so we don't have race condiftions between import and mock 