### PR TITLE
ci: fix delete useless k8s objects script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ stages:
 - "Registration"
 - "Deploy"
 - "Notify Finished Deployment"
-- "Delete Pods"
+- "Delete K8S Objects"
 
 
 #
@@ -201,11 +201,11 @@ Deploy @cdtn/frontend (prod):
   - master
 
 #######################################
-###           DELETE PODS           ###
+###       DELETE K8S OBJECTS        ###
 #######################################
 
-delete-pods:
-  stage: "Delete Pods"
+delete-k8s-objects:
+  stage: "Delete K8S Objects"
   image:
     name: $CI_REGISTRY/$IMAGE_INFRA_BASE_NAME/docker-kube:latest
     entrypoint: [""]
@@ -214,6 +214,6 @@ delete-pods:
   before_script:
   - /apps/create-kubeconfig.sh
   script:
-  - python3 k8s/scripts/delete-pods.py
+  - python3 k8s/scripts/delete-k8s-objects.py
   only:
   - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,203 +2,200 @@
 include:
 - /.gitlab-ci/variables.yml
 - /.gitlab-ci/extends.yml
-#
-- '/k8s/elasticsearch/.deploy-elasticsearch-k8s.yml'
-- '/k8s/code-du-travail-data/.deploy-code-du-travail-data-k8s.yml'
-- '/k8s/code-du-travail-api/.deploy-code-du-travail-api-k8s.yml'
-- '/k8s/code-du-travail-frontend/.deploy-code-du-travail-frontend-k8s.yml'
-- '/k8s/code-du-travail-nlp/.deploy-code-du-travail-nlp-k8s.yml'
-#
-- /.gitlab-ci/stages/prepare.yml
-- /.gitlab-ci/stages/quality.yml
-- /.gitlab-ci/stages/register.yml
-- /.gitlab-ci/stages/notify.yml
+
+# - '/k8s/elasticsearch/.deploy-elasticsearch-k8s.yml'
+# - '/k8s/code-du-travail-data/.deploy-code-du-travail-data-k8s.yml'
+# - '/k8s/code-du-travail-api/.deploy-code-du-travail-api-k8s.yml'
+# - '/k8s/code-du-travail-frontend/.deploy-code-du-travail-frontend-k8s.yml'
+# - '/k8s/code-du-travail-nlp/.deploy-code-du-travail-nlp-k8s.yml'
+
+# - /.gitlab-ci/stages/prepare.yml
+# - /.gitlab-ci/stages/quality.yml
+# - /.gitlab-ci/stages/register.yml
+# - /.gitlab-ci/stages/notify.yml
 
 image: node:10-alpine
 
 stages:
-- "Prepare"
-- "Code Quality"
-- "Registration"
-- "Deploy"
-- "Notify Finished Deployment"
+# - "Prepare"
+# - "Code Quality"
+# - "Registration"
+# - "Deploy"
+# - "Notify Finished Deployment"
 - "Delete K8S Objects"
 
 
-#
+# .deploy_stage: &deploy_stage
+#   stage: "Deploy"
+#   dependencies: []
+#   services:
+#     - docker:$DOCKER_VERSION-dind
+#   variables: &deploy_stage_variables
+#     IMAGE_TAG: $CI_COMMIT_SHA
+#   before_script:
+#     - source .gitlab-ci/env.sh
 
-.deploy_stage: &deploy_stage
-  stage: "Deploy"
-  dependencies: []
-  services:
-    - docker:$DOCKER_VERSION-dind
-  variables: &deploy_stage_variables
-    IMAGE_TAG: $CI_COMMIT_SHA
-  before_script:
-    - source .gitlab-ci/env.sh
-
-#
 
 ######################################
 ### DEPLOY CDTN TO K8S DEV CLUSTER ###
 ######################################
 
-Deploy Elasticsearch (dev):
-  <<: *deploy_stage
-  environment:
-    name: dev
-    url: $ELASTICSEARCH_HOST
-  extends: .deploy-elasticsearch-dev-k8s
-  variables:
-    <<: *deploy_stage_variables
-    ES_PORT: ${ELASTICSEARCH_PORT}
-    ES_INTER_NODE: ${ELASTICSEARCH_INTER_NODE_PORT}
-    CDTN_REGISTRY: $CI_REGISTRY_IMAGE
-  except:
-  - master
+# Deploy Elasticsearch (dev):
+#   <<: *deploy_stage
+#   environment:
+#     name: dev
+#     url: $ELASTICSEARCH_HOST
+#   extends: .deploy-elasticsearch-dev-k8s
+#   variables:
+#     <<: *deploy_stage_variables
+#     ES_PORT: ${ELASTICSEARCH_PORT}
+#     ES_INTER_NODE: ${ELASTICSEARCH_INTER_NODE_PORT}
+#     CDTN_REGISTRY: $CI_REGISTRY_IMAGE
+#   except:
+#   - master
 
-Create Elasticsearch Index (dev):
-  <<: *deploy_stage
-  environment:
-    name: dev
-  extends: .deploy-code-du-travail-data-k8s
-  variables:
-    <<: *deploy_stage_variables
-    ES_PORT: ${ELASTICSEARCH_PORT}
-    CDTN_REGISTRY: $CI_REGISTRY_IMAGE
-  except:
-  - master
+# Create Elasticsearch Index (dev):
+#   <<: *deploy_stage
+#   environment:
+#     name: dev
+#   extends: .deploy-code-du-travail-data-k8s
+#   variables:
+#     <<: *deploy_stage_variables
+#     ES_PORT: ${ELASTICSEARCH_PORT}
+#     CDTN_REGISTRY: $CI_REGISTRY_IMAGE
+#   except:
+#   - master
 
