### PR TITLE
chore(CI): add ShellCheck linter

### DIFF
--- a/.gitlab-ci/stages/quality.yml
+++ b/.gitlab-ci/stages/quality.yml
@@ -48,6 +48,17 @@ Lint Dockerfiles:
         hadolint ${i}
       done
 
+Lint shell scripts:
+  <<: *quality_stage
+  image: koalaman/shellcheck-alpine:stable
+  script:
+    - |-
+      for i in $(find . -name "*.sh" | grep -v node_modules); do
+        echo ""
+        echo "[+] ShellCheck ${i}"
+        shellcheck ${i}
+      done
+
 Test @cdtn/frontend:
   <<: *quality_stage
   <<: *master_based_stage


### PR DESCRIPTION
Je mets ca en standby, il y a pas mal de fixes à prévoir

```sh

[+] ShellCheck ./.gitlab-ci/env.sh

In ./.gitlab-ci/env.sh line 15:
BRANCH_NAME_HASHED=$( printf "${BRANCH_NAME}" | sha1sum | cut -c1-${HASH_SIZE} )
                             ^--------------^ SC2059: Don't use variables in the printf format string. Use printf "..%s.." "$foo".


In ./.gitlab-ci/env.sh line 30:
  export BRANCH_HASH=$( printf "${COMMIT_TAG}" | sed "s/\./-/g" );
         ^---------^ SC2155: Declare and assign separately to avoid masking return values.
                               ^-------------^ SC2059: Don't use variables in the printf format string. Use printf "..%s.." "$foo".


In ./.gitlab-ci/env.sh line 45:
export ELASTICSEARCH_URL="http://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}";
                                                       ^-------------------^ SC2153: Possible misspelling: ELASTICSEARCH_PORT may not be assigned, but ELASTICSEARCH_HOST is.


In ./.gitlab-ci/env.sh line 49:
export NLP_API_URL="http://${NLP_API_HOST}:${NLP_PORT}"
                                           ^---------^ SC2153: Possible misspelling: NLP_PORT may not be assigned, but NLP_HOST is.

For more information:
  https://www.shellcheck.net/wiki/SC2153 -- Possible misspelling: ELASTICSEAR...
  https://www.shellcheck.net/wiki/SC2155 -- Declare and assign separately to ...
  https://www.shellcheck.net/wiki/SC2059 -- Don't use variables in the printf...

[+] ShellCheck ./.k8s/scripts/wait-elasticsearch.sh

In ./.k8s/scripts/wait-elasticsearch.sh line 4:
function index_should_exist() {
^-- SC2112: 'function' keyword is non-standard. Delete it.


In ./.k8s/scripts/wait-elasticsearch.sh line 10:
    ! curl -sS --fail "${URL}" && [[ $(( retry-- )) -gt 0 ]];
                                  ^------------------------^ SC2039: In POSIX sh, [[ ]] is undefined.
                                              ^-- SC2039: In POSIX sh, -- is undefined.


In ./.k8s/scripts/wait-elasticsearch.sh line 13:
  [[ $(( retry )) -lt 1 ]] && exit 128;
  ^----------------------^ SC2039: In POSIX sh, [[ ]] is undefined.

For more information:
  https://www.shellcheck.net/wiki/SC2039 -- In POSIX sh, -- is undefined.
  https://www.shellcheck.net/wiki/SC2112 -- 'function' keyword is non-standar...

[+] ShellCheck ./.k8s/scripts/send-url.sh

[+] ShellCheck ./.k8s/scripts/get-deploy-id.sh

In ./.k8s/scripts/get-deploy-id.sh line 56:
cat "${CACHE_RESPONSE}" \
    ^-----------------^ SC2002: Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.

For more information:
  https://www.shellcheck.net/wiki/SC2002 -- Useless cat. Consider 'cmd < file...

[+] ShellCheck ./.k8s/data/create-index.sh

[+] ShellCheck ./dockscan.sh

In ./dockscan.sh line 19:
  docker run --rm -v "$PWD:/mnt" koalaman/shellcheck:stable ${i}
                                                            ^--^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
  docker run --rm -v "$PWD:/mnt" koalaman/shellcheck:stable "${i}"

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

[+] ShellCheck ./backup.sh

[+] ShellCheck ./scripts/deploy-dev.sh

In ./scripts/deploy-dev.sh line 6:
git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
             ^-- SC2046: Quote this to prevent word splitting.
                                   ^-- SC2046: Quote this to prevent word splitting.

For more information:
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...

[+] ShellCheck ./scripts/update-data.sh

In ./scripts/update-data.sh line 9:
ROOT_DIR=$( cd $(dirname $0) ; pwd -P | xargs dirname )
            ^--------------^ SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
               ^-----------^ SC2046: Quote this to prevent word splitting.
                         ^-- SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
ROOT_DIR=$( cd $(dirname "$0") || exit ; pwd -P | xargs dirname )


In ./scripts/update-data.sh line 11:
cd $ROOT_DIR
^----------^ SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
   ^-------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
cd "$ROOT_DIR" || exit


In ./scripts/update-data.sh line 22:
cd packages/code-du-travail-data/dataset/fiches_service_public && yarn updateTheme && cd $ROOT_DIR
                                                                                      ^----------^ SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
                                                                                         ^-------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
cd packages/code-du-travail-data/dataset/fiches_service_public && yarn updateTheme && cd "$ROOT_DIR" || exit


In ./scripts/update-data.sh line 23:
cd packages/code-du-travail-data/dataset/fiches_ministere_travail && yarn updateTheme && cd $ROOT_DIR
                                                                                         ^----------^ SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
                                                                                            ^-------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
cd packages/code-du-travail-data/dataset/fiches_ministere_travail && yarn updateTheme && cd "$ROOT_DIR" || exit


In ./scripts/update-data.sh line 25:
cd packages/code-du-travail-data && yarn && yarn populate-dev && cd $ROOT_DIR
                                                                 ^----------^ SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
                                                                    ^-------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
cd packages/code-du-travail-data && yarn && yarn populate-dev && cd "$ROOT_DIR" || exit

For more information:
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2164 -- Use 'cd ... || exit' or 'cd ... |...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

[+] ShellCheck ./packages/code-du-travail-nlp/scripts/entrypoint.sh

In ./packages/code-du-travail-nlp/scripts/entrypoint.sh line 8:
gunicorn -t 3000 -k gevent -w 1 -b :${NLP_PORT} "api:create_app()" --log-level "debug" --log-file "-"
                                    ^---------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
gunicorn -t 3000 -k gevent -w 1 -b :"${NLP_PORT}" "api:create_app()" --log-level "debug" --log-file "-"

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

[+] ShellCheck ./packages/code-du-travail-nlp/scripts/download-suggester.sh

In ./packages/code-du-travail-nlp/scripts/download-suggester.sh line 5:
for file in $(curl -Ls $SUGGEST_DATA_URL); do
                       ^---------------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
for file in $(curl -Ls "$SUGGEST_DATA_URL"); do


In ./packages/code-du-travail-nlp/scripts/download-suggester.sh line 6:
  curl -L $file > data/data-$count.zip
          ^---^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
  curl -L "$file" > data/data-$count.zip

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```