### PR TITLE
Update synonyms.json

### DIFF
--- a/packages/code-du-travail-data/dataset/synonyms/synonyms.json
+++ b/packages/code-du-travail-data/dataset/synonyms/synonyms.json
@@ -458,7 +458,7 @@
   "consultation de dépistage anonyme et gratuit, cdag",
   "contamination microbiologique, biocontamination contamination microbienne",
   "contraception d'urgence, pilule du lendemain",
-  "contrat","contrat de travail",
+  "contrat, contrat de travail",
   "contrat d'accueil et d'intégration, cai",
   "contrat d'agglomération, contrat local pour l'accueil et l'intégration",
   "contrat d'amélioration des pratiques individuelles, capi",

--- a/packages/code-du-travail-data/dataset/synonyms/synonyms.json
+++ b/packages/code-du-travail-data/dataset/synonyms/synonyms.json
@@ -458,6 +458,7 @@
   "consultation de dépistage anonyme et gratuit, cdag",
   "contamination microbiologique, biocontamination contamination microbienne",
   "contraception d'urgence, pilule du lendemain",
+  "contrat","contrat de travail",
   "contrat d'accueil et d'intégration, cai",
   "contrat d'agglomération, contrat local pour l'accueil et l'intégration",
   "contrat d'amélioration des pratiques individuelles, capi",


### PR DESCRIPTION
petite modif (contrat = > contrat de travail ) - on retrouve beaucoup de contenu imprécis où il est question du contrat au lieu du contrat de travail.  Ne rien faire si le fichier n'est plus utilisé.