### PR TITLE
ci: change flag format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ jobs:
         -v $PWD/coverage:/app/packages/code-du-travail-frontend/coverage
         $DOCKER_IMAGE
         yarn workspace @cdt/frontend test --coverage
-      after_success: npx codecov --flags @cdt/frontend
+      after_success: npx codecov --flags frontend
     - <<: *main_code_quality_stage
       name: Test @cdt/api
       script: docker run


### PR DESCRIPTION
Following https://docs.codecov.io/docs#section-flag-creation

Flags must be lowercase, alphanumeric, and not exceed 45 characters
Only lowercase, alphanumeric values are accepted. `^[a-z0-9_]{1,45}$`