-Deploy @cdtn/api (dev):
-  <<: *deploy_stage
-  environment:
-    name: dev
-    url: $API_HOST
-  extends: .deploy-code-du-travail-api-k8s
-  variables:
-    <<: *deploy_stage_variables
-    ELASTICSEARCH_LOG_LEVEL: "trace"
-    APM_SERVER_ACTIVE: 0
-    APM_SERVER_URL: ""
-    ENVIRONMENT: $CI_ENVIRONMENT_NAME
-    PORT: ${API_PORT}
-    ES_PORT: ${ELASTICSEARCH_PORT}
-    CDTN_REGISTRY: $CI_REGISTRY_IMAGE
-  except:
-  - master
+# Deploy @cdtn/api (dev):
+#   <<: *deploy_stage
+#   environment:
+#     name: dev
+#     url: $API_HOST
+#   extends: .deploy-code-du-travail-api-k8s
+#   variables:
+#     <<: *deploy_stage_variables
+#     ELASTICSEARCH_LOG_LEVEL: "trace"
+#     APM_SERVER_ACTIVE: 0
+#     APM_SERVER_URL: ""
+#     ENVIRONMENT: $CI_ENVIRONMENT_NAME
+#     PORT: ${API_PORT}
+#     ES_PORT: ${ELASTICSEARCH_PORT}
+#     CDTN_REGISTRY: $CI_REGISTRY_IMAGE
+#   except:
+#   - master
 
-Deploy @cdtn/nlp (dev):
-  <<: *deploy_stage
-  environment:
-    name: dev
-    url: $NLP_HOST
-  extends: .deploy-code-du-travail-nlp-k8s
-  variables:
-    <<: *deploy_stage_variables
-    ENVIRONMENT: $CI_ENVIRONMENT_NAME
-    FLASK_APP: ${FLASK_APP}
-    PORT: ${NLP_PORT}
-    SUGGEST_DATA: ${SUGGEST_DATA_URL}
-    CDTN_REGISTRY: $CI_REGISTRY_IMAGE
-  except:
-  - master
+# Deploy @cdtn/nlp (dev):
+#   <<: *deploy_stage
+#   environment:
+#     name: dev
+#     url: $NLP_HOST
+#   extends: .deploy-code-du-travail-nlp-k8s
+#   variables:
+#     <<: *deploy_stage_variables
+#     ENVIRONMENT: $CI_ENVIRONMENT_NAME
+#     FLASK_APP: ${FLASK_APP}
+#     PORT: ${NLP_PORT}
+#     SUGGEST_DATA: ${SUGGEST_DATA_URL}
+#     CDTN_REGISTRY: $CI_REGISTRY_IMAGE
+#   except:
+#   - master
 
-Deploy @cdtn/frontend (dev):
-  <<: *deploy_stage
-  environment:
-    name: dev
-    url: $FRONTEND_HOST
-  extends: .deploy-code-du-travail-frontend-k8s
-  variables:
-    <<: *deploy_stage_variables
-    ENVIRONMENT: $CI_ENVIRONMENT_NAME
-    PORT: ${FRONTEND_PORT}
-    CDTN_REGISTRY: $CI_REGISTRY_IMAGE
-  except:
-  - master
+# Deploy @cdtn/frontend (dev):
+#   <<: *deploy_stage
+#   environment:
+#     name: dev
+#     url: $FRONTEND_HOST
+#   extends: .deploy-code-du-travail-frontend-k8s
+#   variables:
+#     <<: *deploy_stage_variables
+#     ENVIRONMENT: $CI_ENVIRONMENT_NAME
+#     PORT: ${FRONTEND_PORT}
+#     CDTN_REGISTRY: $CI_REGISTRY_IMAGE
+#   except:
+#   - master
 
 ########################################
 #### DEPLOY CDTN TO K8S PROD CLUSTER ###
 ########################################
 
-Deploy Elasticsearch (prod):
-  <<: *deploy_stage
-  environment:
-    name: incubateur
-    url: $ELASTICSEARCH_HOST
-  extends: .deploy-elasticsearch-prod-k8s
-  variables:
-    <<: *deploy_stage_variables
-    HASH_BRANCH_NAME: ''
-    ES_PORT: ${ELASTICSEARCH_PORT}
-    ES_INTER_NODE: ${ELASTICSEARCH_INTER_NODE_PORT}
-    CDTN_REGISTRY: $CI_REGISTRY_IMAGE
-  only:
-  - master
+# Deploy Elasticsearch (prod):
+#   <<: *deploy_stage
+#   environment:
+#     name: incubateur
+#     url: $ELASTICSEARCH_HOST
+#   extends: .deploy-elasticsearch-prod-k8s
+#   variables:
+#     <<: *deploy_stage_variables
+#     HASH_BRANCH_NAME: ''
+#     ES_PORT: ${ELASTICSEARCH_PORT}
+#     ES_INTER_NODE: ${ELASTICSEARCH_INTER_NODE_PORT}
+#     CDTN_REGISTRY: $CI_REGISTRY_IMAGE
+#   only:
+#   - master
 
