### PR TITLE
improve conventions suggestions

### DIFF
--- a/packages/code-du-travail-api/src/server/routes/__tests__/__snapshots__/idcc.spec.js.snap
+++ b/packages/code-du-travail-api/src/server/routes/__tests__/__snapshots__/idcc.spec.js.snap
@@ -6,7 +6,7 @@ Object {
     Object {
       "_id": "10",
       "_index": "cdtn_document_test",
-      "_score": 1.858978,
+      "_score": 1.8064516,
       "_source": Object {
         "id": "KALICONT000005635886",
         "idcc": "843",
@@ -19,7 +19,7 @@ Object {
     Object {
       "_id": "11",
       "_index": "cdtn_document_test",
-      "_score": 1.858978,
+      "_score": 1.7264521,
       "_source": Object {
         "id": "KALICONT000005635691",
         "idcc": "1747",
@@ -30,7 +30,7 @@ Object {
       "_type": "cdtn_document_test",
     },
   ],
-  "max_score": 1.858978,
+  "max_score": 1.8064516,
   "total": 2,
 }
 `;
@@ -57,7 +57,7 @@ Object {
     Object {
       "_id": "10",
       "_index": "cdtn_document_test",
-      "_score": 1.6673176,
+      "_score": 0.57498115,
       "_source": Object {
         "id": "KALICONT000005635886",
         "idcc": "843",
@@ -70,7 +70,7 @@ Object {
     Object {
       "_id": "11",
       "_index": "cdtn_document_test",
-      "_score": 1.6673176,
+      "_score": 0.57498115,
       "_source": Object {
         "id": "KALICONT000005635691",
         "idcc": "1747",
@@ -81,7 +81,7 @@ Object {
       "_type": "cdtn_document_test",
     },
   ],
-  "max_score": 1.6673176,
+  "max_score": 0.57498115,
   "total": 2,
 }
 `;

--- a/packages/code-du-travail-api/src/server/routes/idcc/idcc.elastic.js
+++ b/packages/code-du-travail-api/src/server/routes/idcc/idcc.elastic.js
@@ -32,7 +32,7 @@ function getIdccBody({ query }) {
               },
               {
                 match_phrase_prefix: {
-                  "title.french_stemmed": {
+                  title: {
                     query: `${query}`
                   }
                 }

--- a/packages/code-du-travail-api/src/server/routes/idcc/idcc.elastic.js
+++ b/packages/code-du-travail-api/src/server/routes/idcc/idcc.elastic.js
@@ -24,8 +24,10 @@ function getIdccBody({ query }) {
                 }
               },
               {
-                prefix: {
-                  idcc: `${query}`
+                match_phrase_prefix: {
+                  "idcc.text": {
+                    query: `${query}`
+                  }
                 }
               },
               {

--- a/packages/code-du-travail-api/src/server/routes/idcc/idcc.elastic.js
+++ b/packages/code-du-travail-api/src/server/routes/idcc/idcc.elastic.js
@@ -24,9 +24,8 @@ function getIdccBody({ query }) {
                 }
               },
               {
-                multi_match: {
-                  query: `${query}`,
-                  fields: "idcc.*"
+                prefix: {
+                  idcc: `${query}`
                 }
               },
               {


### PR DESCRIPTION
florent nous a fait remarquer que lorsqu'on cherche '69' dans le bloc de recherche de convention collectives, il ne propose pas la 693. J'ai modifié les paramètres de recherches ES pour que ça marche mieux. 

Un autre fix s'est glissé dans cette PR pour réparer ce cas : 
- frigorifiq => suggere la 1412
- frigorifiqu => aucune suggestion
- frigorifique => suggere la 1412