### PR TITLE
feat(frontend): conventions publish date wording update + remove extensions textes

### DIFF
--- a/packages/code-du-travail-frontend/src/conventions/Convention.js
+++ b/packages/code-du-travail-frontend/src/conventions/Convention.js
@@ -45,16 +45,6 @@ const Convention = ({ convention, conteneur }) => (
             />
           ),
           key: "salaires"
-        },
-        {
-          tab: "Textes d'extensions",
-          panel: (
-            <ConventionListeTextes
-              conteneur={conteneur}
-              typeTextes={"extensions"}
-            />
-          ),
-          key: "extensions"
         }
       ]}
     />

--- a/packages/code-du-travail-frontend/src/conventions/ConventionInfos.js
+++ b/packages/code-du-travail-frontend/src/conventions/ConventionInfos.js
@@ -16,7 +16,7 @@ class ConventionInfos extends React.Component {
               <td>{conteneur.num}</td>
             </tr>
             <tr>
-              <th>Date de publication originale</th>
+              <th>Date d’entrée en vigueur</th>
               <td>{format(conteneur.date_publi, "DD/MM/YYYY")}</td>
             </tr>
           </tbody>

--- a/packages/code-du-travail-frontend/src/conventions/__test__/__snapshots__/Convention.test.js.snap
+++ b/packages/code-du-travail-frontend/src/conventions/__test__/__snapshots__/Convention.test.js.snap
@@ -349,16 +349,6 @@ exports[`<Convention /> should render 1`] = `
       >
         Texte salaires
       </li>
-      <li
-        aria-controls="react-tabs-9"
-        aria-disabled="false"
-        aria-selected="false"
-        class="c7"
-        id="react-tabs-8"
-        role="tab"
-      >
-        Textes d'extensions
-      </li>
     </ul>
     <div
       aria-labelledby="react-tabs-0"
@@ -386,7 +376,7 @@ exports[`<Convention /> should render 1`] = `
               </tr>
               <tr>
                 <th>
-                  Date de publication originale
+                  Date d’entrée en vigueur
                 </th>
                 <td>
                   01/11/1993
@@ -422,12 +412,6 @@ exports[`<Convention /> should render 1`] = `
       aria-labelledby="react-tabs-6"
       class="c8"
       id="react-tabs-7"
-      role="tabpanel"
-    />
-    <div
-      aria-labelledby="react-tabs-8"
-      class="c8"
-      id="react-tabs-9"
       role="tabpanel"
     />
   </div>


### PR DESCRIPTION
sur les retours de Florent, un petit renommage et on enlève la tab textes d'extensions, qui ne sont qu'utiles pour avoir une vue historique de la convention.