-Create Elasticsearch Index (prod):
-  <<: *deploy_stage
-  environment:
-    name: incubateur
-  extends: .deploy-code-du-travail-data-prod-k8s
-  variables:
-    <<: *deploy_stage_variables
-    HASH_BRANCH_NAME: ''
-    ES_PORT: ${ELASTICSEARCH_PORT}
-    CDTN_REGISTRY: $CI_REGISTRY_IMAGE
-  only:
-  - master
+# Create Elasticsearch Index (prod):
+#   <<: *deploy_stage
+#   environment:
+#     name: incubateur
+#   extends: .deploy-code-du-travail-data-prod-k8s
+#   variables:
+#     <<: *deploy_stage_variables
+#     HASH_BRANCH_NAME: ''
+#     ES_PORT: ${ELASTICSEARCH_PORT}
+#     CDTN_REGISTRY: $CI_REGISTRY_IMAGE
+#   only:
+#   - master
 
-Deploy @cdtn/api (prod):
-  <<: *deploy_stage
-  environment:
-    name: incubateur
-    url: $API_HOST
-  extends: .deploy-code-du-travail-api-prod-k8s
-  variables:
-    <<: *deploy_stage_variables
-    HASH_BRANCH_NAME: ''
-    ELASTICSEARCH_LOG_LEVEL: "trace"
-    APM_SERVER_ACTIVE: 0
-    APM_SERVER_URL: ""
-    ENVIRONMENT: $CI_ENVIRONMENT_NAME
-    PORT: ${API_PORT}
-    ES_PORT: ${ELASTICSEARCH_PORT}
-    CDTN_REGISTRY: $CI_REGISTRY_IMAGE
-  only:
-  - master
+# Deploy @cdtn/api (prod):
+#   <<: *deploy_stage
+#   environment:
+#     name: incubateur
+#     url: $API_HOST
+#   extends: .deploy-code-du-travail-api-prod-k8s
+#   variables:
+#     <<: *deploy_stage_variables
+#     HASH_BRANCH_NAME: ''
+#     ELASTICSEARCH_LOG_LEVEL: "trace"
+#     APM_SERVER_ACTIVE: 0
+#     APM_SERVER_URL: ""
+#     ENVIRONMENT: $CI_ENVIRONMENT_NAME
+#     PORT: ${API_PORT}
+#     ES_PORT: ${ELASTICSEARCH_PORT}
+#     CDTN_REGISTRY: $CI_REGISTRY_IMAGE
+#   only:
+#   - master
 
-Deploy @cdtn/nlp (prod):
-  <<: *deploy_stage
-  environment:
-    name: incubateur
-    url: $NLP_HOST
-  extends: .deploy-code-du-travail-nlp-prod-k8s
-  variables:
-    <<: *deploy_stage_variables
-    HASH_BRANCH_NAME: ''
-    ENVIRONMENT: $CI_ENVIRONMENT_NAME
-    FLASK_APP: ${FLASK_APP}
-    PORT: ${NLP_PORT}
-    SUGGEST_DATA: ${SUGGEST_DATA_URL}
-    CDTN_REGISTRY: $CI_REGISTRY_IMAGE
-  only:
-  - master
+# Deploy @cdtn/nlp (prod):
+#   <<: *deploy_stage
+#   environment:
+#     name: incubateur
+#     url: $NLP_HOST
+#   extends: .deploy-code-du-travail-nlp-prod-k8s
+#   variables:
+#     <<: *deploy_stage_variables
+#     HASH_BRANCH_NAME: ''
+#     ENVIRONMENT: $CI_ENVIRONMENT_NAME
+#     FLASK_APP: ${FLASK_APP}
+#     PORT: ${NLP_PORT}
+#     SUGGEST_DATA: ${SUGGEST_DATA_URL}
+#     CDTN_REGISTRY: $CI_REGISTRY_IMAGE
+#   only:
+#   - master
 
-Deploy @cdtn/frontend (prod):
-  <<: *deploy_stage
-  environment:
-    name: incubateur
-    url: $FRONTEND_HOST
-  extends: .deploy-code-du-travail-frontend-prod-k8s
-  variables:
-    <<: *deploy_stage_variables
-    HASH_BRANCH_NAME: ''
-    ENVIRONMENT: $CI_ENVIRONMENT_NAME
-    PORT: ${FRONTEND_PORT}
-    CDTN_REGISTRY: $CI_REGISTRY_IMAGE
-  only:
-  - master
+# Deploy @cdtn/frontend (prod):
+#   <<: *deploy_stage
+#   environment:
+#     name: incubateur
+#     url: $FRONTEND_HOST
+#   extends: .deploy-code-du-travail-frontend-prod-k8s
+#   variables:
+#     <<: *deploy_stage_variables
+#     HASH_BRANCH_NAME: ''
+#     ENVIRONMENT: $CI_ENVIRONMENT_NAME
+#     PORT: ${FRONTEND_PORT}
+#     CDTN_REGISTRY: $CI_REGISTRY_IMAGE
+#   only:
+#   - master
 
 #######################################
 ###       DELETE K8S OBJECTS        ###
@@ -216,4 +213,4 @@ delete-k8s-objects:
   script:
   - python3 k8s/scripts/delete-k8s-objects.py
   only:
-  - master
+  - boni-fix-delete-pod

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,199 +3,199 @@ include:
 - /.gitlab-ci/variables.yml
 - /.gitlab-ci/extends.yml
 
