### PR TITLE
feat(frontend): add Company Suggester to find the CCN with a SIRET number

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,6 +5,7 @@ NODE_ENV=production
 # frontend
 FRONTEND_PORT=3006
 API_URL=http://127.0.0.1:3005/api/v1
+API_SIRET2IDCC_URL=https://siret2idcc.num.social.gouv.fr/
 SENTRY_PUBLIC_DSN=https://xxxxxxx@sentry.test.com/5
 PIWIK_URL=https://stats.pouet.com
 PIWIK_SITE_ID=42

--- a/packages/code-du-travail-api/src/server/routes/__tests__/__snapshots__/idcc.spec.js.snap
+++ b/packages/code-du-travail-api/src/server/routes/__tests__/__snapshots__/idcc.spec.js.snap
@@ -9,6 +9,7 @@ Object {
       "_score": 2.1846728,
       "_source": Object {
         "idcc": "843",
+        "slug": "843-convention-collective-nationale-de-la-boulangerie-patisserie-du-19-mars-1976",
         "title": "Convention collective nationale de la boulangerie-pâtisserie du 19 mars 1976.  Etendue par arrêté du 21 juin 1978 JONC 28 juillet 1978.",
         "url": "https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635886",
       },
@@ -20,6 +21,7 @@ Object {
       "_score": 2.1846728,
       "_source": Object {
         "idcc": "1747",
+        "slug": "1747-convention-collective-nationale-des-activites-industrielles-de-boulangerie",
         "title": "Convention collective nationale des activités industrielles de boulangerie et pâtisserie du 13 juillet 1993. Mise à jour par avenant n°10 du 11 octobre 2011.",
         "url": "https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635691",
       },
@@ -28,5 +30,26 @@ Object {
   ],
   "max_score": 2.1846728,
   "total": 2,
+}
+`;
+
+exports[`return idcc results for num 843 1`] = `
+Object {
+  "hits": Array [
+    Object {
+      "_id": "10",
+      "_index": "cdtn_document_test",
+      "_score": 0,
+      "_source": Object {
+        "idcc": "843",
+        "slug": "843-convention-collective-nationale-de-la-boulangerie-patisserie-du-19-mars-1976",
+        "title": "Convention collective nationale de la boulangerie-pâtisserie du 19 mars 1976.  Etendue par arrêté du 21 juin 1978 JONC 28 juillet 1978.",
+        "url": "https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635886",
+      },
+      "_type": "cdtn_document_test",
+    },
+  ],
+  "max_score": 0,
+  "total": 1,
 }
 `;

--- a/packages/code-du-travail-api/src/server/routes/__tests__/__snapshots__/idcc.spec.js.snap
+++ b/packages/code-du-travail-api/src/server/routes/__tests__/__snapshots__/idcc.spec.js.snap
@@ -35,21 +35,15 @@ Object {
 
 exports[`return idcc results for num 843 1`] = `
 Object {
-  "hits": Array [
-    Object {
-      "_id": "10",
-      "_index": "cdtn_document_test",
-      "_score": 0,
-      "_source": Object {
-        "idcc": "843",
-        "slug": "843-convention-collective-nationale-de-la-boulangerie-patisserie-du-19-mars-1976",
-        "title": "Convention collective nationale de la boulangerie-pâtisserie du 19 mars 1976.  Etendue par arrêté du 21 juin 1978 JONC 28 juillet 1978.",
-        "url": "https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635886",
-      },
-      "_type": "cdtn_document_test",
-    },
-  ],
-  "max_score": 0,
-  "total": 1,
+  "_id": "10",
+  "_index": "cdtn_document_test",
+  "_score": 0,
+  "_source": Object {
+    "idcc": "843",
+    "slug": "843-convention-collective-nationale-de-la-boulangerie-patisserie-du-19-mars-1976",
+    "title": "Convention collective nationale de la boulangerie-pâtisserie du 19 mars 1976.  Etendue par arrêté du 21 juin 1978 JONC 28 juillet 1978.",
+    "url": "https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635886",
+  },
+  "_type": "cdtn_document_test",
 }
 `;

--- a/packages/code-du-travail-api/src/server/routes/__tests__/idcc.spec.js
+++ b/packages/code-du-travail-api/src/server/routes/__tests__/idcc.spec.js
@@ -14,7 +14,12 @@ test("return idcc results for boulangerie", async () => {
 });
 
 test("return idcc results for num 843", async () => {
-  const response = await request(app.callback()).get(`/api/v1/idcc?num=843`);
+  const response = await request(app.callback()).get(`/api/v1/idcc/843`);
   expect(response.status).toBe(200);
-  expect(response.body.hits).toMatchSnapshot();
+  expect(response.body).toMatchSnapshot();
+});
+
+test("returns 404 when IDCC with num not found", async () => {
+  const response = await request(app.callback()).get(`/api/v1/idcc/8434`);
+  expect(response.status).toBe(404);
 });

--- a/packages/code-du-travail-api/src/server/routes/__tests__/idcc.spec.js
+++ b/packages/code-du-travail-api/src/server/routes/__tests__/idcc.spec.js
@@ -12,3 +12,9 @@ test("return idcc results for boulangerie", async () => {
   expect(response.status).toBe(200);
   expect(response.body.hits).toMatchSnapshot();
 });
+
+test("return idcc results for num 843", async () => {
+  const response = await request(app.callback()).get(`/api/v1/idcc?num=843`);
+  expect(response.status).toBe(200);
+  expect(response.body.hits).toMatchSnapshot();
+});

--- a/packages/code-du-travail-api/src/server/routes/idcc/idcc.elastic.js
+++ b/packages/code-du-travail-api/src/server/routes/idcc/idcc.elastic.js
@@ -1,7 +1,7 @@
 function getIdccBody({ query }) {
   return {
     size: 1000,
-    _source: ["title", "url", "idcc"],
+    _source: ["title", "url", "idcc", "slug"],
     query: {
       bool: {
         filter: [

--- a/packages/code-du-travail-api/src/server/routes/idcc/idccByNum.elastic.js
+++ b/packages/code-du-travail-api/src/server/routes/idcc/idccByNum.elastic.js
@@ -1,0 +1,24 @@
+function getIdccByNumBody({ query }) {
+  return {
+    size: 1,
+    _source: ["title", "url", "idcc", "slug"],
+    query: {
+      bool: {
+        filter: [
+          {
+            term: {
+              source: "kali"
+            }
+          },
+          {
+            term: {
+              idcc: query
+            }
+          }
+        ]
+      }
+    }
+  };
+}
+
+module.exports = getIdccByNumBody;

--- a/packages/code-du-travail-api/src/server/routes/idcc/index.js
+++ b/packages/code-du-travail-api/src/server/routes/idcc/index.js
@@ -3,6 +3,7 @@ const API_BASE_URL = require("../v1.prefix");
 
 const elasticsearchClient = require("../../conf/elasticsearch.js");
 const getIdccBody = require("./idcc.elastic");
+const getIdccByNumBody = require("./idccByNum.elastic");
 
 const index =
   process.env.ELASTICSEARCH_DOCUMENT_INDEX || "code_du_travail_numerique";
@@ -18,12 +19,17 @@ const router = new Router({ prefix: API_BASE_URL });
  * http://localhost:1337/api/v1/idcc?q=1020Z
  *
  * @param {string} querystring.q A `q` querystring param containing the query to process.
+ * @param {string} querystring.num A `num` querystring param containing the num to process.
  * @returns {Object} Results.
  */
 router.get("/idcc", async ctx => {
-  const query = ctx.request.query.q;
+  let body;
+  if (ctx.request.query.num) {
+    body = getIdccByNumBody({ query: ctx.request.query.num });
+  } else {
+    body = getIdccBody({ query: ctx.request.query.q });
+  }
 
-  const body = getIdccBody({ query });
   ctx.body = await elasticsearchClient.search({ index, body });
 });
 

--- a/packages/code-du-travail-frontend/next.config.js
+++ b/packages/code-du-travail-frontend/next.config.js
@@ -19,6 +19,8 @@ module.exports = withCSS({
   },
   publicRuntimeConfig: {
     API_URL: process.env.API_URL || "http://127.0.0.1:1337/api/v1",
+    API_SIRET2IDCC_URL:
+      process.env.API_SIRET2IDCC_URL || "https://siret2idcc.num.social.gouv.fr",
     API_ADDRESS: "https://api-adresse.data.gouv.fr/search",
     PACKAGE_VERSION: require("./package.json").version,
     SENTRY_PUBLIC_DSN: process.env.SENTRY_PUBLIC_DSN,

--- a/packages/code-du-travail-frontend/pages/kali.js
+++ b/packages/code-du-travail-frontend/pages/kali.js
@@ -14,33 +14,32 @@ const {
 
 // a FAQ answer
 
-const fetchKali = ({ slug, idccNum }) =>
-  slug
-    ? fetch(`${API_URL}/items/kali/${slug}`).then(r => r.json())
-    : fetch(`${API_URL}/idcc?num=${idccNum}`)
-        .then(r => r.json())
-        .then(r => r.hits.hits)
-        .then(hits => {
-          return hits.length == 1 ? hits[0] : null;
-        });
+const fetchKali = ({ slug, idccNum }) => {
+  const url = slug
+    ? `${API_URL}/items/kali/${slug}`
+    : `${API_URL}/idcc/${idccNum}`;
+  return fetch(url)
+    .then(r => r.json())
+    .then(r => r.status != 404 && r._source);
+};
 
 class Kali extends React.Component {
   static async getInitialProps({ query }) {
-    const data = await fetchKali(query);
-    return { data };
+    const convention = await fetchKali(query);
+    return { convention };
   }
 
   render() {
-    const { data } = this.props;
-    if (!data || data.status === 404) {
+    if (!this.props.convention) {
       return (
         <Answer emptyMessage="Cette convention collective n'a pas été trouvée" />
       );
     }
+    const { title, url } = this.props.convention;
     return (
       <PageLayout>
         <Answer
-          title={data._source.title}
+          title={title}
           emptyMessage="Cette convention collective n'a pas été trouvée"
           footer="Informations fournies par la DILA"
           sourceType="Convention collective"
@@ -50,7 +49,7 @@ class Kali extends React.Component {
             Cliquez sur le lien ci dessous pour accéder à la convention
             collective sur LegiFrance :
           </p>
-          <a target="_blank" rel="noopener noreferrer" href={data._source.url}>
+          <a target="_blank" rel="noopener noreferrer" href={url}>
             <Button primary>
               <ExternalLink
                 style={{ verticalAlign: "middle", marginRight: 10 }}

--- a/packages/code-du-travail-frontend/pages/kali.js
+++ b/packages/code-du-travail-frontend/pages/kali.js
@@ -14,8 +14,15 @@ const {
 
 // a FAQ answer
 
-const fetchKali = ({ slug }) =>
-  fetch(`${API_URL}/items/kali/${slug}`).then(r => r.json());
+const fetchKali = ({ slug, idccNum }) =>
+  slug
+    ? fetch(`${API_URL}/items/kali/${slug}`).then(r => r.json())
+    : fetch(`${API_URL}/idcc?num=${idccNum}`)
+        .then(r => r.json())
+        .then(r => r.hits.hits)
+        .then(hits => {
+          return hits.length == 1 ? hits[0] : null;
+        });
 
 class Kali extends React.Component {
   static async getInitialProps({ query }) {
@@ -25,7 +32,7 @@ class Kali extends React.Component {
 
   render() {
     const { data } = this.props;
-    if (data.status === 404) {
+    if (!data || data.status === 404) {
       return (
         <Answer emptyMessage="Cette convention collective n'a pas été trouvée" />
       );

--- a/packages/code-du-travail-frontend/routes.js
+++ b/packages/code-du-travail-frontend/routes.js
@@ -51,6 +51,13 @@ module.exports = routes()
     pattern: "/kali/:slug"
   })
 
+  // http://localhost:3000/kali/1930-nouvelle-convention-collective-nationale-des-metiers-de-la-transformation-des-gr
+  .add({
+    name: "kaliIdcc",
+    page: "kali",
+    pattern: "/kali-idcc/:idccNum"
+  })
+
   // http://localhost:3000/outils/indemnite-licenciement
   .add({
     name: "outils",

--- a/packages/code-du-travail-frontend/routes.js
+++ b/packages/code-du-travail-frontend/routes.js
@@ -53,7 +53,7 @@ module.exports = routes()
 
   // http://localhost:3000/kali/1930-nouvelle-convention-collective-nationale-des-metiers-de-la-transformation-des-gr
   .add({
-    name: "kaliIdcc",
+    name: "kali-idcc",
     page: "kali",
     pattern: "/kali-idcc/:idccNum"
   })

--- a/packages/code-du-travail-frontend/src/common/CompanyForm.js
+++ b/packages/code-du-travail-frontend/src/common/CompanyForm.js
@@ -1,0 +1,103 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { X } from "react-feather";
+import styled from "styled-components";
+import { Button } from "@cdt/ui";
+import { CompanySuggester } from "./CompanySuggester";
+import { ConventionPreview, SuggestWrapper, Title } from "./ConventionForm";
+
+class CompanyForm extends React.Component {
+  static propTypes = {
+    onSearch: PropTypes.func.isRequired,
+    getCompany: PropTypes.func.isRequired
+  };
+
+  state = {
+    company: null
+  };
+
+  onSelect = company => {
+    this.setState({ company });
+    this.props.getCompany(company.siret).then(company => {
+      this.setState({ company });
+    });
+  };
+
+  onClear = () => this.setState({ company: null });
+
+  render() {
+    const { company } = this.state;
+    return (
+      <form>
+        <Title>Recherche par SIRET</Title>
+        Saisissez le numéro de SIRET de votre entreprise afin d&apos;obtenir
+        votre convention collective&nbsp;:
+        <SuggestWrapper>
+          {!this.state.company ? (
+            <React.Fragment>
+              <CompanySuggester
+                onSearch={this.props.onSearch}
+                onSelect={this.onSelect}
+              />
+              <p style={{ fontStyle: "italic" }}>
+                Vous pouvez chercher le SIRET de votre entreprise sur&nbsp;
+                <a href="https://entreprise.data.gouv.fr/">
+                  entreprise.data.gouv.fr
+                </a>
+              </p>
+            </React.Fragment>
+          ) : (
+            <React.Fragment>
+              <Company onClear={this.onClear} {...company} />
+            </React.Fragment>
+          )}
+        </SuggestWrapper>
+      </form>
+    );
+  }
+}
+
+const Company = ({ name, idccList, onClear }) => {
+  return (
+    <div>
+      <div>
+        <b>{name}</b>
+        <div>
+          <Button link onClick={onClear}>
+            Chercher une autre entreprise
+          </Button>
+          <Button link onClick={onClear}>
+            {/* it does not seem to work when in the same Button */}
+            <X size="16" />
+          </Button>
+        </div>
+      </div>
+      {idccList ? (
+        <React.Fragment>
+          <CompanyIdccListWrapper>
+            Cette entreprise emploie des salariés sous
+            {idccList.length == 1
+              ? " une seule convention collective"
+              : ` ${idccList.length} conventions collectives`}
+            &nbsp;:
+          </CompanyIdccListWrapper>
+          <ul>
+            {idccList.map(idcc => (
+              <li key={idcc.num} data-testid="companyIdcc">
+                <ConventionPreview idcc={idcc.num} title={idcc.titre} />
+              </li>
+            ))}
+          </ul>
+        </React.Fragment>
+      ) : (
+        "..."
+      )}
+    </div>
+  );
+};
+
+const CompanyIdccListWrapper = styled.div`
+  margin: 10px 0;
+`;
+
+export { CompanyForm };

--- a/packages/code-du-travail-frontend/src/common/CompanyForm.js
+++ b/packages/code-du-travail-frontend/src/common/CompanyForm.js
@@ -16,11 +16,10 @@ class CompanyForm extends React.Component {
     company: null
   };
 
-  onSelect = company => {
+  onSelect = async company => {
     this.setState({ company });
-    this.props.getCompany(company.siret).then(company => {
-      this.setState({ company });
-    });
+    const fullCompany = await this.props.getCompany(company.siret);
+    this.setState({ company: fullCompany });
   };
 
   onClear = () => this.setState({ company: null });

--- a/packages/code-du-travail-frontend/src/common/CompanySuggester.js
+++ b/packages/code-du-travail-frontend/src/common/CompanySuggester.js
@@ -5,7 +5,7 @@ import {
   renderSuggestionsContainer,
   Suggestion,
   suggesterTheme
-} from "./IdccSuggester";
+} from "./IdccSuggesterTheme";
 
 export const reformatSiret = value =>
   value

--- a/packages/code-du-travail-frontend/src/common/CompanySuggester.js
+++ b/packages/code-du-travail-frontend/src/common/CompanySuggester.js
@@ -24,7 +24,10 @@ export class CompanySuggester extends React.Component {
     this.props.onSelect(value);
   };
 
-  renderMessage = (query, suggestions) => {
+  renderMessage = (query, suggestions, loading) => {
+    if (loading) {
+      return <p>chargement ...</p>;
+    }
     const helpMessage =
       suggestions != null &&
       suggestions.length == 0 &&

--- a/packages/code-du-travail-frontend/src/common/CompanySuggester.js
+++ b/packages/code-du-travail-frontend/src/common/CompanySuggester.js
@@ -23,6 +23,17 @@ export class CompanySuggester extends React.Component {
   onSelect = value => {
     this.props.onSelect(value);
   };
+
+  renderMessage = (query, suggestions) => {
+    const helpMessage =
+      suggestions != null &&
+      suggestions.length == 0 &&
+      query.replace(/ /g, "").length == 14 &&
+      `Aucune entreprise trouvée pour le SIRET ${query}`;
+    // we display the <p> tag even when there is no message to prevent flickering
+    return <p>{helpMessage ? helpMessage : <span>&nbsp;</span>}</p>;
+  };
+
   render() {
     return (
       <Suggester
@@ -34,14 +45,8 @@ export class CompanySuggester extends React.Component {
         theme={suggesterTheme}
         // inserts spaces to have a "000 000 000 00000" format and limits to 14 chars
         reformatEnteredValue={reformatSiret}
-        // remove spaces when sending query for search
-        reformatSearchedValue={v => v.replace(/ /g, "")}
         // only display an error message when the query is 14 chars long
-        getHelpMessage={(query, suggestions) =>
-          suggestions.length == 0 &&
-          query.replace(/ /g, "").length == 14 &&
-          `Aucune entreprise trouvée pour le SIRET ${query}`
-        }
+        renderMessage={this.renderMessage}
       />
     );
   }

--- a/packages/code-du-travail-frontend/src/common/CompanySuggester.js
+++ b/packages/code-du-travail-frontend/src/common/CompanySuggester.js
@@ -7,6 +7,14 @@ import {
   suggesterTheme
 } from "./IdccSuggester";
 
+export const reformatSiret = value =>
+  value
+    .toString()
+    .replace(/ /g, "")
+    .substring(0, 14)
+    .replace(/(\d{1,3})?(\d{1,3})?(\d{1,3})?(\d{1,5})?/, "$1 $2 $3 $4")
+    .trim();
+
 export class CompanySuggester extends React.Component {
   static propTypes = {
     onSearch: PropTypes.func.isRequired,
@@ -25,14 +33,7 @@ export class CompanySuggester extends React.Component {
         placeholder="Numéro de SIRET à 14 chiffres"
         theme={suggesterTheme}
         // inserts spaces to have a "000 000 000 00000" format and limits to 14 chars
-        reformatEnteredValue={v =>
-          v
-            .toString()
-            .replace(/ /g, "")
-            .substring(0, 14)
-            .replace(/(\d{1,3})?(\d{1,3})?(\d{1,3})?(\d{1,5})?/, "$1 $2 $3 $4")
-            .trim()
-        }
+        reformatEnteredValue={reformatSiret}
         // remove spaces when sending query for search
         reformatSearchedValue={v => v.replace(/ /g, "")}
         // only display an error message when the query is 14 chars long

--- a/packages/code-du-travail-frontend/src/common/CompanySuggester.js
+++ b/packages/code-du-travail-frontend/src/common/CompanySuggester.js
@@ -1,0 +1,51 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Suggester } from "./Suggester";
+import {
+  renderSuggestionsContainer,
+  Suggestion,
+  suggesterTheme
+} from "./IdccSuggester";
+
+export class CompanySuggester extends React.Component {
+  static propTypes = {
+    onSearch: PropTypes.func.isRequired,
+    onSelect: PropTypes.func.isRequired
+  };
+  onSelect = value => {
+    this.props.onSelect(value);
+  };
+  render() {
+    return (
+      <Suggester
+        onSearch={this.props.onSearch}
+        onSelect={this.onSelect}
+        renderSuggestion={renderSuggestion}
+        renderSuggestionsContainer={renderSuggestionsContainer}
+        placeholder="Numéro de SIRET à 14 chiffres"
+        theme={suggesterTheme}
+        // inserts spaces to have a "000 000 000 00000" format and limits to 14 chars
+        reformatEnteredValue={v =>
+          v
+            .toString()
+            .replace(/ /g, "")
+            .substring(0, 14)
+            .replace(/(\d{1,3})?(\d{1,3})?(\d{1,3})?(\d{1,5})?/, "$1 $2 $3 $4")
+            .trim()
+        }
+        // remove spaces when sending query for search
+        reformatSearchedValue={v => v.replace(/ /g, "")}
+        // only display an error message when the query is 14 chars long
+        getHelpMessage={(query, suggestions) =>
+          suggestions.length == 0 &&
+          query.replace(/ /g, "").length == 14 &&
+          `Aucune entreprise trouvée pour le SIRET ${query}`
+        }
+      />
+    );
+  }
+}
+
+const renderSuggestion = suggestion => (
+  <Suggestion>{suggestion.name}</Suggestion>
+);

--- a/packages/code-du-travail-frontend/src/common/ConventionForm.js
+++ b/packages/code-du-travail-frontend/src/common/ConventionForm.js
@@ -4,6 +4,7 @@ import { X } from "react-feather";
 import styled from "styled-components";
 import { Button } from "@cdt/ui";
 import { IdccSuggester } from "./IdccSuggester";
+import { Link } from "../../routes";
 
 class ConventionForm extends React.Component {
   static propTypes = {
@@ -87,11 +88,14 @@ const Subtitle = styled.div`
 `;
 
 const ConventionPreview = ({ slug, idcc, title }) => {
-  const path = slug ? `/kali/${slug}` : `/kali-idcc/${idcc}`;
+  const route = slug ? "kali" : "kali-idcc";
+  const params = slug ? { slug } : { idccNum: idcc };
   return (
-    <a href={path}>
-      IDCC {idcc} {title ? `- ${title}` : ""}
-    </a>
+    <Link route={route} params={params}>
+      <a>
+        IDCC {idcc} {title ? `- ${title}` : ""}
+      </a>
+    </Link>
   );
 };
 ConventionPreview.propTypes = {

--- a/packages/code-du-travail-frontend/src/common/ConventionForm.js
+++ b/packages/code-du-travail-frontend/src/common/ConventionForm.js
@@ -97,7 +97,7 @@ const ConventionPreview = ({ slug, idcc, title }) => {
 ConventionPreview.propTypes = {
   slug: PropTypes.string,
   idcc: PropTypes.string,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string
 };
 
 export { ConventionForm, ConventionPreview, Title, SuggestWrapper };

--- a/packages/code-du-travail-frontend/src/common/ConventionForm.js
+++ b/packages/code-du-travail-frontend/src/common/ConventionForm.js
@@ -1,11 +1,11 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { X, Download } from "react-feather";
+import { X } from "react-feather";
 import styled from "styled-components";
 import { Button } from "@cdt/ui";
 import { IdccSuggester } from "./IdccSuggester";
 
-export class ConventionForm extends React.Component {
+class ConventionForm extends React.Component {
   static propTypes = {
     onSearch: PropTypes.func.isRequired
   };
@@ -25,10 +25,11 @@ export class ConventionForm extends React.Component {
   render() {
     return (
       <form>
-        <h2>Convention collective</h2>
+        <h2>Trouvez votre convention collective</h2>
         <div>
+          <Title>Recherche par nom ou par identifiant</Title>
           Saisissez l&apos;identifiant de convention collective (IDCC) ou le nom
-          de la branche :
+          de la branche&nbsp;:
           <SuggestWrapper>
             {!this.state.convention ? (
               <IdccSuggester
@@ -37,14 +38,14 @@ export class ConventionForm extends React.Component {
               />
             ) : (
               <React.Fragment>
-                <ConventionPreview data={this.state.convention} />
+                <ConventionPreview {...this.state.convention} />
                 <Button link onClick={this.onClearConvention}>
                   <X size="16" />
                 </Button>
               </React.Fragment>
             )}
           </SuggestWrapper>
-          <Title>Comment trouver ma convention collective ?</Title>
+          <Subtitle>Comment trouver ma convention collective ?</Subtitle>
           <ul>
             <li>
               Elle doit figurer au <b>bulletin de paie</b>, et sur une notice
@@ -55,7 +56,7 @@ export class ConventionForm extends React.Component {
               modalités de consultation en entreprise)
             </li>
           </ul>
-          <Title>Quelle est la convention collective applicable ?</Title>
+          <Subtitle>Quelle est la convention collective applicable ?</Subtitle>
           <ul>
             <li>
               En principe celle relevant de l&apos;activité principale dans
@@ -73,27 +74,30 @@ const SuggestWrapper = styled.div`
 `;
 
 const Title = styled.h3`
-  color: initial;
+  color: #000;
   font-size: 1.2em;
   margin-top: 20px;
 `;
 
-const ConventionPreview = ({ data }) => {
+const Subtitle = styled.div`
+  color: #666;
+  font-size: 1em;
+  font-weight: bold;
+  margin: 20px 0 10px 0;
+`;
+
+const ConventionPreview = ({ slug, idcc, title }) => {
+  const path = slug ? `/kali/${slug}` : `/kali-idcc/${idcc}`;
   return (
-    <a target="_blank" href={data.url} rel="noopener noreferrer">
-      <Download
-        alt="Télécharger la convention"
-        title="Télécharger la convention"
-        size="16"
-        style={{ marginRight: 5 }}
-      />
-      IDCC {data.idcc} - {data.title}
+    <a href={path}>
+      IDCC {idcc} {title ? `- ${title}` : ""}
     </a>
   );
 };
 ConventionPreview.propTypes = {
-  data: PropTypes.shape({
-    title: PropTypes.string.isRequired,
-    url: PropTypes.string.isRequired
-  }).isRequired
+  slug: PropTypes.string,
+  idcc: PropTypes.string,
+  title: PropTypes.string.isRequired
 };
+
+export { ConventionForm, ConventionPreview, Title, SuggestWrapper };

--- a/packages/code-du-travail-frontend/src/common/IdccSuggester.js
+++ b/packages/code-du-travail-frontend/src/common/IdccSuggester.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { Suggester } from "./Suggester";
 import styled from "styled-components";
 
-export class IdccSuggester extends React.Component {
+class IdccSuggester extends React.Component {
   static propTypes = {
     onSearch: PropTypes.func.isRequired,
     onSelect: PropTypes.func.isRequired
@@ -88,4 +88,11 @@ const suggesterTheme = {
   suggestionHighlighted: {
     background: "#eee"
   }
+};
+
+export {
+  IdccSuggester,
+  renderSuggestionsContainer,
+  Suggestion,
+  suggesterTheme
 };

--- a/packages/code-du-travail-frontend/src/common/IdccSuggester.js
+++ b/packages/code-du-travail-frontend/src/common/IdccSuggester.js
@@ -1,9 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Suggester } from "./Suggester";
-import styled from "styled-components";
+import {
+  renderSuggestionsContainer,
+  Suggestion,
+  suggesterTheme
+} from "./IdccSuggesterTheme";
 
-class IdccSuggester extends React.Component {
+export class IdccSuggester extends React.Component {
   static propTypes = {
     onSearch: PropTypes.func.isRequired,
     onSelect: PropTypes.func.isRequired
@@ -31,27 +35,6 @@ const getSuggestionValue = suggestion =>
     ? `${suggestion._source.idcc} - ${suggestion._source.title}`
     : suggestion._source.title;
 
-const SuggestionsContainer = styled.div`
-  li[role="option"]:nth-child(2n + 1) {
-    background: #f7f7f7;
-  }
-`;
-
-const renderSuggestionsContainer = ({ containerProps, children }) => (
-  <SuggestionsContainer {...containerProps}>{children}</SuggestionsContainer>
-);
-
-const Suggestion = styled.div`
-  width: 90%;
-  overflow: hidden;
-  padding: 5px;
-  font-size: 0.9rem;
-  text-decoration: underline;
-  :hover {
-    text-decoration: none;
-  }
-`;
-
 const renderSuggestion = suggestion => {
   return (
     <Suggestion>
@@ -60,39 +43,4 @@ const renderSuggestion = suggestion => {
         : suggestion._source.title}
     </Suggestion>
   );
-};
-
-// see https://github.com/moroshko/react-autosuggest#themeProp
-const suggesterTheme = {
-  container: {
-    position: "relative"
-  },
-  suggestionsContainerOpen: {
-    maxHeight: "300px",
-    border: "1px solid silver",
-    position: "absolute",
-    overflowY: "scroll",
-    left: 0,
-    right: 0,
-    borderRadius: "3px",
-    borderRopLeftRadius: 0,
-    borderTopRightRadius: 0,
-    marginTop: "-3px",
-    boxShadow: "0 5px 20px 0 rgba(0, 0, 0, 0.3)"
-  },
-  suggestionsList: {
-    margin: 0,
-    padding: 0,
-    background: "white"
-  },
-  suggestionHighlighted: {
-    background: "#eee"
-  }
-};
-
-export {
-  IdccSuggester,
-  renderSuggestionsContainer,
-  Suggestion,
-  suggesterTheme
 };

--- a/packages/code-du-travail-frontend/src/common/IdccSuggesterTheme.js
+++ b/packages/code-du-travail-frontend/src/common/IdccSuggesterTheme.js
@@ -1,0 +1,51 @@
+import React from "react";
+import styled from "styled-components";
+
+const SuggestionsContainer = styled.div`
+  li[role="option"]:nth-child(2n + 1) {
+    background: #f7f7f7;
+  }
+`;
+
+export const renderSuggestionsContainer = ({ containerProps, children }) => (
+  <SuggestionsContainer {...containerProps}>{children}</SuggestionsContainer>
+);
+
+export const Suggestion = styled.div`
+  width: 90%;
+  overflow: hidden;
+  padding: 5px;
+  font-size: 0.9rem;
+  text-decoration: underline;
+  :hover {
+    text-decoration: none;
+  }
+`;
+
+// see https://github.com/moroshko/react-autosuggest#themeProp
+export const suggesterTheme = {
+  container: {
+    position: "relative"
+  },
+  suggestionsContainerOpen: {
+    maxHeight: "300px",
+    border: "1px solid silver",
+    position: "absolute",
+    overflowY: "scroll",
+    left: 0,
+    right: 0,
+    borderRadius: "3px",
+    borderRopLeftRadius: 0,
+    borderTopRightRadius: 0,
+    marginTop: "-3px",
+    boxShadow: "0 5px 20px 0 rgba(0, 0, 0, 0.3)"
+  },
+  suggestionsList: {
+    margin: 0,
+    padding: 0,
+    background: "white"
+  },
+  suggestionHighlighted: {
+    background: "#eee"
+  }
+};

--- a/packages/code-du-travail-frontend/src/common/Suggester.js
+++ b/packages/code-du-travail-frontend/src/common/Suggester.js
@@ -11,9 +11,8 @@ export class Suggester extends React.Component {
     renderSuggestion: PropTypes.func,
     renderSuggestionsContainer: PropTypes.func,
     theme: PropTypes.object,
-    reformatSearchedValue: PropTypes.func,
     reformatEnteredValue: PropTypes.func,
-    getHelpMessage: PropTypes.func
+    renderMessage: PropTypes.func
   };
 
   static defaultProps = {
@@ -23,14 +22,13 @@ export class Suggester extends React.Component {
     renderSuggestion: suggestion => <span>{suggestion.toString()}</span>,
     renderSuggestionsContainer: undefined,
     theme: undefined,
-    reformatSearchedValue: v => v,
+    renderMessage: () => null,
     reformatEnteredValue: v => v
   };
 
   state = {
     query: "",
-    suggestions: [],
-    loading: false
+    suggestions: null
   };
 
   onChange = event => {
@@ -46,24 +44,23 @@ export class Suggester extends React.Component {
   };
 
   onSuggestionsFetchRequested = ({ value }) => {
-    this.setState({ loading: true });
-    this.props.onSearch(this.props.reformatSearchedValue(value)).then(results =>
+    this.setState({ suggestions: null });
+    this.props.onSearch(value).then(results =>
       this.setState({
-        suggestions: results,
-        loading: false
+        suggestions: results
       })
     );
   };
 
   onSuggestionsClearRequested = () => {
     this.setState({
-      suggestions: []
+      suggestions: null
     });
   };
 
   render() {
-    const { loading, suggestions, query } = this.state;
-    const { placeholder, className, getHelpMessage } = this.props;
+    const { suggestions, query } = this.state;
+    const { placeholder, className } = this.props;
     const inputProps = {
       name: "query",
       placeholder: placeholder,
@@ -72,13 +69,11 @@ export class Suggester extends React.Component {
       onChange: this.onChange,
       className: className
     };
-    const helpMessage =
-      !loading && getHelpMessage && getHelpMessage(query, suggestions);
 
     return (
       <React.Fragment>
         <Autosuggest
-          suggestions={suggestions}
+          suggestions={suggestions || []}
           onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
           onSuggestionsClearRequested={this.onSuggestionsClearRequested}
           onSuggestionSelected={this.onSuggestionSelected}
@@ -88,10 +83,7 @@ export class Suggester extends React.Component {
           theme={this.props.theme}
           inputProps={inputProps}
         />
-        {getHelpMessage && (
-          // we display the <p> tag even when there is no message to prevent flickering
-          <p>{helpMessage ? helpMessage : <span>&nbsp;</span>}</p>
-        )}
+        {this.props.renderMessage(query, suggestions)}
       </React.Fragment>
     );
   }

--- a/packages/code-du-travail-frontend/src/common/Suggester.js
+++ b/packages/code-du-travail-frontend/src/common/Suggester.js
@@ -28,7 +28,8 @@ export class Suggester extends React.Component {
 
   state = {
     query: "",
-    suggestions: null
+    suggestions: [],
+    loading: false
   };
 
   onChange = event => {
@@ -44,10 +45,11 @@ export class Suggester extends React.Component {
   };
 
   onSuggestionsFetchRequested = ({ value }) => {
-    this.setState({ suggestions: null });
+    this.setState({ suggestions: null, loading: true });
     this.props.onSearch(value).then(results =>
       this.setState({
-        suggestions: results
+        suggestions: results,
+        loading: false
       })
     );
   };
@@ -59,7 +61,7 @@ export class Suggester extends React.Component {
   };
 
   render() {
-    const { suggestions, query } = this.state;
+    const { suggestions, query, loading } = this.state;
     const { placeholder, className } = this.props;
     const inputProps = {
       name: "query",
@@ -83,7 +85,7 @@ export class Suggester extends React.Component {
           theme={this.props.theme}
           inputProps={inputProps}
         />
-        {this.props.renderMessage(query, suggestions)}
+        {this.props.renderMessage(query, suggestions, loading)}
       </React.Fragment>
     );
   }

--- a/packages/code-du-travail-frontend/src/common/__tests__/CompanyForm.test.js
+++ b/packages/code-du-travail-frontend/src/common/__tests__/CompanyForm.test.js
@@ -1,0 +1,55 @@
+import React from "react";
+import { fireEvent, render, waitForElement } from "react-testing-library";
+
+jest.mock("../CompanySuggester", () => {
+  const CompanySuggester = props => {
+    return (
+      <button
+        data-testid="suggest"
+        onClick={() => props.onSelect({ name: "RENAULT-3200-VILLARD" })}
+      />
+    );
+  };
+  return { CompanySuggester };
+});
+
+const { CompanyForm } = require("../CompanyForm");
+
+const getCompany = siret =>
+  Promise.resolve({
+    siret,
+    name: "RENAULT-3200-VILLARD",
+    idccList: [
+      { num: "200", titre: "Convention collective nationale de la coiffure" },
+      {
+        num: "86",
+        titre: "Convention collective nationale des boulangers associés"
+      }
+    ]
+  });
+
+describe("<CompanyForm />", () => {
+  it("should render", () => {
+    const { container } = render(
+      <CompanyForm onSearch={jest.fn()} getCompany={getCompany} />
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it("should display the company and its IDCCs once you click on the suggestion", async () => {
+    const { container, getByText, getByTestId } = render(
+      <CompanyForm onSearch={jest.fn()} getCompany={getCompany} />
+    );
+    const suggester = getByTestId(/suggest/i);
+    fireEvent.click(suggester);
+    await waitForElement(() =>
+      getByText(/IDCC 200 - Convention collective nationale de la coiffure/i)
+    );
+    await waitForElement(() =>
+      getByText(
+        /IDCC 86 - Convention collective nationale des boulangers associés/i
+      )
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/code-du-travail-frontend/src/common/__tests__/CompanySuggester.test.js
+++ b/packages/code-du-travail-frontend/src/common/__tests__/CompanySuggester.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { fireEvent, render, waitForElement } from "react-testing-library";
 
-import { CompanySuggester } from "../CompanySuggester";
+import { CompanySuggester, reformatSiret } from "../CompanySuggester";
 
 const item = {
   name: "RENAULT-32444-VILLARD",
@@ -67,5 +67,31 @@ describe("<CompanySuggester />", () => {
     await waitForElement(() =>
       getByText("Aucune entreprise trouvée pour le SIRET 340 495 283 94945")
     );
+  });
+});
+
+describe("reformatSiret", () => {
+  it("does nothing for less than 3 numbers", () => {
+    expect(reformatSiret("34")).toEqual("34");
+  });
+
+  it("add one space with 3-6 numbers", () => {
+    expect(reformatSiret("34344")).toEqual("343 44");
+  });
+
+  it("adds 2 spaces with 6-9 numbers", () => {
+    expect(reformatSiret("34344499")).toEqual("343 444 99");
+  });
+
+  it("adds 3 spaces with 9+ numbers", () => {
+    expect(reformatSiret("34344499940")).toEqual("343 444 999 40");
+  });
+
+  it("limits to 14 chars", () => {
+    expect(reformatSiret("49348322990909444")).toEqual("493 483 229 90909");
+  });
+
+  it("doesn't explode with non-numerical values", () => {
+    expect(reformatSiret("abcdefgh")).toEqual("abcdefgh");
   });
 });

--- a/packages/code-du-travail-frontend/src/common/__tests__/CompanySuggester.test.js
+++ b/packages/code-du-travail-frontend/src/common/__tests__/CompanySuggester.test.js
@@ -1,0 +1,71 @@
+import React from "react";
+import { fireEvent, render, waitForElement } from "react-testing-library";
+
+import { CompanySuggester } from "../CompanySuggester";
+
+const item = {
+  name: "RENAULT-32444-VILLARD",
+  siret: "49348322990909"
+};
+const results = [item];
+
+describe("<CompanySuggester />", () => {
+  it("should render", () => {
+    const { container } = render(
+      <CompanySuggester onSelect={() => {}} onSearch={jest.fn()} />
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it("should render suggestions", async () => {
+    const onSearch = jest.fn().mockResolvedValue(results);
+    const { container, getAllByRole, getByPlaceholderText } = render(
+      <CompanySuggester onSelect={() => {}} onSearch={onSearch} />
+    );
+    const input = getByPlaceholderText(/Numéro de SIRET à 14 chiffres/i);
+    fireEvent.change(input, { target: { value: "test" } });
+    input.focus();
+    await waitForElement(() => getAllByRole("option"));
+    expect(container).toMatchSnapshot();
+  });
+
+  it("should call onSelect when user clicks some option", async () => {
+    const onSearch = jest.fn().mockResolvedValue(results);
+    const onSelect = jest.fn();
+    const { getByRole, getByPlaceholderText } = render(
+      <CompanySuggester onSearch={onSearch} onSelect={onSelect} />
+    );
+    const input = getByPlaceholderText(/Numéro de SIRET à 14 chiffres/i);
+    fireEvent.change(input, { target: { value: "test" } });
+    input.focus();
+    const option = await waitForElement(() => getByRole("option"));
+    option.click();
+    expect(onSelect).toHaveBeenCalledWith(item);
+  });
+
+  it("should reformat the entered values but not the searched ones", async () => {
+    const onSearch = jest.fn().mockResolvedValue([]);
+    const onSelect = jest.fn();
+    const { getByPlaceholderText, getByDisplayValue } = render(
+      <CompanySuggester onSearch={onSearch} onSelect={onSelect} />
+    );
+    const input = getByPlaceholderText(/Numéro de SIRET à 14 chiffres/i);
+    fireEvent.change(input, { target: { value: "34049528394945" } });
+    await waitForElement(() => getByDisplayValue("340 495 283 94945"));
+    expect(onSearch).toHaveBeenCalledWith("34049528394945");
+  });
+
+  it("should display an empty message when necessary", async () => {
+    const onSearch = jest.fn().mockResolvedValue([]);
+    const onSelect = jest.fn();
+    const { getByText, getByPlaceholderText } = render(
+      <CompanySuggester onSearch={onSearch} onSelect={onSelect} />
+    );
+    const input = getByPlaceholderText(/Numéro de SIRET à 14 chiffres/i);
+    fireEvent.change(input, { target: { value: "34049528394945" } });
+    input.focus();
+    await waitForElement(() =>
+      getByText("Aucune entreprise trouvée pour le SIRET 340 495 283 94945")
+    );
+  });
+});

--- a/packages/code-du-travail-frontend/src/common/__tests__/CompanySuggester.test.js
+++ b/packages/code-du-travail-frontend/src/common/__tests__/CompanySuggester.test.js
@@ -43,7 +43,7 @@ describe("<CompanySuggester />", () => {
     expect(onSelect).toHaveBeenCalledWith(item);
   });
 
-  it("should reformat the entered values but not the searched ones", async () => {
+  it("should reformat the entered values", async () => {
     const onSearch = jest.fn().mockResolvedValue([]);
     const onSelect = jest.fn();
     const { getByPlaceholderText, getByDisplayValue } = render(

--- a/packages/code-du-travail-frontend/src/common/__tests__/ConventionForm.test.js
+++ b/packages/code-du-travail-frontend/src/common/__tests__/ConventionForm.test.js
@@ -7,7 +7,12 @@ jest.mock("../IdccSuggester", () => {
       <button
         data-testid="suggest"
         type="button"
-        onClick={() => props.onSelect({ title: "foo", url: "bar.url" })}
+        onClick={() =>
+          props.onSelect({
+            title: "Convention des Poulaillers",
+            slug: "200-convention-des-poulaillers"
+          })
+        }
       />
     );
   };

--- a/packages/code-du-travail-frontend/src/common/__tests__/Suggester.test.js
+++ b/packages/code-du-travail-frontend/src/common/__tests__/Suggester.test.js
@@ -47,9 +47,13 @@ describe("<Suggester />", () => {
       <Suggester
         onSelect={() => {}}
         onSearch={onSearch}
-        renderMessage={(query, suggestions) => (
+        renderMessage={(query, suggestions, loading) => (
           <p>
-            {query} returned {suggestions && suggestions.length} results
+            {!loading && (
+              <span>
+                {query} returned {suggestions && suggestions.length} results
+              </span>
+            )}
           </p>
         )}
       />

--- a/packages/code-du-travail-frontend/src/common/__tests__/Suggester.test.js
+++ b/packages/code-du-travail-frontend/src/common/__tests__/Suggester.test.js
@@ -26,6 +26,51 @@ describe("<Suggester />", () => {
     expect(container).toMatchSnapshot();
   });
 
+  it("should allow reformatting the entered value", async () => {
+    const onSearch = jest.fn().mockResolvedValue(results);
+    const { getByDisplayValue, getByPlaceholderText } = render(
+      <Suggester
+        onSelect={() => {}}
+        onSearch={onSearch}
+        reformatEnteredValue={v => v.replace(/e/, "O")}
+      />
+    );
+    const input = getByPlaceholderText(/faire une recherche/i);
+    fireEvent.change(input, { target: { value: "test" } });
+    input.focus();
+    await waitForElement(() => getByDisplayValue("tOst"));
+  });
+
+  it("should allow reformatting the searched value", async () => {
+    const onSearch = jest.fn().mockResolvedValue(results);
+    const { getByPlaceholderText } = render(
+      <Suggester
+        onSelect={() => {}}
+        onSearch={onSearch}
+        reformatSearchedValue={v => v.replace(/e/, "O")}
+      />
+    );
+    const input = getByPlaceholderText(/faire une recherche/i);
+    fireEvent.change(input, { target: { value: "test" } });
+    expect(onSearch).toBeCalledWith("tOst");
+  });
+
+  it("should allow displaying a help message", async () => {
+    const onSearch = jest.fn().mockResolvedValue(results);
+    const { getByPlaceholderText, getByText } = render(
+      <Suggester
+        onSelect={() => {}}
+        onSearch={onSearch}
+        getHelpMessage={(query, suggestions) =>
+          `${query} returned ${suggestions.length} results`
+        }
+      />
+    );
+    const input = getByPlaceholderText(/faire une recherche/i);
+    fireEvent.change(input, { target: { value: "test" } });
+    await waitForElement(() => getByText("test returned 1 results"));
+  });
+
   it("should call onSelect when user clicks some option", async () => {
     const onSearch = jest.fn().mockResolvedValue(results);
     const onSelect = jest.fn();

--- a/packages/code-du-travail-frontend/src/common/__tests__/Suggester.test.js
+++ b/packages/code-du-travail-frontend/src/common/__tests__/Suggester.test.js
@@ -41,29 +41,17 @@ describe("<Suggester />", () => {
     await waitForElement(() => getByDisplayValue("tOst"));
   });
 
-  it("should allow reformatting the searched value", async () => {
-    const onSearch = jest.fn().mockResolvedValue(results);
-    const { getByPlaceholderText } = render(
-      <Suggester
-        onSelect={() => {}}
-        onSearch={onSearch}
-        reformatSearchedValue={v => v.replace(/e/, "O")}
-      />
-    );
-    const input = getByPlaceholderText(/faire une recherche/i);
-    fireEvent.change(input, { target: { value: "test" } });
-    expect(onSearch).toBeCalledWith("tOst");
-  });
-
   it("should allow displaying a help message", async () => {
     const onSearch = jest.fn().mockResolvedValue(results);
     const { getByPlaceholderText, getByText } = render(
       <Suggester
         onSelect={() => {}}
         onSearch={onSearch}
-        getHelpMessage={(query, suggestions) =>
-          `${query} returned ${suggestions.length} results`
-        }
+        renderMessage={(query, suggestions) => (
+          <p>
+            {query} returned {suggestions && suggestions.length} results
+          </p>
+        )}
       />
     );
     const input = getByPlaceholderText(/faire une recherche/i);

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/CompanyForm.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/CompanyForm.test.js.snap
@@ -1,0 +1,129 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<CompanyForm /> should display the company and its IDCCs once you click on the suggestion 1`] = `
+<div>
+  <form>
+    <h3
+      class="sc-EHOje djbide"
+    >
+      Recherche par SIRET
+    </h3>
+    Saisissez le numéro de SIRET de votre entreprise afin d'obtenir votre convention collective :
+    <div
+      class="sc-ifAKCX duHYHE"
+    >
+      <div>
+        <div>
+          <b>
+            RENAULT-3200-VILLARD
+          </b>
+          <div>
+            <div
+              class="btn btn__link  "
+              link="true"
+              role="button"
+              tabindex="0"
+            >
+              Chercher une autre entreprise
+            </div>
+            <div
+              class="btn btn__link  "
+              link="true"
+              role="button"
+              tabindex="0"
+            >
+              <svg
+                fill="none"
+                height="16"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <line
+                  x1="18"
+                  x2="6"
+                  y1="6"
+                  y2="18"
+                />
+                <line
+                  x1="6"
+                  x2="18"
+                  y1="6"
+                  y2="18"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+        <div
+          class="sc-gzVnrw kvvweo"
+        >
+          Cette entreprise emploie des salariés sous
+           2 conventions collectives
+           :
+        </div>
+        <ul>
+          <li
+            data-testid="companyIdcc"
+          >
+            <a
+              href="/kali-idcc/200"
+            >
+              IDCC 
+              200
+               
+              - Convention collective nationale de la coiffure
+            </a>
+          </li>
+          <li
+            data-testid="companyIdcc"
+          >
+            <a
+              href="/kali-idcc/86"
+            >
+              IDCC 
+              86
+               
+              - Convention collective nationale des boulangers associés
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </form>
+</div>
+`;
+
+exports[`<CompanyForm /> should render 1`] = `
+<div>
+  <form>
+    <h3
+      class="sc-EHOje djbide"
+    >
+      Recherche par SIRET
+    </h3>
+    Saisissez le numéro de SIRET de votre entreprise afin d'obtenir votre convention collective :
+    <div
+      class="sc-ifAKCX duHYHE"
+    >
+      <button
+        data-testid="suggest"
+      />
+      <p
+        style="font-style: italic;"
+      >
+        Vous pouvez chercher le SIRET de votre entreprise sur 
+        <a
+          href="https://entreprise.data.gouv.fr/"
+        >
+          entreprise.data.gouv.fr
+        </a>
+      </p>
+    </div>
+  </form>
+</div>
+`;

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/CompanyForm.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/CompanyForm.test.js.snap
@@ -1,16 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<CompanyForm /> should display the company and its IDCCs once you click on the suggestion 1`] = `
+.c1 {
+  margin-top: 10px;
+}
+
+.c0 {
+  color: #000;
+  font-size: 1.2em;
+  margin-top: 20px;
+}
+
+.c2 {
+  margin: 10px 0;
+}
+
 <div>
   <form>
     <h3
