### PR TITLE
chore(k8s): udpate ES readynessProbe

### DIFF
--- a/.k8s/api/deployment.yml
+++ b/.k8s/api/deployment.yml
@@ -25,13 +25,13 @@ spec:
             httpGet:
               path: /api/v1/version
               port: ${PORT}
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
             periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /api/v1/version
               port: ${PORT}
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
             periodSeconds: 5
           env:
           - name: PORT

--- a/.k8s/api/deployment.yml
+++ b/.k8s/api/deployment.yml
@@ -36,11 +36,28 @@ spec:
           env:
           - name: PORT
             value: "${PORT}"
-          - name: ELASTICSEARCH_LOG_LEVEL
-            value: "${ELASTICSEARCH_LOG_LEVEL}"
           - name: ELASTICSEARCH_URL
             value: "${ELASTICSEARCH_URL}"
           - name: VERSION
             value: "${VERSION}"
           - name: NLP_URL
             value: "${NLP_API_URL}"
+      initContainers:
+        - name: wait-for-elasticsearch
+          image: alpine
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              apk --no-cache --update add curl;
+
+              retry=120; # 5s * (12 * 10) = 10min
+              while
+                ! curl -sS "${ELASTICSEARCH_URL}/_cat/indices/code_du_travail_numerique" &&
+                [[ $(( retry-- )) -gt 0 ]];
+              do echo "Waiting for Elasticsearch incides to go Green ($(( retry )))" ; sleep 5s ; done ;
+
+              [[ $(( retry )) -lt 1 ]] && exit 128;
+
+              echo Ready;

--- a/.k8s/api/deployment.yml
+++ b/.k8s/api/deployment.yml
@@ -25,13 +25,13 @@ spec:
             httpGet:
               path: /api/v1/version
               port: ${PORT}
-            initialDelaySeconds: 300
+            initialDelaySeconds: 5
             periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /api/v1/version
               port: ${PORT}
-            initialDelaySeconds: 300
+            initialDelaySeconds: 5
             periodSeconds: 5
           env:
           - name: PORT

--- a/.k8s/api/deployment.yml
+++ b/.k8s/api/deployment.yml
@@ -56,7 +56,7 @@ spec:
               while
                 ! curl -sS --fail "${ELASTICSEARCH_URL}/_cat/indices/code_du_travail_numerique" &&
                 [[ $(( retry-- )) -gt 0 ]];
-              do echo "Waiting for Elasticsearch incides to go Green ($(( retry )))" ; sleep 5s ; done ;
+              do echo "Waiting for Elasticsearch indices to go Green ($(( retry )))" ; sleep 5s ; done ;
 
               [[ $(( retry )) -lt 1 ]] && exit 128;
 

--- a/.k8s/api/deployment.yml
+++ b/.k8s/api/deployment.yml
@@ -54,7 +54,7 @@ spec:
 
               retry=120; # 5s * (12 * 10) = 10min
               while
-                ! curl -sS "${ELASTICSEARCH_URL}/_cat/indices/code_du_travail_numerique" &&
+                ! curl -sS --fail "${ELASTICSEARCH_URL}/_cat/indices/code_du_travail_numerique" &&
                 [[ $(( retry-- )) -gt 0 ]];
               do echo "Waiting for Elasticsearch incides to go Green ($(( retry )))" ; sleep 5s ; done ;
 

--- a/.k8s/elasticsearch/statefulset.dev.yml
+++ b/.k8s/elasticsearch/statefulset.dev.yml
@@ -61,7 +61,7 @@ spec:
         readinessProbe:
           httpGet:
             scheme: HTTP
-            path: /_cat/indices/code_du_travail_numerique
+            path: /_cluster/health
             port: ${PORT}
           initialDelaySeconds: 60
           periodSeconds: 5

--- a/.k8s/elasticsearch/statefulset.dev.yml
+++ b/.k8s/elasticsearch/statefulset.dev.yml
@@ -61,9 +61,10 @@ spec:
         readinessProbe:
           httpGet:
             scheme: HTTP