-# - '/k8s/elasticsearch/.deploy-elasticsearch-k8s.yml'
-# - '/k8s/code-du-travail-data/.deploy-code-du-travail-data-k8s.yml'
-# - '/k8s/code-du-travail-api/.deploy-code-du-travail-api-k8s.yml'
-# - '/k8s/code-du-travail-frontend/.deploy-code-du-travail-frontend-k8s.yml'
-# - '/k8s/code-du-travail-nlp/.deploy-code-du-travail-nlp-k8s.yml'
+- '/k8s/elasticsearch/.deploy-elasticsearch-k8s.yml'
+- '/k8s/code-du-travail-data/.deploy-code-du-travail-data-k8s.yml'
+- '/k8s/code-du-travail-api/.deploy-code-du-travail-api-k8s.yml'
+- '/k8s/code-du-travail-frontend/.deploy-code-du-travail-frontend-k8s.yml'
+- '/k8s/code-du-travail-nlp/.deploy-code-du-travail-nlp-k8s.yml'
 
-# - /.gitlab-ci/stages/prepare.yml
-# - /.gitlab-ci/stages/quality.yml
-# - /.gitlab-ci/stages/register.yml
-# - /.gitlab-ci/stages/notify.yml
+- /.gitlab-ci/stages/prepare.yml
+- /.gitlab-ci/stages/quality.yml
+- /.gitlab-ci/stages/register.yml
+- /.gitlab-ci/stages/notify.yml
 
 image: node:10-alpine
 
 stages:
-# - "Prepare"
-# - "Code Quality"
-# - "Registration"
-# - "Deploy"
-# - "Notify Finished Deployment"
+- "Prepare"
+- "Code Quality"
+- "Registration"
+- "Deploy"
+- "Notify Finished Deployment"
 - "Delete K8S Objects"
 
 
-# .deploy_stage: &deploy_stage
-#   stage: "Deploy"
-#   dependencies: []
-#   services:
-#     - docker:$DOCKER_VERSION-dind
-#   variables: &deploy_stage_variables
-#     IMAGE_TAG: $CI_COMMIT_SHA
-#   before_script:
-#     - source .gitlab-ci/env.sh
+.deploy_stage: &deploy_stage
+  stage: "Deploy"
+  dependencies: []
+  services:
+    - docker:$DOCKER_VERSION-dind
+  variables: &deploy_stage_variables
+    IMAGE_TAG: $CI_COMMIT_SHA
+  before_script:
+    - source .gitlab-ci/env.sh
 
 
 ######################################
 ### DEPLOY CDTN TO K8S DEV CLUSTER ###
 ######################################
 
-# Deploy Elasticsearch (dev):
-#   <<: *deploy_stage
-#   environment:
-#     name: dev
-#     url: $ELASTICSEARCH_HOST
-#   extends: .deploy-elasticsearch-dev-k8s
-#   variables:
-#     <<: *deploy_stage_variables
-#     ES_PORT: ${ELASTICSEARCH_PORT}
-#     ES_INTER_NODE: ${ELASTICSEARCH_INTER_NODE_PORT}
-#     CDTN_REGISTRY: $CI_REGISTRY_IMAGE
-#   except:
-#   - master
+Deploy Elasticsearch (dev):
+  <<: *deploy_stage
+  environment:
+    name: dev
+    url: $ELASTICSEARCH_HOST
+  extends: .deploy-elasticsearch-dev-k8s
+  variables:
+    <<: *deploy_stage_variables
+    ES_PORT: ${ELASTICSEARCH_PORT}
+    ES_INTER_NODE: ${ELASTICSEARCH_INTER_NODE_PORT}
+    CDTN_REGISTRY: $CI_REGISTRY_IMAGE
+  except:
+  - master
 
-# Create Elasticsearch Index (dev):
-#   <<: *deploy_stage
-#   environment:
-#     name: dev
-#   extends: .deploy-code-du-travail-data-k8s
-#   variables:
-#     <<: *deploy_stage_variables
-#     ES_PORT: ${ELASTICSEARCH_PORT}
-#     CDTN_REGISTRY: $CI_REGISTRY_IMAGE
-#   except:
-#   - master
+Create Elasticsearch Index (dev):
+  <<: *deploy_stage
+  environment:
+    name: dev
+  extends: .deploy-code-du-travail-data-k8s
+  variables:
+    <<: *deploy_stage_variables
+    ES_PORT: ${ELASTICSEARCH_PORT}
+    CDTN_REGISTRY: $CI_REGISTRY_IMAGE
+  except:
+  - master
 
-# Deploy @cdtn/api (dev):
-#   <<: *deploy_stage
-#   environment:
-#     name: dev
-#     url: $API_HOST
-#   extends: .deploy-code-du-travail-api-k8s
-#   variables:
-#     <<: *deploy_stage_variables
-#     ELASTICSEARCH_LOG_LEVEL: "trace"
-#     APM_SERVER_ACTIVE: 0
-#     APM_SERVER_URL: ""
-#     ENVIRONMENT: $CI_ENVIRONMENT_NAME
-#     PORT: ${API_PORT}
-#     ES_PORT: ${ELASTICSEARCH_PORT}
-#     CDTN_REGISTRY: $CI_REGISTRY_IMAGE
-#   except:
-#   - master
+Deploy @cdtn/api (dev):
+  <<: *deploy_stage
+  environment:
+    name: dev
+    url: $API_HOST
+  extends: .deploy-code-du-travail-api-k8s
+  variables:
+    <<: *deploy_stage_variables
+    ELASTICSEARCH_LOG_LEVEL: "trace"
+    APM_SERVER_ACTIVE: 0
+    APM_SERVER_URL: ""
+    ENVIRONMENT: $CI_ENVIRONMENT_NAME
+    PORT: ${API_PORT}
+    ES_PORT: ${ELASTICSEARCH_PORT}
+    CDTN_REGISTRY: $CI_REGISTRY_IMAGE
+  except:
+  - master
 
