### PR TITLE
fix(frontend): issue in matomo

### DIFF
--- a/packages/code-du-travail-frontend/src/piwik.js
+++ b/packages/code-du-travail-frontend/src/piwik.js
@@ -2,21 +2,20 @@ import ReactPiwik from "react-piwik";
 import { Router } from "../routes";
 import getConfig from "next/config";
 
-const onRouteChangeComplete = () => {
-  ReactPiwik.push(["trackPageView"]);
-};
-
 const {
   publicRuntimeConfig: { PIWIK_URL, PIWIK_SITE_ID }
 } = getConfig();
 
 if (typeof window !== "undefined" && PIWIK_URL && PIWIK_SITE_ID) {
-  new ReactPiwik({
+  const piwik = new ReactPiwik({
     url: PIWIK_URL,
     siteId: PIWIK_SITE_ID,
     trackErrors: true
   });
-  Router.events.on("routeChangeComplete", onRouteChangeComplete);
+  ReactPiwik.push(["trackPageView"]);
+  Router.events.on("routeChangeComplete", path => {
+    piwik.track({ path });
+  });
 } else if (typeof window !== "undefined") {
   window._paq = [];
 }


### PR DESCRIPTION
closes #722

Little explanation: 

`ReactPiwik.push(["trackPageView"]);` must be called only once after the instantiation process.
We could then use the method `connectToHistory` provided by the instance of the piwik class but it seems to require an instance of `react-router` (thanks for pointing that out @lionelB). So instead, I use the listener of our router to call the `track` method of the piwik instance (which is normally called on route change once `connectToHistory` has been called). The `track` method expects a loc object which, in fact, only needs one key, which is: `path`.

https://github.com/guillaumeparis2000/react-piwik/blob/master/src/React-Piwik.js
https://developer.matomo.org/api-reference/tracking-javascript