### PR TITLE
test(frontend): silent  warning

### DIFF
--- a/packages/code-du-travail-frontend/test/jest.setup.js
+++ b/packages/code-du-travail-frontend/test/jest.setup.js
@@ -11,6 +11,15 @@ jest.mock("react-piwik", () => ({
   push: jest.fn()
 }));
 
-// trick to prevent @reach-modal warning if styles are not imported
+// HACK(lionelB): trick to prevent @reach-modal warning if styles are not imported
 // jsdom doesn"t support it for now @see https://github.com/jsdom/jsdom/issues/1895
-document.documentElement.style.setProperty("--reach-modal", "1");
+// We will be able to use :
+// document.documentElement.style.setProperty("--reach-modal", "1");
+// when jsdom support it :)
+//
+// Meanwhile...
+//
+// HACK(douglasduteil): mock the check style function from `@reach/utils`
+// As `@reach/*` packages are usion the "checkStyles" function from `@reach/utils`
+// to warn us about missing stylesheet, we silent it with a mock 💩
+require("@reach/utils").checkStyles = jest.fn();


### PR DESCRIPTION
<img src=https://media.giphy.com/media/vdgq3PzB13XLq/giphy.gif width=693>

---

We repeatedly have this waring in our tests :

```
    console.warn ../../node_modules/@reach/utils/index.js:16
      @reach/dialog styles not found. If you are using a bundler like webpack or parcel include this in the entry file of your app before any of your own styles:

          import "@reach/dialog/styles.css";

        Otherwise you'll need to include them some other way:

          <link rel="stylesheet" type="text/css" href="node_modules/@reach/dialog/styles.css" />

        For more information visit https://ui.reach.tech/styling.
```

This is due to an internal `@reach/utils` styles check on CSS Custom Properties.
As @lionelB stated [5b83354@/packages/code-du-travail-frontend/test/jest.setup.js](https://github.com/SocialGouv/code-du-travail-numerique/blob/5b83354ebe05369aee67eb1bbef94d9d240c6e53/packages/code-du-travail-frontend/test/jest.setup.js),
jsdom doesn't support CSS Custom Properties for now @see https://github.com/jsdom/jsdom/issues/1895
So we hack it by mocking the check itself 💩