-# Deploy @cdtn/nlp (dev):
-#   <<: *deploy_stage
-#   environment:
-#     name: dev
-#     url: $NLP_HOST
-#   extends: .deploy-code-du-travail-nlp-k8s
-#   variables:
-#     <<: *deploy_stage_variables
-#     ENVIRONMENT: $CI_ENVIRONMENT_NAME
-#     FLASK_APP: ${FLASK_APP}
-#     PORT: ${NLP_PORT}
-#     SUGGEST_DATA: ${SUGGEST_DATA_URL}
-#     CDTN_REGISTRY: $CI_REGISTRY_IMAGE
-#   except:
-#   - master
+Deploy @cdtn/nlp (dev):
+  <<: *deploy_stage
+  environment:
+    name: dev
+    url: $NLP_HOST
+  extends: .deploy-code-du-travail-nlp-k8s
+  variables:
+    <<: *deploy_stage_variables
+    ENVIRONMENT: $CI_ENVIRONMENT_NAME
+    FLASK_APP: ${FLASK_APP}
+    PORT: ${NLP_PORT}
+    SUGGEST_DATA: ${SUGGEST_DATA_URL}
+    CDTN_REGISTRY: $CI_REGISTRY_IMAGE
+  except:
+  - master
 
-# Deploy @cdtn/frontend (dev):
-#   <<: *deploy_stage
-#   environment:
-#     name: dev
-#     url: $FRONTEND_HOST
-#   extends: .deploy-code-du-travail-frontend-k8s
-#   variables:
-#     <<: *deploy_stage_variables
-#     ENVIRONMENT: $CI_ENVIRONMENT_NAME
-#     PORT: ${FRONTEND_PORT}
-#     CDTN_REGISTRY: $CI_REGISTRY_IMAGE
-#   except:
-#   - master
+Deploy @cdtn/frontend (dev):
+  <<: *deploy_stage
+  environment:
+    name: dev
+    url: $FRONTEND_HOST
+  extends: .deploy-code-du-travail-frontend-k8s
+  variables:
+    <<: *deploy_stage_variables
+    ENVIRONMENT: $CI_ENVIRONMENT_NAME
+    PORT: ${FRONTEND_PORT}
+    CDTN_REGISTRY: $CI_REGISTRY_IMAGE
+  except:
+  - master
 
 ########################################
 #### DEPLOY CDTN TO K8S PROD CLUSTER ###
 ########################################
 
-# Deploy Elasticsearch (prod):
-#   <<: *deploy_stage
-#   environment:
-#     name: incubateur
-#     url: $ELASTICSEARCH_HOST
-#   extends: .deploy-elasticsearch-prod-k8s
-#   variables:
-#     <<: *deploy_stage_variables
-#     HASH_BRANCH_NAME: ''
-#     ES_PORT: ${ELASTICSEARCH_PORT}
-#     ES_INTER_NODE: ${ELASTICSEARCH_INTER_NODE_PORT}
-#     CDTN_REGISTRY: $CI_REGISTRY_IMAGE
-#   only:
-#   - master
+Deploy Elasticsearch (prod):
+  <<: *deploy_stage
+  environment:
+    name: incubateur
+    url: $ELASTICSEARCH_HOST
+  extends: .deploy-elasticsearch-prod-k8s
+  variables:
+    <<: *deploy_stage_variables
+    HASH_BRANCH_NAME: ''
+    ES_PORT: ${ELASTICSEARCH_PORT}
+    ES_INTER_NODE: ${ELASTICSEARCH_INTER_NODE_PORT}
+    CDTN_REGISTRY: $CI_REGISTRY_IMAGE
+  only:
+  - master
 
-# Create Elasticsearch Index (prod):
-#   <<: *deploy_stage
-#   environment:
-#     name: incubateur
-#   extends: .deploy-code-du-travail-data-prod-k8s
-#   variables:
-#     <<: *deploy_stage_variables
-#     HASH_BRANCH_NAME: ''
-#     ES_PORT: ${ELASTICSEARCH_PORT}
-#     CDTN_REGISTRY: $CI_REGISTRY_IMAGE
-#   only:
-#   - master
+Create Elasticsearch Index (prod):
+  <<: *deploy_stage
+  environment:
+    name: incubateur
+  extends: .deploy-code-du-travail-data-prod-k8s
+  variables:
+    <<: *deploy_stage_variables
+    HASH_BRANCH_NAME: ''
+    ES_PORT: ${ELASTICSEARCH_PORT}
+    CDTN_REGISTRY: $CI_REGISTRY_IMAGE
+  only:
+  - master
 
