### PR TITLE
fix(api): use process.env.API_PORT

### DIFF
--- a/packages/code-du-travail-api/src/server/index.js
+++ b/packages/code-du-travail-api/src/server/index.js
@@ -21,7 +21,7 @@ const API_BASE_URL = require("./routes/api").BASE_URL;
 const { logger } = require("./utils/logger");
 
 const app = new Koa();
-const PORT = process.env.PORT || 1337;
+const PORT = process.env.API_PORT || 1337;
 
 /**
  * use a middleware for catching errors and re-emit them


### PR DESCRIPTION
As we spread multiple envs vars from a simple `.env` in docker-compose, we have to use  dedicated var name