### PR TITLE
fix(frontend): handle http error properly for modeles page

### DIFF
--- a/packages/code-du-travail-frontend/pages/_error.js
+++ b/packages/code-du-travail-frontend/pages/_error.js
@@ -25,8 +25,9 @@ const notifySentry = statusCode => {
 };
 
 export default class Error extends React.Component {
-  static async getInitialProps({ res }) {
-    return { statusCode: res.statusCode };
+  static async getInitialProps({ res, err }) {
+    const statusCode = res ? res.statusCode : err ? err.statusCode : null;
+    return { statusCode };
   }
 
   componentDidMount() {

--- a/packages/code-du-travail-frontend/pages/modeles.js
+++ b/packages/code-du-travail-frontend/pages/modeles.js
@@ -14,7 +14,13 @@ const {
   publicRuntimeConfig: { API_URL }
 } = getConfig();
 
-const fetchAllModeles = () => fetch(`${API_URL}/modeles`).then(r => r.json());
+const fetchAllModeles = () =>
+  fetch(`${API_URL}/modeles`).then(res => {
+    if (!res.ok) {
+      throw { statusCode: res.status, ...res };
+    }
+    return res.json();
+  });
 
 class Modeles extends React.Component {
   static async getInitialProps() {
@@ -23,7 +29,7 @@ class Modeles extends React.Component {
   }
 
   render() {
-    const { data, pageUrl, ogImage } = this.props;
+    const { data = { hits: {} }, pageUrl, ogImage } = this.props;
     return (
       <PageLayout>
         <Metas
@@ -44,7 +50,7 @@ class Modeles extends React.Component {
   }
 }
 
-const List = ({ items, ...props }) => (
+const List = ({ items = [], ...props }) => (
   <ul {...props}>
     {items.map(({ id, _source }) => (
       <Item key={id}>


### PR DESCRIPTION
In case of error 4xx-5xx from API , error page is not triggered on client-side. 
I will add other PR to ensure there is no other error in error page.