-      class="sc-EHOje djbide"
+      class="c0"
     >
       Recherche par SIRET
     </h3>
     Saisissez le numéro de SIRET de votre entreprise afin d'obtenir votre convention collective :
     <div
-      class="sc-ifAKCX duHYHE"
+      class="c1"
     >
       <div>
         <div>
@@ -60,7 +74,7 @@ exports[`<CompanyForm /> should display the company and its IDCCs once you click
           </div>
         </div>
         <div
-          class="sc-gzVnrw kvvweo"
+          class="c2"
         >
           Cette entreprise emploie des salariés sous
            2 conventions collectives
@@ -99,16 +113,26 @@ exports[`<CompanyForm /> should display the company and its IDCCs once you click
 `;
 
 exports[`<CompanyForm /> should render 1`] = `
+.c1 {
+  margin-top: 10px;
+}
+
+.c0 {
+  color: #000;
+  font-size: 1.2em;
+  margin-top: 20px;
+}
+
 <div>
   <form>
     <h3
-      class="sc-EHOje djbide"
+      class="c0"
     >
       Recherche par SIRET
     </h3>
     Saisissez le numéro de SIRET de votre entreprise afin d'obtenir votre convention collective :
     <div
-      class="sc-ifAKCX duHYHE"
+      class="c1"
     >
       <button
         data-testid="suggest"

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/CompanySuggester.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/CompanySuggester.test.js.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<CompanySuggester /> should render 1`] = `
+<div>
+  <div
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-owns="react-autowhatever-1"
+    role="combobox"
+    style="position: relative;"
+  >
+    <input
+      aria-autocomplete="list"
+      aria-controls="react-autowhatever-1"
+      autocomplete="off"
+      class="full-width"
+      name="query"
+      placeholder="Numéro de SIRET à 14 chiffres"
+      type="search"
+      value=""
+    />
+    <div
+      class="sc-bdVaJa iCIbBI"
+      id="react-autowhatever-1"
+      role="listbox"
+    />
+  </div>
+  <p>
+    <span>
+       
+    </span>
+  </p>
+</div>
+`;
+
+exports[`<CompanySuggester /> should render suggestions 1`] = `
+<div>
+  <div
+    aria-expanded="true"
+    aria-haspopup="listbox"
+    aria-owns="react-autowhatever-1"
+    role="combobox"
+    style="position: relative;"
+  >
+    <input
+      aria-autocomplete="list"
+      aria-controls="react-autowhatever-1"
+      autocomplete="off"
+      class="full-width"
+      name="query"
+      placeholder="Numéro de SIRET à 14 chiffres"
+      type="search"
+      value="test"
+    />
+    <div
+      class="sc-bdVaJa iCIbBI"
+      id="react-autowhatever-1"
+      role="listbox"
+      style="max-height: 300px; border: 1px solid silver; position: absolute; overflow-y: scroll; left: 0px; right: 0px; border-radius: 3px; border-top-right-radius: 0; margin-top: -3px; box-shadow: 0 5px 20px 0 rgba(0, 0, 0, 0.3);"
+    >
+      <ul
+        role="listbox"
+        style="margin: 0px; padding: 0px; background: white;"
+      >
+        <li
+          aria-selected="false"
+          data-suggestion-index="0"
+          id="react-autowhatever-1--item-0"
+          role="option"
+        >
+          <div
+            class="sc-bwzfXH bXyoxZ"
+          >
+            RENAULT-32444-VILLARD
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <p>
+    <span>
+       
+    </span>
+  </p>
+</div>
+`;

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/CompanySuggester.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/CompanySuggester.test.js.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<CompanySuggester /> should render 1`] = `
+.c0 li[role="option"]:nth-child(2n + 1) {
+  background: #f7f7f7;
+}
+
 <div>
   <div
     aria-expanded="false"
@@ -20,7 +24,7 @@ exports[`<CompanySuggester /> should render 1`] = `
       value=""
     />
     <div
