### PR TITLE
WIP feat(search): add a fixed list of boostable expressions

### DIFF
--- a/packages/code-du-travail-api/src/server/routes/search/search.elastic.js
+++ b/packages/code-du-travail-api/src/server/routes/search/search.elastic.js
@@ -1,3 +1,5 @@
+const getExpressions = require("./search.expressions");
+
 function getSearchBody({ query, size, excludeSources = [] }) {
   return {
     size: size,
@@ -53,7 +55,8 @@ function getSearchBody({ query, size, excludeSources = [] }) {
                       query: query
                     }
                   }
-                }
+                },
+                ...getExpressions(query)
               ]
             }
           }

--- a/packages/code-du-travail-api/src/server/routes/search/search.expressions.js
+++ b/packages/code-du-travail-api/src/server/routes/search/search.expressions.js
@@ -1,0 +1,46 @@
+// todo : require(smthing)
+const normalize = str =>
+  str
+    .toLowerCase()
+    .replace(/[à]/g, "a")
+    .replace(/[î]/g, "i")
+    .replace(/[ô]/g, "o")
+    .replace(/[éèê]/g, "e")
+    .replace(/\s\s*/g, " ")
+    .trim();
+
+// expression should be normalized too
+const expressions = [
+  "rupture conventionnelle",
+  "contrat de travail",
+  "rupture anticipee",
+  "licenciement collectif",
+  "motif personnel",
+  "remplacement d'un salarie",
+  "assistante maternelle"
+];
+
+// return matched expressions in query if any
+// expressions is a suite of some words.  eg: ["rupture conventionnelle", "contrat de travail"];
+const getExpressions = query => {
+  const normalizedQuery = normalize(query);
+  if (!normalizedQuery) {
+    return [];
+  }
+  return expressions.filter(
+    expression => normalizedQuery.indexOf(expression) > -1
+  );
+};
+
+// return some additional ES filters for a given query
+const getQueries = query =>
+  getExpressions(query).map(expression => ({
+    multi_match: {
+      query: expression,
+      fields: ["text.french", "title.french"],
+      type: "phrase",
+      boost: 1
+    }
+  }));
+
+module.exports = getQueries;

--- a/packages/code-du-travail-api/src/server/routes/search/search.expressions.js
+++ b/packages/code-du-travail-api/src/server/routes/search/search.expressions.js
@@ -24,12 +24,10 @@ const expressions = [
 // expressions is a suite of some words.  eg: ["rupture conventionnelle", "contrat de travail"];
 const getExpressions = query => {
   const normalizedQuery = normalize(query);
-  if (!normalizedQuery) {
+  if (normalizedQuery === "") {
     return [];
   }
-  return expressions.filter(
-    expression => normalizedQuery.indexOf(expression) > -1
-  );
+  return expressions.filter(expression => normalizedQuery.includes(expression));
 };
 
 // return some additional ES filters for a given query


### PR DESCRIPTION
Essai naïf pour booster les expressions multi-mots.

Objectif : dans une requête, si une expression "multi-mots" est connue, booster les résultats qui contiennent cette expression exactement.

On peut voir quelques améliorations avec les quelques exemples que j'ai mis.

A évaluer