### PR TITLE
fix(search): url encode params

### DIFF
--- a/packages/code-du-travail-frontend/pages/recherche.js
+++ b/packages/code-du-travail-frontend/pages/recherche.js
@@ -19,7 +19,9 @@ class SearchPage extends React.Component {
   static async getInitialProps({ query }) {
     const excludeSources = getExcludeSources(query.source);
     const response = await fetch(
-      `${API_URL}/search?q=${query.q}&excludeSources=${excludeSources}`
+      `${API_URL}/search?q=${encodeURIComponent(
+        query.q
+      )}&excludeSources=${encodeURIComponent(excludeSources)}`
     );
     if (!response.ok) {
       return { statusCode: response.status };


### PR DESCRIPTION
probleme visible here: http://master.code-du-travail-numerique.dev.factory.social.gouv.fr/recherche?q=salarri%C3%A9&source=