-            path: /_cluster/health?local=true
+            path: /_cat/indices/code_du_travail_numerique
             port: ${PORT}
           initialDelaySeconds: 60
+          periodSeconds: 5
         ports:
         - containerPort: ${PORT}
           name: es-http

--- a/.k8s/elasticsearch/statefulset.prod.yml
+++ b/.k8s/elasticsearch/statefulset.prod.yml
@@ -25,12 +25,26 @@ spec:
         emptyDir: {}
       containers:
       - name: elasticsearch
-        image: ${IMAGE_NAME}:${IMAGE_TAG}
         resources:
           limits:
             cpu: 1000m
           requests:
             cpu: 100m
+        image: ${IMAGE_NAME}:${IMAGE_TAG}
+        livenessProbe:
+          httpGet:
+            scheme: HTTP
+            path: /_cluster/health
+            port: ${PORT}
+          initialDelaySeconds: 60
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            scheme: HTTP
+            path: /_cluster/health
+            port: ${PORT}
+          initialDelaySeconds: 60
+          periodSeconds: 5
         ports:
         - containerPort: ${PORT}
           name: rest

--- a/.k8s/frontend/deployment.dev.yml
+++ b/.k8s/frontend/deployment.dev.yml
@@ -25,13 +25,13 @@ spec:
             httpGet:
               path: /
               port: ${PORT}
-            initialDelaySeconds: 3
+            initialDelaySeconds: 10
             periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /
               port: ${PORT}
-            initialDelaySeconds: 3
+            initialDelaySeconds: 10
             periodSeconds: 5
           env:
             - name: API_URL
@@ -61,6 +61,24 @@ spec:
               retry=120; # 5s * (12 * 10) = 10min
               while
                 ! curl -sS --fail "${API_URL}/api/v1/version" &&
+                [[ $(( retry-- )) -gt 0 ]];
+              do echo "Waiting for api to respond ($(( retry )))" ; sleep 5s ; done ;
+
+              [[ $(( retry )) -lt 1 ]] && exit 128;
+
+              echo Ready;
+        - name: wait-for-nlp
+          image: alpine
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              apk --no-cache --update add curl;
+
+              retry=120; # 5s * (12 * 10) = 10min
+              while
+                ! curl -sS --fail "${NLP_URL}" &&
                 [[ $(( retry-- )) -gt 0 ]];
               do echo "Waiting for api to respond ($(( retry )))" ; sleep 5s ; done ;
 

--- a/.k8s/frontend/deployment.dev.yml
+++ b/.k8s/frontend/deployment.dev.yml
@@ -60,9 +60,9 @@ spec:
 
               retry=120; # 5s * (12 * 10) = 10min
               while
-                ! curl -sS ${API_URL}/api/v1/version" &&
+                ! curl -sS "${API_URL}/api/v1/version" &&
                 [[ $(( retry-- )) -gt 0 ]];
-              do echo "Waiting for api to be available ($(( retry )))" ; sleep 5s ; done ;
+              do echo "Waiting for api to respond ($(( retry )))" ; sleep 5s ; done ;
 
               [[ $(( retry )) -lt 1 ]] && exit 128;
 

--- a/.k8s/frontend/deployment.dev.yml
+++ b/.k8s/frontend/deployment.dev.yml
@@ -48,3 +48,22 @@ spec:
               value: "${NLP_URL}/api/suggest"
             - name: VERSION
               value: "${VERSION}"
+      initContainers:
+        - name: wait-for-api
+          image: alpine
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              apk --no-cache --update add curl;
+
+              retry=120; # 5s * (12 * 10) = 10min
+              while
+                ! curl -sS ${API_URL}/api/v1/version" &&
+                [[ $(( retry-- )) -gt 0 ]];
+              do echo "Waiting for api to be available ($(( retry )))" ; sleep 5s ; done ;
+
+              [[ $(( retry )) -lt 1 ]] && exit 128;
+
+              echo Ready;

--- a/.k8s/frontend/deployment.dev.yml
+++ b/.k8s/frontend/deployment.dev.yml
@@ -60,7 +60,7 @@ spec:
 
               retry=120; # 5s * (12 * 10) = 10min
               while
