### PR TITLE
fix(frontend): fix undefined meta

### DIFF
--- a/packages/code-du-travail-frontend/pages/_app.js
+++ b/packages/code-du-travail-frontend/pages/_app.js
@@ -29,16 +29,15 @@ export default class MyApp extends App {
     if (Component.getInitialProps) {
       pageProps = await Component.getInitialProps(ctx);
     }
-    // pageUrl is only defined on serverside request
-    pageProps.pageUrl = ctx.req
-      ? `${ctx.req.protocol}://${ctx.req.headers.host}${ctx.req.path}`
-      : undefined;
-
-    pageProps.ogImage =
-      ctx.req &&
-      `${ctx.req.protocol}://${
+    // pageUrl and ogImage are only defined on serverside request
+    if (ctx.req) {
+      pageProps.pageUrl = `${ctx.req.protocol}://${ctx.req.headers.host}${
+        ctx.req.path
+      }`;
+      pageProps.ogImage = `${ctx.req.protocol}://${
         ctx.req.headers.host
       }/static/images/social-preview.png`;
+    }
 
     return { pageProps };
   }

--- a/packages/code-du-travail-frontend/src/common/Metas.js
+++ b/packages/code-du-travail-frontend/src/common/Metas.js
@@ -1,19 +1,17 @@
-import React, { useEffect } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import Head from "next/head";
 import { Router } from "../../routes";
 
 export default function Metas({ url, title, description, image }) {
-  useEffect(() => {
-    if (!url && Router && location) {
-      url = `${location.protocol}//${location.host}${Router.asPath}`;
-    }
-    if (!image && location) {
-      image = `${location.protocol}//${
-        location.hostname
-      }/static/images/social-preview.png`;
-    }
-  });
+  if (!url && Router && location) {
+    url = `${location.protocol}//${location.host}${Router.asPath}`;
+  }
+  if (!image && location) {
+    image = `${location.protocol}//${
+      location.hostname
+    }/static/images/social-preview.png`;
+  }
   return (
     <Head>
       <title>{title}</title>


### PR DESCRIPTION
fix #981 

1 - When not on a server-side rendered page, url and image in the head tags are undefined
2 - It seems that useEffect does not update the rendering in the `<Head>` component provided by Next.js.

Fix: 
Remove useEffect which is of no use and does not break tests anymore now that Router has been mocked.

