### PR TITLE
fix(frontend): display error message in ccn infos

### DIFF
--- a/packages/code-du-travail-frontend/src/outils/indemniteLicenciement/components/ErrorField.js
+++ b/packages/code-du-travail-frontend/src/outils/indemniteLicenciement/components/ErrorField.js
@@ -3,22 +3,19 @@ import PropTypes from "prop-types";
 import { Field } from "react-final-form";
 import { Alert } from "@cdt/ui";
 
-function ErrorField({ name, immediate = false }) {
+function ErrorField({ name }) {
   return (
     <Field
       name={name}
-      subscribe={{ error: true, touched: true, visited: immediate }}
-      render={({ meta: { touched, error, visited } }) =>
-        (error && touched) || (error && visited && immediate) ? (
-          <Alert>{error}</Alert>
-        ) : null
+      subscribe={{ error: true, dirty: true }}
+      render={({ meta: { error, touched, dirty } }) =>
+        (error && dirty) || (error && touched) ? <Alert>{error}</Alert> : null
       }
     />
   );
 }
 ErrorField.propTypes = {
-  name: PropTypes.string.isRequired,
-  immediate: PropTypes.bool
+  name: PropTypes.string.isRequired
 };
 
 function ErrorComputedField({ name }) {

--- a/packages/code-du-travail-frontend/src/outils/indemniteLicenciement/components/YesNoQuestion.js
+++ b/packages/code-du-travail-frontend/src/outils/indemniteLicenciement/components/YesNoQuestion.js
@@ -34,7 +34,7 @@ function YesNoQuestion({ name, label, onChange }) {
           <span>Non</span>
         </Label>
       </RadioContainer>
-      <ErrorField name={name} immediate />
+      <ErrorField name={name} />
       {onChange && (
         <OnChange name={name}>{values => onChange(values)}</OnChange>
       )}

--- a/packages/code-du-travail-frontend/src/outils/indemniteLicenciement/components/__tests__/ErrorField.test.js
+++ b/packages/code-du-travail-frontend/src/outils/indemniteLicenciement/components/__tests__/ErrorField.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "react-testing-library";
+import { render, fireEvent } from "react-testing-library";
 import { ErrorField } from "../ErrorField";
 import { Form, Field } from "react-final-form";
 
@@ -8,7 +8,7 @@ describe("<ErroField />", () => {
     const onSubmit = jest.fn();
     const { container, getByTestId } = render(
       <Form
-        initialValues={{ absences: [{ type: "Grève", duration: 3 }] }}
+        initialValues={{ test: "a" }}
         onSubmit={onSubmit}
         render={() => (
           <>
@@ -24,7 +24,7 @@ describe("<ErroField />", () => {
       />
     );
     const input = getByTestId("test");
-    input.focus();
+    fireEvent.change(input, { target: { value: "" } });
     input.blur();
     expect(container).toMatchSnapshot();
   });

--- a/packages/code-du-travail-frontend/src/outils/indemniteLicenciement/components/__tests__/YesNoQuestion.test.js
+++ b/packages/code-du-travail-frontend/src/outils/indemniteLicenciement/components/__tests__/YesNoQuestion.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "react-testing-library";
+import { render, fireEvent } from "react-testing-library";
 import { YesNoQuestion } from "../YesNoQuestion";
 import { Form } from "react-final-form";
 
@@ -37,7 +37,7 @@ describe("<YesNoQuestion />", () => {
     expect(onChange).toHaveBeenCalledWith(true);
   });
 
-  it("should render error", () => {
+  it("should render error when form validate", () => {
     const onSubmit = jest.fn();
     const { getByText } = render(
       <Form onSubmit={onSubmit}>
@@ -49,8 +49,30 @@ describe("<YesNoQuestion />", () => {
         )}
       </Form>
     );
-    const bt = getByText(/validate/i);
-    bt.click();
+    const non = getByText(/validate/i);
+    fireEvent.click(non);
     expect(getByText(/ce champ est requis/i)).toBeDefined();
+  });
+
+  it("should render error when radio change", () => {
+    const onSubmit = jest.fn();
+    const { getByLabelText, getByText } = render(
+      <Form
+        onSubmit={onSubmit}
+        validate={values =>
+          values.test === "oui" ? {} : { test: "mauvaise réponse" }
+        }
+      >
+        {({ handleSubmit }) => (
+          <form onSubmit={handleSubmit}>
+            <YesNoQuestion name="test" label="lorem ipsum ?" />
+            <button>validate</button>
+          </form>
+        )}
+      </Form>
+    );
+    const non = getByLabelText(/non/i);
+    fireEvent.click(non);
+    expect(getByText(/mauvaise réponse/i)).toBeDefined();
   });
 });


### PR DESCRIPTION
This bug appears only on safari. When selecting cdd or faute-grave on
the first screen of the idl.
Error messages are now trigger using the dirty flag

fix #960