-                ! curl -sS "${API_URL}/api/v1/version" &&
+                ! curl -sS --fail "${API_URL}/api/v1/version" &&
                 [[ $(( retry-- )) -gt 0 ]];
               do echo "Waiting for api to respond ($(( retry )))" ; sleep 5s ; done ;
 

--- a/.k8s/frontend/deployment.prod.yml
+++ b/.k8s/frontend/deployment.prod.yml
@@ -53,3 +53,22 @@ spec:
               value: "${NLP_URL}/api/suggest"
             - name: VERSION
               value: "${VERSION}"
+      initContainers:
+        - name: wait-for-api
+          image: alpine
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              apk --no-cache --update add curl;
+
+              retry=120; # 5s * (12 * 10) = 10min
+              while
+                ! curl -sS ${API_URL}/api/v1/version" &&
+                [[ $(( retry-- )) -gt 0 ]];
+              do echo "Waiting for api to be available ($(( retry )))" ; sleep 5s ; done ;
+
+              [[ $(( retry )) -lt 1 ]] && exit 128;
+
+              echo Ready;

--- a/.k8s/frontend/deployment.prod.yml
+++ b/.k8s/frontend/deployment.prod.yml
@@ -65,7 +65,7 @@ spec:
 
               retry=120; # 5s * (12 * 10) = 10min
               while
-                ! curl -sS ${API_URL}/api/v1/version" &&
+                ! curl -sS "${API_URL}/api/v1/version" &&
                 [[ $(( retry-- )) -gt 0 ]];
               do echo "Waiting for api to be available ($(( retry )))" ; sleep 5s ; done ;
 

--- a/.k8s/nlp/deployment.dev.yml
+++ b/.k8s/nlp/deployment.dev.yml
@@ -35,14 +35,14 @@ spec:
             httpGet:
               path: /
               port: ${PORT}
-            initialDelaySeconds: 500
+            initialDelaySeconds: 60
             periodSeconds: 5
           readinessProbe:
             failureThreshold: 5
             httpGet:
               path: /
               port: ${PORT}
-            initialDelaySeconds: 500
+            initialDelaySeconds: 60
             periodSeconds: 5
           env:
             - name: NLP_PORT

