### PR TITLE
Theme routes

### DIFF
--- a/packages/code-du-travail-data/search/extraction/themes_front/data.py
+++ b/packages/code-du-travail-data/search/extraction/themes_front/data.py
@@ -31,7 +31,7 @@ def populate_theme(data):
 
             theme = {
                 'title': item['title'],
-                'slug':  'themes/' + slug,
+                'slug':  slug,
                 'text': text,
             }
             THEMES.append(theme)

--- a/packages/code-du-travail-data/search/indexing/cdtn_documents.py
+++ b/packages/code-du-travail-data/search/indexing/cdtn_documents.py
@@ -104,6 +104,7 @@ def populate_cdtn_documents():
             'date': val.get('date'),
         })
 
+    logger.info("Load %s themes from dataset/themes-front.json", len(THEMES))
     for val in THEMES:
         CDTN_DOCUMENTS.append({
             'source': 'themes',

--- a/packages/code-du-travail-frontend/pages/theme.js
+++ b/packages/code-du-travail-frontend/pages/theme.js
@@ -60,7 +60,7 @@ const getBreadcrumbs = parents =>
       ) : (
         <Link
           key={parent.title}
-          route="theme"
+          route="themes"
           params={{ slug: parent.slug || ["/"] }}
         >
           <a title={parent.title}>{parent.title}</a>

--- a/packages/code-du-travail-frontend/routes.js
+++ b/packages/code-du-travail-frontend/routes.js
@@ -68,11 +68,9 @@ module.exports = routes()
   // theme navigation
   //
   // http://localhost:3000/themes
-  .add({ name: "themes", page: "theme", pattern: "/themes" })
-
   // http://localhost:3000/theme/rupture-de-contrat
   // http://localhost:3000/theme/rupture-de-contrat/la-rupture-conventionnelle
-  .add({ name: "theme", page: "theme", pattern: "/themes/:slug+" }) // slug is an array of slugs
+  .add({ name: "themes", page: "theme", pattern: "/themes/:slug*" })
 
   // http://localhost:3000/a-propos
   .add({ name: "about", page: "about", pattern: "/a-propos" })

--- a/packages/code-du-travail-frontend/src/home/Categories.js
+++ b/packages/code-du-travail-frontend/src/home/Categories.js
@@ -46,7 +46,7 @@ export default class Categories extends React.Component {
             <CategoriesWrapper>
               {themes.map(({ slug, title, text, icon }) => (
                 <CategoryItem key={slug + title} small={!isRoot}>
-                  <Link route="theme" params={{ slug: slug || "/" }}>
+                  <Link route="themes" params={{ slug: slug || "/" }}>
                     <a title={title}>
                       <Category title={title} text={text} icon={icon} />
                     </a>


### PR DESCRIPTION
 - use a single route for theme/themes
 - index themes.slug without prefix (as other content)