### PR TITLE
ci: pass api test env inside package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,8 +135,6 @@ jobs:
         -v $PWD/coverage:/app/packages/code-du-travail-api/coverage
         -e ELASTICSEARCH_URL=http://elasticsearch:9200
         -e ELASTICSEARCH_LOG_LEVEL=info
-        -e ELASTICSEARCH_DOCUMENT_INDEX=cdtn_document_test
-        -e ELASTICSEARCH_ANNUAIRE_INDEX=cdtn_annuaire_test
         --network $(docker network ls -qf name=code)
         $DOCKER_IMAGE
         yarn workspace @cdt/api test --coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,6 @@ jobs:
       name: Pull Request Stage
       env:
         - ELASTICSEARCH_LOG_LEVEL=info
-        - ELASTICSEARCH_DOCUMENT_INDEX=cdtn_document_test
-        - ELASTICSEARCH_ANNUAIRE_INDEX=cdtn_annuaire_test
       before_install:
         - yarn global add @commitlint/travis-cli @commitlint/config-conventional
         - commitlint-travis

--- a/packages/code-du-travail-api/package.json
+++ b/packages/code-du-travail-api/package.json
@@ -10,7 +10,7 @@
     "prepush": "yarn lint",
     "start": "node ./dist/index.js",
     "dev": "nodemon ./src/server/index.js",
-    "test": "jest",
+    "test": "ELASTICSEARCH_DOCUMENT_INDEX=cdtn_document_test ELASTICSEARCH_ANNUAIRE_INDEX=cdtn_annuaire_test jest",
     "elastic": "node scripts/elastic.js"
   },
   "repository": {


### PR DESCRIPTION
 move env variable to package.json, since test should always use dedicated index 