-      class="sc-bdVaJa iCIbBI"
+      class="c0"
       id="react-autowhatever-1"
       role="listbox"
     />
@@ -34,6 +38,24 @@ exports[`<CompanySuggester /> should render 1`] = `
 `;
 
 exports[`<CompanySuggester /> should render suggestions 1`] = `
+.c0 li[role="option"]:nth-child(2n + 1) {
+  background: #f7f7f7;
+}
+
+.c1 {
+  width: 90%;
+  overflow: hidden;
+  padding: 5px;
+  font-size: 0.9rem;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 <div>
   <div
     aria-expanded="true"
@@ -53,7 +75,7 @@ exports[`<CompanySuggester /> should render suggestions 1`] = `
       value="test"
     />
     <div
-      class="sc-bdVaJa iCIbBI"
+      class="c0"
       id="react-autowhatever-1"
       role="listbox"
       style="max-height: 300px; border: 1px solid silver; position: absolute; overflow-y: scroll; left: 0px; right: 0px; border-radius: 3px; border-top-right-radius: 0; margin-top: -3px; box-shadow: 0 5px 20px 0 rgba(0, 0, 0, 0.3);"
@@ -69,7 +91,7 @@ exports[`<CompanySuggester /> should render suggestions 1`] = `
           role="option"
         >
           <div
-            class="sc-bwzfXH bXyoxZ"
+            class="c1"
           >
             RENAULT-32444-VILLARD
           </div>

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/ConventionForm.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/ConventionForm.test.js.snap
@@ -14,48 +14,24 @@ exports[`<ConventionForm /> should display idcc item once click on suggestion 1`
 <div>
   <form>
     <h2>
-      Convention collective
+      Trouvez votre convention collective
     </h2>
     <div>
-      Saisissez l'identifiant de convention collective (IDCC) ou le nom de la branche :
+      <h3
+        class="sc-bxivhb cSBDhQ"
+      >
+        Recherche par nom ou par identifiant
+      </h3>
+      Saisissez l'identifiant de convention collective (IDCC) ou le nom de la branche :
       <div
         class="c0"
       >
         <a
-          href="bar.url"
-          rel="noopener noreferrer"
-          target="_blank"
+          href="/kali/200-convention-des-poulaillers"
         >
-          <svg
-            alt="Télécharger la convention"
-            fill="none"
-            height="16"
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            style="margin-right: 5px;"
-            title="Télécharger la convention"
-            viewBox="0 0 24 24"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"
-            />
-            <polyline
-              points="7 10 12 15 17 10"
-            />
-            <line
-              x1="12"
-              x2="12"
-              y1="15"
-              y2="3"
-            />
-          </svg>
-          IDCC 
-           - 
-          foo
+          IDCC
+
+          - Convention des Poulaillers
         </a>
         <div
           class="btn btn__link  "
@@ -93,14 +69,14 @@ exports[`<ConventionForm /> should display idcc item once click on suggestion 1`
         class="c1"
       >
         Comment trouver ma convention collective ?
-      </h3>
+      </div>
       <ul>
         <li>
-          Elle doit figurer au 
+          Elle doit figurer au
           <b>
             bulletin de paie
           </b>
-          , et sur une notice remise à l'embauche ou 
+          , et sur une notice remise à l'embauche ou
           <b>
             sur le contrat de travail
           </b>
@@ -113,7 +89,7 @@ exports[`<ConventionForm /> should display idcc item once click on suggestion 1`
         class="c1"
       >
         Quelle est la convention collective applicable ?
-      </h3>
+      </div>
       <ul>
         <li>
           En principe celle relevant de l'activité principale dans l'entreprise pour les cas les plus simples.
@@ -138,10 +114,15 @@ exports[`<ConventionForm /> should render 1`] = `
 <div>
   <form>
     <h2>