-# Deploy @cdtn/api (prod):
-#   <<: *deploy_stage
-#   environment:
-#     name: incubateur
-#     url: $API_HOST
-#   extends: .deploy-code-du-travail-api-prod-k8s
-#   variables:
-#     <<: *deploy_stage_variables
-#     HASH_BRANCH_NAME: ''
-#     ELASTICSEARCH_LOG_LEVEL: "trace"
-#     APM_SERVER_ACTIVE: 0
-#     APM_SERVER_URL: ""
-#     ENVIRONMENT: $CI_ENVIRONMENT_NAME
-#     PORT: ${API_PORT}
-#     ES_PORT: ${ELASTICSEARCH_PORT}
-#     CDTN_REGISTRY: $CI_REGISTRY_IMAGE
-#   only:
-#   - master
+Deploy @cdtn/api (prod):
+  <<: *deploy_stage
+  environment:
+    name: incubateur
+    url: $API_HOST
+  extends: .deploy-code-du-travail-api-prod-k8s
+  variables:
+    <<: *deploy_stage_variables
+    HASH_BRANCH_NAME: ''
+    ELASTICSEARCH_LOG_LEVEL: "trace"
+    APM_SERVER_ACTIVE: 0
+    APM_SERVER_URL: ""
+    ENVIRONMENT: $CI_ENVIRONMENT_NAME
+    PORT: ${API_PORT}
+    ES_PORT: ${ELASTICSEARCH_PORT}
+    CDTN_REGISTRY: $CI_REGISTRY_IMAGE
+  only:
+  - master
 
-# Deploy @cdtn/nlp (prod):
-#   <<: *deploy_stage
-#   environment:
-#     name: incubateur
-#     url: $NLP_HOST
-#   extends: .deploy-code-du-travail-nlp-prod-k8s
-#   variables:
-#     <<: *deploy_stage_variables
-#     HASH_BRANCH_NAME: ''
-#     ENVIRONMENT: $CI_ENVIRONMENT_NAME
-#     FLASK_APP: ${FLASK_APP}
-#     PORT: ${NLP_PORT}
-#     SUGGEST_DATA: ${SUGGEST_DATA_URL}
-#     CDTN_REGISTRY: $CI_REGISTRY_IMAGE
-#   only:
-#   - master
+Deploy @cdtn/nlp (prod):
+  <<: *deploy_stage
+  environment:
+    name: incubateur
+    url: $NLP_HOST
+  extends: .deploy-code-du-travail-nlp-prod-k8s
+  variables:
+    <<: *deploy_stage_variables
+    HASH_BRANCH_NAME: ''
+    ENVIRONMENT: $CI_ENVIRONMENT_NAME
+    FLASK_APP: ${FLASK_APP}
+    PORT: ${NLP_PORT}
+    SUGGEST_DATA: ${SUGGEST_DATA_URL}
+    CDTN_REGISTRY: $CI_REGISTRY_IMAGE
+  only:
+  - master
 
-# Deploy @cdtn/frontend (prod):
-#   <<: *deploy_stage
-#   environment:
-#     name: incubateur
-#     url: $FRONTEND_HOST
-#   extends: .deploy-code-du-travail-frontend-prod-k8s
-#   variables:
-#     <<: *deploy_stage_variables
-#     HASH_BRANCH_NAME: ''
-#     ENVIRONMENT: $CI_ENVIRONMENT_NAME
-#     PORT: ${FRONTEND_PORT}
-#     CDTN_REGISTRY: $CI_REGISTRY_IMAGE
-#   only:
-#   - master
+Deploy @cdtn/frontend (prod):
+  <<: *deploy_stage
+  environment:
+    name: incubateur
+    url: $FRONTEND_HOST
+  extends: .deploy-code-du-travail-frontend-prod-k8s
+  variables:
+    <<: *deploy_stage_variables
+    HASH_BRANCH_NAME: ''
+    ENVIRONMENT: $CI_ENVIRONMENT_NAME
+    PORT: ${FRONTEND_PORT}
+    CDTN_REGISTRY: $CI_REGISTRY_IMAGE
+  only:
+  - master
 
 #######################################
 ###       DELETE K8S OBJECTS        ###
@@ -213,4 +213,4 @@ delete-k8s-objects:
   script:
   - python3 k8s/scripts/delete-k8s-objects.py
   only:
-  - boni-fix-delete-pod
+  - master

--- a/.gitlab-ci/env.sh
+++ b/.gitlab-ci/env.sh
@@ -5,8 +5,8 @@
 export BRANCH_NAME=${BRANCH_NAME:=$CI_COMMIT_REF_NAME}
 export COMMIT=${COMMIT:=$CI_COMMIT_SHA}
 export JOB_ID=${JOB_ID:=$CI_JOB_ID}
-
-BRANCH_NAME_HASHED=$(printf "${BRANCH_NAME}" | sha1sum | cut -c1-7 )
+export HASH_SIZE=${HASH_SIZE}
+BRANCH_NAME_HASHED=$(printf "${BRANCH_NAME}" | sha1sum | cut -c1-${HASH_SIZE} )
 export BRANCH_HASH=${BRANCH_HASH:=$BRANCH_NAME_HASHED}
 
 #

--- a/.gitlab-ci/variables.yml
+++ b/.gitlab-ci/variables.yml
@@ -1,7 +1,7 @@
 variables:
   API_PORT: 1337
   APM_SERVER_PORT: 8200
-  BRANCH_HASHER: printf "${CI_COMMIT_REF_NAME}" | sha1sum | cut -c1-7
+  HASH_SIZE: 7
   DOCKER_COMPOSE_VERSION: "1.23.2"
   DOCKER_DRIVER: overlay2
   DOCKER_HOST: tcp://localhost:2375

