### PR TITLE
fix(k8s): increase ES-dev probes delays

### DIFF
--- a/.k8s/elasticsearch/statefulset.dev.yml
+++ b/.k8s/elasticsearch/statefulset.dev.yml
@@ -56,14 +56,14 @@ spec:
             scheme: HTTP
             path: /_cluster/health
             port: ${PORT}
-          initialDelaySeconds: 5
+          initialDelaySeconds: 30
           periodSeconds: 5
         readinessProbe:
           httpGet:
             scheme: HTTP
             path: /_cluster/health?local=true
             port: ${PORT}
-          initialDelaySeconds: 5
+          initialDelaySeconds: 30
         ports:
         - containerPort: ${PORT}
           name: es-http


### PR DESCRIPTION
Looks like the ES pod is killed when not ready fast enough