-      Convention collective
+      Trouvez votre convention collective
     </h2>
     <div>
-      Saisissez l'identifiant de convention collective (IDCC) ou le nom de la branche :
+      <h3
+        class="sc-bxivhb cSBDhQ"
+      >
+        Recherche par nom ou par identifiant
+      </h3>
+      Saisissez l'identifiant de convention collective (IDCC) ou le nom de la branche :
       <div
         class="c0"
       >
@@ -154,14 +135,14 @@ exports[`<ConventionForm /> should render 1`] = `
         class="c1"
       >
         Comment trouver ma convention collective ?
-      </h3>
+      </div>
       <ul>
         <li>
-          Elle doit figurer au 
+          Elle doit figurer au
           <b>
             bulletin de paie
           </b>
-          , et sur une notice remise à l'embauche ou 
+          , et sur une notice remise à l'embauche ou
           <b>
             sur le contrat de travail
           </b>
@@ -174,7 +155,7 @@ exports[`<ConventionForm /> should render 1`] = `
         class="c1"
       >
         Quelle est la convention collective applicable ?
-      </h3>
+      </div>
       <ul>
         <li>
           En principe celle relevant de l'activité principale dans l'entreprise pour les cas les plus simples.

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/ConventionForm.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/ConventionForm.test.js.snap
@@ -1,14 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ConventionForm /> should display idcc item once click on suggestion 1`] = `
-.c0 {
+.c1 {
   margin-top: 10px;
 }
 
-.c1 {
-  color: initial;
+.c0 {
+  color: #000;
   font-size: 1.2em;
   margin-top: 20px;
+}
+
+.c2 {
+  color: #666;
+  font-size: 1em;
+  font-weight: bold;
+  margin: 20px 0 10px 0;
 }
 
 <div>
@@ -18,19 +25,19 @@ exports[`<ConventionForm /> should display idcc item once click on suggestion 1`
     </h2>
     <div>
       <h3
-        class="sc-bxivhb cSBDhQ"
+        class="c0"
       >
         Recherche par nom ou par identifiant
       </h3>
       Saisissez l'identifiant de convention collective (IDCC) ou le nom de la branche :
       <div
-        class="c0"
+        class="c1"
       >
         <a
           href="/kali/200-convention-des-poulaillers"
         >
-          IDCC
-
+          IDCC 
+           
           - Convention des Poulaillers
         </a>
         <div
@@ -65,18 +72,18 @@ exports[`<ConventionForm /> should display idcc item once click on suggestion 1`
           </svg>
         </div>
       </div>
-      <h3
-        class="c1"
+      <div
+        class="c2"
       >
         Comment trouver ma convention collective ?
       </div>
       <ul>
         <li>
-          Elle doit figurer au
+          Elle doit figurer au 
           <b>
             bulletin de paie
           </b>
-          , et sur une notice remise à l'embauche ou
+          , et sur une notice remise à l'embauche ou 
           <b>
             sur le contrat de travail
           </b>
@@ -85,8 +92,8 @@ exports[`<ConventionForm /> should display idcc item once click on suggestion 1`
           Sur l'affichage obligatoire dans l'entreprise (avec les modalités de consultation en entreprise)
         </li>
       </ul>
-      <h3
-        class="c1"
+      <div
+        class="c2"
       >
         Quelle est la convention collective applicable ?
       </div>
@@ -101,14 +108,21 @@ exports[`<ConventionForm /> should display idcc item once click on suggestion 1`
 `;
 
 exports[`<ConventionForm /> should render 1`] = `
-.c0 {
+.c1 {
   margin-top: 10px;
 }
 
-.c1 {
-  color: initial;
+.c0 {
+  color: #000;
   font-size: 1.2em;
   margin-top: 20px;
+}
+
+.c2 {
+  color: #666;
+  font-size: 1em;
+  font-weight: bold;
+  margin: 20px 0 10px 0;
 }
 
 <div>
@@ -118,31 +132,31 @@ exports[`<ConventionForm /> should render 1`] = `
     </h2>
     <div>
       <h3
-        class="sc-bxivhb cSBDhQ"
+        class="c0"
       >
         Recherche par nom ou par identifiant
       </h3>
       Saisissez l'identifiant de convention collective (IDCC) ou le nom de la branche :
       <div
-        class="c0"
+        class="c1"
       >
         <button
           data-testid="suggest"
           type="button"
         />
       </div>
-      <h3
-        class="c1"
+      <div
+        class="c2"
       >
         Comment trouver ma convention collective ?
       </div>
       <ul>
         <li>
-          Elle doit figurer au
+          Elle doit figurer au 
           <b>
             bulletin de paie
           </b>
-          , et sur une notice remise à l'embauche ou
+          , et sur une notice remise à l'embauche ou 
           <b>
             sur le contrat de travail
           </b>
@@ -151,8 +165,8 @@ exports[`<ConventionForm /> should render 1`] = `
           Sur l'affichage obligatoire dans l'entreprise (avec les modalités de consultation en entreprise)
         </li>
       </ul>
-      <h3
-        class="c1"
+      <div
+        class="c2"
       >
         Quelle est la convention collective applicable ?
       </div>

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/convention.service.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/convention.service.test.js.snap
@@ -1,10 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`feedback service should make a request 1`] = `
+exports[`convention service can get a single company with IDCCs 1`] = `undefined`;
+
+exports[`convention service can search IDCCs 1`] = `
 Array [
   Object {
-    "title": "foo",
-    "url": "bar.url",
+    "idcc": "3844",
+    "slug": "3844-convention-des-boulangeries",
+    "title": "Convention des Boulangeries",
+    "url": "https://legifrance.com/boulangerie",
   },
 ]
 `;
+
+exports[`convention service can search companies 1`] = `undefined`;

--- a/packages/code-du-travail-frontend/src/common/__tests__/convention.service.test.js
+++ b/packages/code-du-travail-frontend/src/common/__tests__/convention.service.test.js
@@ -47,6 +47,28 @@ describe("convention service", () => {
     expect(results).toMatchSnapshot();
   });
 
+  it("removes spaces from sirets when searching for companies", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          hits: {
+            hits: [
+              {
+                name: "RENAULT-23499-VILLARD",
+                siret: "34048927839394"
+              }
+            ]
+          }
+        })
+    });
+    await searchCompanies("340 489 278 39394");
+    expect(fetch).toBeCalledTimes(1);
+    expect(fetch.mock.calls[0][0]).toMatch(
+      /siret2idcc\.url\/api\/v1\/companies\?siret=34048927839394$/
+    );
+  });
+
   it("can get a single company with IDCCs", async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,

--- a/packages/code-du-travail-frontend/src/common/__tests__/convention.service.test.js
+++ b/packages/code-du-travail-frontend/src/common/__tests__/convention.service.test.js
@@ -1,22 +1,70 @@
-import { searchIdcc } from "../convention.service";
+import { searchIdcc, searchCompanies, getCompany } from "../convention.service";
 
-const results = {
-  hits: {
-    hits: [{ title: "foo", url: "bar.url" }]
-  }
-};
-global.fetch = jest.fn().mockResolvedValue({
-  ok: true,
-  json: () => Promise.resolve(results)
-});
-
-const query = "foo";
-
-describe("feedback service", () => {
-  it("should make a request", async () => {
-    const results = await searchIdcc(query);
+describe("convention service", () => {
+  it("can search IDCCs", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          hits: {
+            hits: [
+              {
+                title: "Convention des Boulangeries",
+                idcc: "3844",
+                slug: "3844-convention-des-boulangeries",
+                url: "https://legifrance.com/boulangerie"
+              }
+            ]
+          }
+        })
+    });
+    const results = await searchIdcc("foo");
     expect(fetch).toBeCalledTimes(1);
     expect(fetch.mock.calls[0][0]).toMatch(/api\.url\/idcc\?q=foo$/);
+    expect(results).toMatchSnapshot();
+  });
+
+  it("can search companies", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          hits: {
+            hits: [
+              {
+                name: "RENAULT-23499-VILLARD",
+                siret: "34048927839394"
+              }
+            ]
+          }
+        })
+    });
+    const results = await searchCompanies("34048927839394");
+    expect(fetch).toBeCalledTimes(1);
+    expect(fetch.mock.calls[0][0]).toMatch(
+      /siret2idcc\.url\/api\/v1\/companies\?siret=34048927839394$/
+    );
+    expect(results).toMatchSnapshot();
+  });
+
+  it("can get a single company with IDCCs", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          name: "RENAULT-23499-VILLARD",
+          siret: "34048927839394",
+          idccList: [
+            { num: "2394", titre: "Convention Des Barrages Hydrauliques" },
+            { num: "1234", titre: "Convention Des Laveurs De Carreaux" }
+          ]
+        })
+    });
+    const results = await getCompany("34048927839394");
+    expect(fetch).toBeCalledTimes(1);
+    expect(fetch.mock.calls[0][0]).toMatch(
+      /siret2idcc\.url\/api\/v1\/company\/34048927839394$/
+    );
     expect(results).toMatchSnapshot();
   });
 });

--- a/packages/code-du-travail-frontend/src/common/convention.service.js
+++ b/packages/code-du-travail-frontend/src/common/convention.service.js
@@ -2,7 +2,7 @@ import getConfig from "next/config";
 import memoizee from "memoizee";
 
 const {
-  publicRuntimeConfig: { API_URL }
+  publicRuntimeConfig: { API_URL, API_SIRET2IDCC_URL }
 } = getConfig();
 
 function searchIdcc(query) {
@@ -16,7 +16,42 @@ function searchIdcc(query) {
   });
 }
 
+function searchCompanies(siret) {
+  const url = `${API_SIRET2IDCC_URL}/api/v1/companies?siret=${encodeURIComponent(
+    siret
+  )}`;
+
+  return fetch(url).then(response => {
+    if (response.ok) {
+      return response.json().then(result => result.companies);
+    }
+    throw new Error("Un problème est survenu.");
+  });
+}
+
+function getCompany(siret) {
+  const url = `${API_SIRET2IDCC_URL}/api/v1/company/${siret}`;
+
+  return fetch(url).then(response => {
+    if (response.ok) {
+      return response.json().then(result => result.company);
+    }
+    throw new Error("Un problème est survenu.");
+  });
+}
+
 // memoize search results
 const searchIdccMemo = memoizee(query => searchIdcc(query), { promise: true });
+const searchCompaniesMemo = memoizee(siret => searchCompanies(siret), {
+  promise: true
+});
+const getCompanyMemo = memoizee(siret => getCompany(siret), { promise: true });
 
-export { searchIdccMemo as searchIdcc, searchIdcc as _searchIdcc };
+export {
+  searchIdccMemo as searchIdcc,
+  searchIdcc as _searchIdcc,
+  searchCompaniesMemo as searchCompanies,
+  searchCompanies as _searchCompanies,
+  getCompanyMemo as getCompany,
+  getCompany as _getCompany
+};

--- a/packages/code-du-travail-frontend/src/common/convention.service.js
+++ b/packages/code-du-travail-frontend/src/common/convention.service.js
@@ -1,5 +1,6 @@
 import getConfig from "next/config";
 import memoizee from "memoizee";
+import pDebounce from "../lib/pDebounce";
 
 const {
   publicRuntimeConfig: { API_URL, API_SIRET2IDCC_URL }
@@ -49,10 +50,12 @@ const searchCompaniesMemo = memoizee(siret => searchCompanies(siret), {
 });
 const getCompanyMemo = memoizee(siret => getCompany(siret), { promise: true });
 
+const searchCompaniesDebounced = pDebounce(searchCompaniesMemo, 800);
+
 export {
   searchIdccMemo as searchIdcc,
   searchIdcc as _searchIdcc,
-  searchCompaniesMemo as searchCompanies,
+  searchCompaniesDebounced as searchCompanies,
   searchCompanies as _searchCompanies,
   getCompanyMemo as getCompany,
   getCompany as _getCompany

--- a/packages/code-du-travail-frontend/src/common/convention.service.js
+++ b/packages/code-du-travail-frontend/src/common/convention.service.js
@@ -6,7 +6,9 @@ const {
 } = getConfig();
 
 function searchIdcc(query) {
-  const url = `${API_URL}/idcc?q=${encodeURIComponent(query)}`;
+  const url = `${API_URL}/idcc?q=${encodeURIComponent(
+    query.replace(/ /g, "")
+  )}`;
 
   return fetch(url).then(response => {
     if (response.ok) {
@@ -18,7 +20,7 @@ function searchIdcc(query) {
 
 function searchCompanies(siret) {
   const url = `${API_SIRET2IDCC_URL}/api/v1/companies?siret=${encodeURIComponent(
-    siret
+    siret.replace(/ /g, "")
   )}`;
 
   return fetch(url).then(response => {

--- a/packages/code-du-travail-frontend/src/home/ConventionModal.js
+++ b/packages/code-du-travail-frontend/src/home/ConventionModal.js
@@ -4,7 +4,12 @@ import styled from "styled-components";
 
 import { Outil, OutilCard } from "./Outils";
 import { ConventionForm } from "../common/ConventionForm";
-import { searchIdcc } from "../common/convention.service";
+import { CompanyForm } from "../common/CompanyForm";
+import {
+  searchIdcc,
+  searchCompanies,
+  getCompany
+} from "../common/convention.service";
 
 class ConventionModal extends React.Component {
   state = {
@@ -40,6 +45,7 @@ class ConventionModal extends React.Component {
         >
           <DialogContent style={{ borderRadius: "3px", margin: "5vh auto" }}>
             <ConventionForm onSearch={searchIdcc} />
+            <CompanyForm onSearch={searchCompanies} getCompany={getCompany} />
           </DialogContent>
         </DialogOverlay>
       </OutilCard>

--- a/packages/code-du-travail-frontend/src/home/__tests__/ConventionModal.test.js
+++ b/packages/code-du-travail-frontend/src/home/__tests__/ConventionModal.test.js
@@ -3,7 +3,9 @@ import { render } from "react-testing-library";
 import ConventionModal from "../ConventionModal";
 
 jest.mock("../../common/convention.service", () => ({
-  searchIdcc: jest.fn()
+  searchIdcc: jest.fn(),
+  searchCompanies: jest.fn(),
+  getCompany: jest.fn()
 }));
 
 // Trouvez votre convention collective

--- a/packages/code-du-travail-frontend/src/home/__tests__/__snapshots__/ConventionModal.test.js.snap
+++ b/packages/code-du-travail-frontend/src/home/__tests__/__snapshots__/ConventionModal.test.js.snap
@@ -92,10 +92,15 @@ exports[`<ConventionModal /> should render a popup when click on button 1`] = `
       >
         <form>
           <h2>
-            Convention collective
+            Trouvez votre convention collective
           </h2>
           <div>
-            Saisissez l'identifiant de convention collective (IDCC) ou le nom de la branche :
+            <h3
+              class="sc-gzVnrw brzehh"
+            >
+              Recherche par nom ou par identifiant
+            </h3>
+            Saisissez l'identifiant de convention collective (IDCC) ou le nom de la branche :
             <div
               class="c1"
             >
@@ -127,14 +132,14 @@ exports[`<ConventionModal /> should render a popup when click on button 1`] = `
               class="c3"
             >
               Comment trouver ma convention collective ?
-            </h3>
+            </div>
             <ul>
               <li>
-                Elle doit figurer au 
+                Elle doit figurer au
                 <b>
                   bulletin de paie
                 </b>
-                , et sur une notice remise à l'embauche ou 
+                , et sur une notice remise à l'embauche ou
                 <b>
                   sur le contrat de travail
                 </b>
@@ -147,12 +152,62 @@ exports[`<ConventionModal /> should render a popup when click on button 1`] = `
               class="c3"
             >
               Quelle est la convention collective applicable ?
-            </h3>
+            </div>
             <ul>
               <li>
                 En principe celle relevant de l'activité principale dans l'entreprise pour les cas les plus simples.
               </li>
             </ul>
+          </div>
+        </form>
+        <form>
+          <h3
+            class="sc-gzVnrw brzehh"
+          >
+            Recherche par SIRET
+          </h3>
+          Saisissez le numéro de SIRET de votre entreprise afin d'obtenir votre convention collective :
+          <div
+            class="sc-bZQynM iUJxtM"
+          >
+            <div
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-owns="react-autowhatever-1"
+              role="combobox"
+              style="position: relative;"
+            >
+              <input
+                aria-autocomplete="list"
+                aria-controls="react-autowhatever-1"
+                autocomplete="off"
+                class="full-width"
+                name="query"
+                placeholder="Numéro de SIRET à 14 chiffres"
+                type="search"
+                value=""
+              />
+              <div
+                class="sc-ifAKCX eCZXzX"
+                id="react-autowhatever-1"
+                role="listbox"
+              />
+            </div>
+            <p>
+              <span>
+                 
+              </span>
+            </p>
+            <p
+              style="font-style: italic;"
+            >
+              Vous pouvez chercher le SIRET de votre entreprise sur 
+              <a
+                href="https://entreprise.data.gouv.fr/"
+              >
+                entreprise.data.gouv.fr
+              </a>
+            </p>
           </div>
         </form>
       </div>

--- a/packages/code-du-travail-frontend/src/home/__tests__/__snapshots__/ConventionModal.test.js.snap
+++ b/packages/code-du-travail-frontend/src/home/__tests__/__snapshots__/ConventionModal.test.js.snap
@@ -33,18 +33,25 @@ exports[`<ConventionModal /> should render a button 1`] = `
 `;
 
 exports[`<ConventionModal /> should render a popup when click on button 1`] = `
-.c2 li[role="option"]:nth-child(2n + 1) {
+.c3 li[role="option"]:nth-child(2n + 1) {
   background: #f7f7f7;
 }
 
-.c1 {
+.c2 {
   margin-top: 10px;
 }
 
-.c3 {
-  color: initial;
+.c1 {
+  color: #000;
   font-size: 1.2em;
   margin-top: 20px;
+}
+
+.c4 {
+  color: #666;
+  font-size: 1em;
+  font-weight: bold;
+  margin: 20px 0 10px 0;
 }
 
 .c0 {
@@ -96,13 +103,13 @@ exports[`<ConventionModal /> should render a popup when click on button 1`] = `
           </h2>
           <div>
             <h3
-              class="sc-gzVnrw brzehh"
+              class="c1"
             >
               Recherche par nom ou par identifiant
             </h3>
             Saisissez l'identifiant de convention collective (IDCC) ou le nom de la branche :
             <div
-              class="c1"
+              class="c2"
             >
               <div
                 aria-expanded="false"
@@ -122,24 +129,24 @@ exports[`<ConventionModal /> should render a popup when click on button 1`] = `
                   value=""
                 />
                 <div
-                  class="c2"
+                  class="c3"
                   id="react-autowhatever-1"
                   role="listbox"
                 />
               </div>
             </div>
-            <h3
-              class="c3"
+            <div
+              class="c4"
             >
               Comment trouver ma convention collective ?
             </div>
             <ul>
               <li>
-                Elle doit figurer au
+                Elle doit figurer au 
                 <b>
                   bulletin de paie
                 </b>
-                , et sur une notice remise à l'embauche ou
+                , et sur une notice remise à l'embauche ou 
                 <b>
                   sur le contrat de travail
                 </b>
@@ -148,8 +155,8 @@ exports[`<ConventionModal /> should render a popup when click on button 1`] = `
                 Sur l'affichage obligatoire dans l'entreprise (avec les modalités de consultation en entreprise)
               </li>
             </ul>
-            <h3
-              class="c3"
+            <div
+              class="c4"
             >
               Quelle est la convention collective applicable ?
             </div>
@@ -162,13 +169,13 @@ exports[`<ConventionModal /> should render a popup when click on button 1`] = `
         </form>
         <form>
           <h3
-            class="sc-gzVnrw brzehh"
+            class="c1"
           >
             Recherche par SIRET
           </h3>
           Saisissez le numéro de SIRET de votre entreprise afin d'obtenir votre convention collective :
           <div
-            class="sc-bZQynM iUJxtM"
+            class="c2"
           >
             <div
               aria-expanded="false"
@@ -188,7 +195,7 @@ exports[`<ConventionModal /> should render a popup when click on button 1`] = `
                 value=""
               />
               <div
-                class="sc-ifAKCX eCZXzX"
+                class="c3"
                 id="react-autowhatever-1"
                 role="listbox"
               />

--- a/packages/code-du-travail-frontend/test/jest.setup.js
+++ b/packages/code-du-travail-frontend/test/jest.setup.js
@@ -5,6 +5,7 @@ import "jest-styled-components";
 jest.mock("next/config", () => () => ({
   publicRuntimeConfig: {
     API_URL: "api.url",
+    API_SIRET2IDCC_URL: "siret2idcc.url",
     API_ADDRESS: "addresse-api.data",
     PACKAGE_VERSION: "x.y.z"
   }


### PR DESCRIPTION
cf issue #49 

![](http://g.recordit.co/Lq47FkmgTG.gif)

Here are two valid SIRETS to test: SIRET à tester : 130 005 481 13617  and 309 755 759 00011 

This PR can and should be read commit by commit, I splitted it to have meaningful steps.

## 1. https://github.com/SocialGouv/code-du-travail-numerique/pull/603/commits/a81722bcdcccc32db85b701082ce22d9a7494212 added kali-idcc route to access a Convention by its num

The new route `kali-idcc/:num` which also uses the `kali` page but searches the IDCC using its num instead of the fully qualified `slug`. This is useful for the IDCC suggestions that come from the `siret2idcc` API as this external API doesn’t know about CDTNs slugs. 

Also, `siret2idcc` API may return IDCC nums that are not in our ES (mostly because they are not “en vigueur” anymore).

Note: For SEO purposes, maybe we should redirect instead of rendering the kali page directly.

## 2. https://github.com/SocialGouv/code-du-travail-numerique/pull/603/commits/d0f58365b17761299fe3b586f0b3c44e14ced0a5 ConventionForm now points to internal Convention pages instead of Legifrance

Updates to the `ConventionPreview` component which shows suggestions results in the modal. It used to be an external link to Legifrance, whereas it is now an internal link to our kali page.

## 3. https://github.com/SocialGouv/code-du-travail-numerique/pull/603/commits/83c2788828bea718ae11e46f9fe3c7be9c5b1312  Add new companies calls to the idcc2siret API in the convention service  

There are two endpoints : 
- one to search by SIRET, it does a 'LIKE query%' query and returns the first 20 results. It doesn't include the IDCCs attached to the companies
- one to get a single company via its SIRET. it will throw a 404 if it's not found.

cf https://github.com/SocialGouv/siret2idcc 

## 4. https://github.com/SocialGouv/code-du-travail-numerique/pull/603/commits/6e9b31a6d045ef066b8d8b14e3251be73f3d0c7a added hooks to Suggester, and created CompanySuggester 

- Updates on the base `Suggester` to add hooks to : 
    - Reformat the entered values in the input
    - Reformat the values submitted for the autocomplete
    - Display a help message
- These hooks are used in the `CompanySuggester` to:
    - Add spaces in the input to look like "000 000 000 00000"
    - Limit the number of characters
    - Show an error message when there are no results but a valid input

## 5. https://github.com/SocialGouv/code-du-travail-numerique/pull/603/commits/72dde48ce67b2bb6b3a1a552641df19f10755632 created new CompanyForm to search by SIRET

This form is very similar to the `ConventionForm`

## 6. https://github.com/SocialGouv/code-du-travail-numerique/pull/603/commits/58a14c160fdf54d506b55aa9c20d03dc3ea330ee updated ConventionModal to include the new CompanyForm