### PR TITLE
fix(frontend): fix source blur in search

### DIFF
--- a/packages/code-du-travail-frontend/src/search/Search.js
+++ b/packages/code-du-travail-frontend/src/search/Search.js
@@ -42,7 +42,7 @@ class Search extends React.Component {
       });
     }
     if (this.props.router.query.source) {
-      const source = this.props.router.query.source;
+      const source = this.props.router.query.source || "";
       const excludeSources = getExcludeSources(source);
       this.setState({ source, excludeSources });
     }
@@ -62,7 +62,7 @@ class Search extends React.Component {
     }
     this.setState({
       query: this.props.router.query.q,
-      source: this.props.router.query.source,
+      source: this.props.router.query.source || "",
       coord: coord,
       excludeSources: getExcludeSources(this.props.router.query.source || "")
     });
@@ -100,6 +100,9 @@ class Search extends React.Component {
         });
         return;
       case "source":
+        if (this.state.source === event.target.value) {
+          return;
+        }
         this.setState({
           source: event.target.value,
           excludeSources: getExcludeSources(event.target.value)

--- a/packages/code-du-travail-frontend/src/search/__tests__/Search.test.js
+++ b/packages/code-du-travail-frontend/src/search/__tests__/Search.test.js
@@ -35,10 +35,19 @@ describe("<search />", () => {
     await waitForElement(() => getAllByRole("option"));
     expect(container).toMatchSnapshot();
   });
+
   it("should not navigate when user change facet if query is empty", () => {
     const { getBySelectText } = renderWithMock(<Search />);
     const select = getBySelectText(/Tous contenus/i);
     fireEvent.change(select, { target: { value: "faq" } });
+    expect(Router.pushRoute).not.toHaveBeenCalled();
+  });
+
+  it("should not navigate when user blur source facet", () => {
+    const { getBySelectText } = renderWithMock(<Search />, { query: { q } });
+    const select = getBySelectText(/Tous contenus/i);
+    fireEvent.focus(select);
+    fireEvent.blur(select);
     expect(Router.pushRoute).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
handleRouteChange reset source in state to undefined
so we need to reset it to an empty string so we can compare new value
to the one in state and bail update if there no change

fix #937 