### PR TITLE
fix(data): fix french indexing

### DIFF
--- a/packages/code-du-travail-api/src/server/routes/__tests__/__snapshots__/search.spec.js.snap
+++ b/packages/code-du-travail-api/src/server/routes/__tests__/__snapshots__/search.spec.js.snap
@@ -17,7 +17,7 @@ Object {
       Object {
         "_id": "8",
         "_index": "cdtn_document_test",
-        "_score": 10.606363,
+        "_score": 9.220069,
         "_source": Object {
           "slug": "r1225-18",
           "source": "code_du_travail",
@@ -40,7 +40,7 @@ Object {
         "_type": "cdtn_document_test",
       },
     ],
-    "max_score": 10.606363,
+    "max_score": 9.220069,
     "total": 2,
   },
 }

--- a/packages/code-du-travail-api/src/server/routes/search/facets.elastic.js
+++ b/packages/code-du-travail-api/src/server/routes/search/facets.elastic.js
@@ -28,7 +28,7 @@ function getFacetsBody({ query }) {
                   match: {
                     "title.article_id": {
                       query: query,
-                      boost: 5
+                      boost: 3
                     }
                   }
                 },

--- a/packages/code-du-travail-api/src/server/routes/search/search.elastic.js
+++ b/packages/code-du-travail-api/src/server/routes/search/search.elastic.js
@@ -44,7 +44,7 @@ function getSearchBody({ query, size, excludeSources = [] }) {
                   match: {
                     "title.article_id": {
                       query: query,
-                      boost: 5
+                      boost: 3
                     }
                   }
                 },

--- a/packages/code-du-travail-data/search/indexing/mappings/code_du_travail_numerique.py
+++ b/packages/code-du-travail-data/search/indexing/mappings/code_du_travail_numerique.py
@@ -21,8 +21,8 @@ code_du_travail_numerique_mapping = {
                 },
                 'french': {
                     'type': 'text',
-                    'analyzer': 'french',
-                    'search_analyzer': 'french_indexing',
+                    'analyser': 'french_indexing',
+                    'search_analyzer': 'french',
                 },
                 'french_stemmed': {
                     'type': 'text',


### PR DESCRIPTION
the french field in title use a custom anaylyser that add a marker at
the beginning of the string. This allow us to have a match_prase_prefix
that match the start of the string.

We use french_indexing as analyser to add our token at index time and
use the normal french analyser at search time (search_analyser)
since we add our token at the api level.

we also can lower the article id boost

cf #984