### PR TITLE
Update synonyms.json

### DIFF
--- a/packages/code-du-travail-data/dataset/synonyms/synonyms.json
+++ b/packages/code-du-travail-data/dataset/synonyms/synonyms.json
@@ -916,6 +916,7 @@
   "indemnité de transports, frais de transport => frais de transport",
   "indemnités de congés payés, icp => icp",
   "indemnités journalières de sécurité, ijss => ijss",
+  "indemnité de départ en retraite, indemnité de mise en retraite => allocation de fin de carrière",
   "indice biotique, igb => igb",
   "indice de poids corporel, poids corporel => poids corporel",
   "individualisation de la formation, formation individualisée => formation individualisée",


### PR DESCRIPTION
ajout de la proposition de nadia: "Hello. La CC 1483 prévoit une "allocation de fin de carrière" qui est versée en guise d'indemnité de départ en retraite et d'indemnité de mise à la retraite. J'ai tapé "allocation de fin de carrière" dans le CDTN, il ne donne pas les résultats en lien avec ces indemnités. Il faudrait les inclure dans les synonymes pour le moteur de recherche. "