### PR TITLE
Update cdtn_synonyms.json

### DIFF
--- a/packages/code-du-travail-data/dataset/synonyms/cdtn_synonyms.json
+++ b/packages/code-du-travail-data/dataset/synonyms/cdtn_synonyms.json
@@ -76,6 +76,8 @@
   "hôtellerie café et restauration, hcr",
   "indemnités de congés payés, icp",
   "indemnités journalières de sécurité, ijss",
+  "indemnité de départ en retraite, allocation de fin de carrière",
+  "indemnité de mise en retraite, allocation de fin de carrière", 
   "inspecteur du travail, it",
   "installation classée pour la protection de l'environnement, icpe",
   "institutions représentatives du personnel, irp",


### PR DESCRIPTION
ajouts indemnité départ et mise en retraite en synonyme d'allocation de fin de carrière,( dans le bon fichier cette fois)