--- a/packages/code-du-travail-data/indexing/es_client.utils.js
+++ b/packages/code-du-travail-data/indexing/es_client.utils.js
@@ -14,7 +14,6 @@ async function createIndex({ client, indexName, mappings }) {
   try {
     await client.indices.create({
       index: indexName,
-      includeTypeName: false,
       body: {
         settings: {
           number_of_shards: 1,

--- a/packages/code-du-travail-data/indexing/index.js
+++ b/packages/code-du-travail-data/indexing/index.js
@@ -37,9 +37,8 @@ async function main() {
   const ts = Date.now();
 
   await version({ client });
-  // Indexing document data
-  // Indexing CCN data
 
+  // Indexing CCN data
   await createIndex({
     client,
     indexName: `${CDTN_CCN_NAME}-${ts}`,
@@ -53,6 +52,7 @@ async function main() {
     });
   }
 
+  // Indexing document data
   await createIndex({
     client,
     indexName: `${CDTN_INDEX_NAME}-${ts}`,
@@ -92,17 +92,23 @@ async function main() {
     documents: themes,
     size: 500
   });
-
-  await client.indices.putAlias(
-    `${ANNUAIRE_INDEX_NAME}-${ts}`,
-    ANNUAIRE_INDEX_NAME
-  );
-  await client.indices.putAlias(
-    `${THEMES_INDEX_NAME}-${ts}`,
-    THEMES_INDEX_NAME
-  );
-  await client.indices.putAlias(`${CDTN_CCN_NAME}-${ts}`, CDTN_CCN_NAME);
-  await client.indices.putAlias(`${CDTN_INDEX_NAME}-${ts}`, CDTN_INDEX_NAME);
+  // Creating alias
+  await client.indices.putAlias({
+    index: `${ANNUAIRE_INDEX_NAME}-${ts}`,
+    name: ANNUAIRE_INDEX_NAME
+  });
+  await client.indices.putAlias({
+    index: `${THEMES_INDEX_NAME}-${ts}`,
+    name: THEMES_INDEX_NAME
+  });
+  await client.indices.putAlias({
+    index: `${CDTN_CCN_NAME}-${ts}`,
+    name: CDTN_CCN_NAME
+  });
+  await client.indices.putAlias({
+    index: `${CDTN_INDEX_NAME}-${ts}`,
+    name: CDTN_INDEX_NAME
+  });
 }
 
 main();

--- a/packages/code-du-travail-data/indexing/index.js
+++ b/packages/code-du-travail-data/indexing/index.js
@@ -111,4 +111,9 @@ async function main() {
   });
 }
 
-main();
+try {
+  main();
+} catch (error) {
+  console.error(error);
+  process.exit(-1);
+}

--- a/packages/code-du-travail-data/indexing/index.js
+++ b/packages/code-du-travail-data/indexing/index.js
@@ -34,18 +34,20 @@ const client = new Client({
 });
 
 async function main() {
+  const ts = Date.now();
+
   await version({ client });
   // Indexing document data
   // Indexing CCN data
 
   await createIndex({
     client,
-    indexName: CDTN_CCN_NAME,
+    indexName: `${CDTN_CCN_NAME}-${ts}`,
     mappings: conventionCollectiveMapping
   });
   for (const documents of cdtnCcnGen(conventionList, 10000000)) {
     await indexDocumentsBatched({
-      indexName: CDTN_CCN_NAME,
+      indexName: `${CDTN_CCN_NAME}-${ts}`,
       client,
       documents
     });
@@ -53,12 +55,12 @@ async function main() {
 
   await createIndex({
     client,
-    indexName: CDTN_INDEX_NAME,
+    indexName: `${CDTN_INDEX_NAME}-${ts}`,
     mappings: documentMapping
   });
   for (const documents of cdtnDocumentsGen()) {
     await indexDocumentsBatched({
-      indexName: CDTN_INDEX_NAME,
+      indexName: `${CDTN_INDEX_NAME}-${ts}`,
       client,
       documents,
       size: 1000
@@ -68,12 +70,12 @@ async function main() {
   // Indexing Annuaire data
   await createIndex({
     client,
-    indexName: ANNUAIRE_INDEX_NAME,
+    indexName: `${ANNUAIRE_INDEX_NAME}-${ts}`,
     mappings: annuaireMapping
   });
   await indexDocumentsBatched({
     client,
-    indexName: ANNUAIRE_INDEX_NAME,
+    indexName: `${ANNUAIRE_INDEX_NAME}-${ts}`,
     documents: annuaire,
     size: 500
   });
@@ -81,15 +83,26 @@ async function main() {
   // Indexing Themes data
   await createIndex({
     client,
-    indexName: THEMES_INDEX_NAME,
+    indexName: `${THEMES_INDEX_NAME}-${ts}`,
     mappings: themesMapping
   });
   await indexDocumentsBatched({
     client,
-    indexName: THEMES_INDEX_NAME,
+    indexName: `${THEMES_INDEX_NAME}-${ts}`,
     documents: themes,
     size: 500
   });
+
+  await client.indices.putAlias(
+    `${ANNUAIRE_INDEX_NAME}-${ts}`,
+    ANNUAIRE_INDEX_NAME
+  );
+  await client.indices.putAlias(
+    `${THEMES_INDEX_NAME}-${ts}`,
+    THEMES_INDEX_NAME
+  );
+  await client.indices.putAlias(`${CDTN_CCN_NAME}-${ts}`, CDTN_CCN_NAME);
+  await client.indices.putAlias(`${CDTN_INDEX_NAME}-${ts}`, CDTN_INDEX_NAME);
 }
 
 main();


### PR DESCRIPTION
- Update readynessProbe for elasticsearch
- use alias mechanism after index 
- remove deprecated code  (`includeTypeName`)
- populate exit(-1) when indexing fails
