### PR TITLE
fix: update docker api image to access document from api

### DIFF
--- a/docker-compose.override.prod.yml
+++ b/docker-compose.override.prod.yml
@@ -24,6 +24,8 @@ services:
       - APM_SERVER_ACTIVE=1
     ports:
       - $API_PORT:$API_PORT
+     volumes:
+      - ./packages/code-du-travail-data/dataset/courrier-type/docx:/code-du-travail-data/dataset/courrier-type/docx
 
   # In production, add an APM Server
   apm:


### PR DESCRIPTION
j'ai modifié la config docker de api pour copier les document docx qui sont téléchargeable depuis l'api

le script de l'api qui se trouve dans `/app/dist` tente d'accéder à
`../../../code-du-travail-data/dataset/courrier-type/docx`   theoriquement cadevrait être `../..` mais comme on peut pas remonter plus haut, ca marche™

c'est pas joli joli mais ca fonctionne, en attendant de trouver une meilleure solution
