### PR TITLE
fix(ci): use base_register_stage so we can use tags too

### DIFF
--- a/.gitlab-ci/stages/register.yml
+++ b/.gitlab-ci/stages/register.yml
@@ -1,17 +1,8 @@
 #
 
 .build_and_push_stage: &build_and_push_stage
-  extends: .base_docker_image_stage
+  extends: .base_register_stage
   stage: "Registration"
-  dependencies: []
-  before_script:
-    - echo "$CI_JOB_TOKEN" | docker login $CI_REGISTRY -u gitlab-ci-token --password-stdin
-  script:
-    - docker pull $IMAGE_NAME:$CI_COMMIT_BEFORE_SHA || true
-    - docker build $DOCKER_BUILD_ARGS --cache-from $IMAGE_NAME:$CI_COMMIT_BEFORE_SHA -t $IMAGE_NAME:$CI_COMMIT_SHA $CONTEXT
-    - docker push $IMAGE_NAME
-
-#
 
 Register api image:
   <<: *build_and_push_stage


### PR DESCRIPTION
ca docker push toujours le `CI_COMMIT_SHA`

si un tag est défini ca push le `CI_COMMIT_TAG` sans le `^v`

sinon ca push le `CI_COMMIT_REF_SLUG` aka "The branch or tag name for which project is built"