### PR TITLE
fix: rename service public

### DIFF
--- a/packages/code-du-travail-frontend/pages/fiche-service-public.js
+++ b/packages/code-du-travail-frontend/pages/fiche-service-public.js
@@ -61,7 +61,7 @@ class Fiche extends React.Component {
             footer={footer}
             date={data._source.date}
             icon={ReponseIcon}
-            sourceType="Fiche service public"
+            sourceType="Fiche service-public.fr"
             referencesJuridiques={data._source.references_juridiques}
             breadcrumbs={data._source.breadcrumbs}
           >


### PR DESCRIPTION
"Fiche service public" " -> "Fiche service-public.fr"