### PR TITLE
fix(api): return slug property when retrieving a single item

### DIFF
--- a/packages/code-du-travail-api/src/server/routes/api.js
+++ b/packages/code-du-travail-api/src/server/routes/api.js
@@ -79,6 +79,7 @@ router.get(`${BASE_URL}/items/:source/:slug`, async ctx => {
       "html",
       "date_debut", // code-du-travail
       "date",
+      "slug", // outils
       "path", // code-du-travail
       "id", // idcc, kali
       "description", // modele de courrier


### PR DESCRIPTION
getSingleItem retourne le slug. celui-ci et utiliser pour retrouver quel outils afficher

fixes #379