### PR TITLE
ci: update docker-compose to allow deploy using tag

### DIFF
--- a/docker-compose.override.dev.yml
+++ b/docker-compose.override.dev.yml
@@ -11,14 +11,12 @@ services:
   python:
     build:
       context: ./packages/code-du-travail-data
-      dockerfile: ./Dockerfile
     volumes:
       - ./packages/code-du-travail-data/:/app
 
   nlp_api:
     build:
       context: ./packages/code-du-travail-nlp
-      dockerfile: ./Dockerfile
     environment:
       - FLASK_RUN_PORT=$NLP_PORT
       - FLASK_ENV=development

--- a/docker-compose.override.dev.yml
+++ b/docker-compose.override.dev.yml
@@ -3,14 +3,22 @@ version: "3"
 services:
   # In development, open ES port so host API can connect to it
   elasticsearch:
+    build:
+      context: ./docker/elasticsearch
     ports:
       - 9200:9200
 
   python:
+    build:
+      context: ./packages/code-du-travail-data
+      dockerfile: ./Dockerfile
     volumes:
       - ./packages/code-du-travail-data/:/app
 
   nlp_api:
+    build:
+      context: ./packages/code-du-travail-nlp
+      dockerfile: ./Dockerfile
     environment:
       - FLASK_RUN_PORT=$NLP_PORT
       - FLASK_ENV=development

--- a/docker-compose.override.prod.yml
+++ b/docker-compose.override.prod.yml
@@ -5,7 +5,7 @@ services:
   elasticsearch:
     image: registry.gitlab.factory.social.gouv.fr/socialgouv/code-du-travail-numerique/elasticsearch:$CDTN_HASH
     ports:
-      - 9200:920
+      - 9200:9200
 
   frontend:
     image: registry.gitlab.factory.social.gouv.fr/socialgouv/code-du-travail-numerique/frontend:$CDTN_HASH

--- a/docker-compose.override.prod.yml
+++ b/docker-compose.override.prod.yml
@@ -1,18 +1,22 @@
 version: "3"
 
 services:
-  # In production, dockerize the frontend
+  # In production, use registry image
+  elasticsearch:
+    image: registry.gitlab.factory.social.gouv.fr/socialgouv/code-du-travail-numerique/elasticsearch:$CDTN_HASH
+    ports:
+      - 9200:920
+
   frontend:
-    image: socialgouv/code-du-travail-numerique-frontend:latest
+    image: registry.gitlab.factory.social.gouv.fr/socialgouv/code-du-travail-numerique/frontend:$CDTN_HASH
     restart: always
     env_file:
       - .env
     ports:
       - $FRONTEND_PORT:$FRONTEND_PORT
 
-  # In production, dockerize the API
   api:
-    image: socialgouv/code-du-travail-numerique-api:latest
+    image: registry.gitlab.factory.social.gouv.fr/socialgouv/code-du-travail-numerique/api:$CDTN_HASH
     restart: always
     env_file:
       - .env
@@ -28,5 +32,10 @@ services:
       - ./packages/code-du-travail-data/dataset/courrier-type/docx:/code-du-travail-data/dataset/courrier-type/docx
 
   nlp_api:
+    image: registry.gitlab.factory.social.gouv.fr/socialgouv/code-du-travail-numerique/nlp:$CDTN_HASH
+    restart: always
     environment:
       - FLASK_ENV=production
+
+  python:
+    image: registry.gitlab.factory.social.gouv.fr/socialgouv/code-du-travail-numerique/data:$CDTN_HASH

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@ version: "3"
 
 services:
   elasticsearch:
-    build:
-      context: ./docker/elasticsearch
     ulimits:
       memlock:
         soft: -1
@@ -17,9 +15,7 @@ services:
       - .env
     depends_on:
       - elasticsearch
-    build:
-      context: ./packages/code-du-travail-data
-      dockerfile: ./Dockerfile
+
 
   nlp_api:
     restart: always
@@ -27,9 +23,7 @@ services:
       - .env
     ports:
       - $NLP_PORT:$NLP_PORT
-    build:
-      context: ./packages/code-du-travail-nlp
-      dockerfile: ./Dockerfile
+
 
 volumes:
   esdata:


### PR DESCRIPTION
udpate docker-compose config to rely on gitlab registry for images
that way after update the docker-compose.override setting with docker-compose.override.prod.yml

we should deploy using `CDTN_HASH=0000000 docker-compose up --build` 

@douglasduteil @revolunet seems good ?