--- a/k8s/scripts/delete-k8s-objects.py
+++ b/k8s/scripts/delete-k8s-objects.py
@@ -1,8 +1,8 @@
 from subprocess import check_output
 import hashlib
 import os
-print "a"
-import requests
+import json
+from urllib import request
 
 # This script compares the active remote branches and active k8s tags.
 # If a k8s tag doesn't match an active hashed remote branches name's, we delete all the k8s objects with this k8s tag.
@@ -10,8 +10,8 @@ github_token = os.environ["GITHUB_TOKEN"]
 hash_size = int(os.environ["HASH_SIZE"])
 
 def get_active_branches():
-  r = requests.get("https://{}@api.github.com/repos/SocialGouv/code-du-travail-numerique/pulls".format(github_token))
-  active_branches = [branch.get("head").get("ref") for branch in r.json()]
+  response = request.urlopen("https://{}@api.github.com/repos/SocialGouv/code-du-travail-numerique/pulls".format(github_token))
+  active_branches = [branch.get("head").get("ref") for branch in json.loads(response.read())]
   print active_branches
   return [
     hashlib.sha1(branche).hexdigest()[:hash_size]

--- a/k8s/scripts/delete-k8s-objects.py
+++ b/k8s/scripts/delete-k8s-objects.py
@@ -1,6 +1,7 @@
 from subprocess import check_output
 import hashlib
 import os
+print "a"
 import requests
 
 # This script compares the active remote branches and active k8s tags.
@@ -11,7 +12,7 @@ hash_size = int(os.environ["HASH_SIZE"])
 def get_active_branches():
   r = requests.get("https://{}@api.github.com/repos/SocialGouv/code-du-travail-numerique/pulls".format(github_token))
   active_branches = [branch.get("head").get("ref") for branch in r.json()]
-  print(active_branches)
+  print active_branches
   return [
     hashlib.sha1(branche).hexdigest()[:hash_size]
     for branche in active_branches

--- a/k8s/scripts/delete-k8s-objects.py
+++ b/k8s/scripts/delete-k8s-objects.py
@@ -12,7 +12,6 @@ hash_size = int(os.environ["HASH_SIZE"])
 def get_active_branches():
   response = request.urlopen("https://{}@api.github.com/repos/SocialGouv/code-du-travail-numerique/pulls".format(github_token))
   active_branches = [branch.get("head").get("ref") for branch in json.loads(response.read())]
-  print active_branches
   return [
     hashlib.sha1(branche).hexdigest()[:hash_size]
     for branche in active_branches

--- a/k8s/scripts/delete-k8s-objects.py
+++ b/k8s/scripts/delete-k8s-objects.py
@@ -10,8 +10,10 @@ github_token = os.environ["GITHUB_TOKEN"]
 hash_size = int(os.environ["HASH_SIZE"])
 
 def get_active_branches():
-  response = request.urlopen("https://{}@api.github.com/repos/SocialGouv/code-du-travail-numerique/pulls".format(github_token))
-  active_branches = [branch.get("head").get("ref") for branch in json.loads(response.read())]
+  url = "https://api.github.com/repos/SocialGouv/code-du-travail-numerique/pulls".format(github_token)
+  req = request.Request(url, None, {"token": github_token})
+  response = request.urlopen(req)
+  [branch.get("head").get("ref") for branch in json.loads(response.read())]
   return [
     hashlib.sha1(branche).hexdigest()[:hash_size]
     for branche in active_branches

--- a/k8s/scripts/delete-k8s-objects.py
+++ b/k8s/scripts/delete-k8s-objects.py
@@ -11,7 +11,7 @@ def get_active_branches():
     if active_branch and not active_branch.startswith('*') and active_branch.strip() != 'origin/master' and active_branch.strip() != 'origin/HEAD -> origin/master':
       active_branch = active_branch.replace('origin/','').replace('/','-').strip()
       active_hash_branch = hashlib.sha1(active_branch.strip().encode())
-      active_branche_list.append(active_hash_branch.hexdigest()[:5])
+      active_branche_list.append(active_hash_branch.hexdigest()[:7])
   return active_branche_list
 
 def get_active_k8s_tags():

--- a/k8s/scripts/delete-k8s-objects.py
+++ b/k8s/scripts/delete-k8s-objects.py
@@ -13,7 +13,7 @@ def get_active_branches():
   url = "https://api.github.com/repos/SocialGouv/code-du-travail-numerique/pulls".format(github_token)
   req = request.Request(url, None, {"token": github_token})
   response = request.urlopen(req)
-  [branch.get("head").get("ref") for branch in json.loads(response.read())]
+  active_branches = [branch.get("head").get("ref") for branch in json.loads(response.read())]
   return [
     hashlib.sha1(branche).hexdigest()[:hash_size]
     for branche in active_branches

--- a/k8s/scripts/delete-k8s-objects.py
+++ b/k8s/scripts/delete-k8s-objects.py
@@ -13,7 +13,7 @@ def get_active_branches():
   url = "https://api.github.com/repos/SocialGouv/code-du-travail-numerique/pulls".format(github_token)
   req = request.Request(url, None, {"token": github_token})
   response = request.urlopen(req)
-  active_branches = [branch.get("head").get("ref") for branch in json.loads(response.read())]
+  active_branches = [branch.get("head").get("ref").encode() for branch in json.loads(response.read())]
   return [
     hashlib.sha1(branche).hexdigest()[:hash_size]
     for branche in active_branches

--- a/k8s/scripts/delete-k8s-objects.py
+++ b/k8s/scripts/delete-k8s-objects.py
@@ -51,5 +51,5 @@ def get_k8s_tag_to_delete(active_k8s_tag_list=[], active_branch_list=[]):
 
 if __name__ == '__main__':
   for k8s_tag_to_delete in get_k8s_tag_to_delete(get_active_k8s_tags(), get_active_branches()):
-    # delete_k8s_object(k8s_tag_to_delete)
+    delete_k8s_object(k8s_tag_to_delete)
     print('k8s objects with label branch=cdtn-'+k8s_tag_to_delete+' have been deleted')

--- a/k8s/scripts/delete-k8s-objects.py
+++ b/k8s/scripts/delete-k8s-objects.py
@@ -1,50 +1,53 @@
 from subprocess import check_output
 import hashlib
+import os
+import requests
 
 # This script compares the active remote branches and active k8s tags.
 # If a k8s tag doesn't match an active hashed remote branches name's, we delete all the k8s objects with this k8s tag.
+github_token = os.environ["GITHUB_TOKEN"]
+hash_size = int(os.environ["HASH_SIZE"])
 
 def get_active_branches():
-  active_branche_list = []
-  raw_active_branche = check_output('git branch -r', shell=True)
-  for  active_branch in raw_active_branche.decode('utf-8').split('\n'):
-    if active_branch and not active_branch.startswith('*') and active_branch.strip() != 'origin/master' and active_branch.strip() != 'origin/HEAD -> origin/master':
-      active_branch = active_branch.replace('origin/','').replace('/','-').strip()
-      active_hash_branch = hashlib.sha1(active_branch.strip().encode())
-      active_branche_list.append(active_hash_branch.hexdigest()[:7])
-  return active_branche_list
+  r = requests.get("https://{}@api.github.com/repos/SocialGouv/code-du-travail-numerique/pulls".format(github_token))
+  active_branches = [branch.get("head").get("ref") for branch in r.json()]
+  print(active_branches)
+  return [
+    hashlib.sha1(branche).hexdigest()[:hash_size]
+    for branche in active_branches
+  ]
 
 def get_active_k8s_tags():
-  active_k8s_tag_list = []
-  raw_k8s_tag_list = check_output("kubectl get pods -o go-template --template '{{range .items}}{{.metadata.labels.branch}}{{end}}'", shell=True)
-  for active_k8s_tag in raw_k8s_tag_list.decode('utf-8').replace('<no value>','').split('cdtn-'):
-    active_k8s_tag_list.append(active_k8s_tag)
-  return active_k8s_tag_list
+  raw_k8s_tag_list = check_output("kubectl get pods -o go-template --template '{{range .items}}{{.metadata.labels.branch}}{{end}}'", shell=True).decode("utf-8")
+  k8s_tag_list = raw_k8s_tag_list.replace('<no value>','').split('cdtn-')
+  return [
+    k8s_tag
+    for k8s_tag in k8s_tag_list if k8s_tag
+  ]
 
 def delete_k8s_object(label):
-  k8s_object_list = ["service", "ingress", "configmap", "deployments", "statefulset"]
+  k8s_object_list = ["service", "ingress", "configmap", "deployments", "statefulset", "pod"]
   for k8s_object in k8s_object_list:
     command_to_delete_k8s_object = ('kubectl delete '+ k8s_object +' --selector branch=cdtn-'+label)
     check_output(command_to_delete_k8s_object, shell=True)
 
-def get_k8s_tag_to_delete(active_k8s_tag_list, active_branch_list):
-  k8s_tag_list_to_delete = []
-  if active_k8s_tag_list is not None:
-    for active_k8s_tag in active_k8s_tag_list:
-      delete_tag = False
-      if active_k8s_tag != '':
-        for active_branch in active_branch_list:
-          if active_k8s_tag == active_branch :
-            delete_tag = False
-            break
-          else:
-            delete_tag = True
-        if(delete_tag):
-          k8s_tag_list_to_delete.append(active_k8s_tag)
-  print(k8s_tag_list_to_delete)
-  return k8s_tag_list_to_delete
+def get_k8s_tag_to_delete(active_k8s_tag_list=[], active_branch_list=[]):
+    k8s_tag_list_to_delete = []
+
+    active_tags = [
+        tag for tag in active_k8s_tag_list if tag != ""
+    ]
+    deletable_tags = [
+        tag
+        for tag in active_tags
+        if tag not in active_branch_list
+    ]
+
+    for tag in deletable_tags:
+        k8s_tag_list_to_delete.append(tag)
+    return k8s_tag_list_to_delete
 
 if __name__ == '__main__':
   for k8s_tag_to_delete in get_k8s_tag_to_delete(get_active_k8s_tags(), get_active_branches()):
-    delete_k8s_object(k8s_tag_to_delete)
+    # delete_k8s_object(k8s_tag_to_delete)
     print('k8s objects with label branch=cdtn-'+k8s_tag_to_delete+' have been deleted')


### PR DESCRIPTION
Le objets k8s étaient tous supprimés car il y a eu un changement sur le nombre de caractères du hash de la branche. On est passé de 5 à 7. 
Du coup, lorsque le script faisait la comparaison des branches actives et des objects k8s actifs, il ne trouvait jamais la même chose et supprimait tout.
