### PR TITLE
ci(release): update release/production job

### DIFF
--- a/.gitlab-ci/stages/deploy.yml
+++ b/.gitlab-ci/stages/deploy.yml
@@ -24,13 +24,17 @@ include:
   only:
     refs:
       - tags
+    variables:
+      - $PRODUCTION
 
 .dev_stage: &dev_stage
   environment:
     name: dev
-  only:
+  except:
     refs:
-      - branches
+      - tags
+    variables:
+      - $PRODUCTION
 
 #
 #

--- a/.gitlab-ci/stages/notify.yml
+++ b/.gitlab-ci/stages/notify.yml
@@ -44,3 +44,23 @@ Notify Success:
     - echo "Notify Success to GitHub deployment id '$(cat $DEPLOY_ID_FILE)'"
     - export URL="http://${FRONTEND_HOST}"
     - sh ./.k8s/scripts/send-url.sh $(cat $DEPLOY_ID_FILE) success
+
+Release:
+  stage: "Notify Finished Deployment"
+  image: node:10
+  only:
+    variables:
+      - $RELEASE
+  when: manual
+  variables:
+    GIT_COMMITTER_EMAIL: $CI_GIT_AUTHOR_EMAIL
+    GIT_COMMITTER_NAME: $CI_GIT_AUTHOR_NAME
+  before_script:
+    - git checkout ${CI_COMMIT_REF_NAME}
+    - git config user.name ${CI_GIT_AUTHOR_NAME}
+    - git config user.email ${CI_GIT_AUTHOR_EMAIL}
+    - git remote set-url origin https://${GITHUB_TOKEN}@github.com/${CI_PROJECT_PATH}.git
+  script:
+    - yarn --frozen-lockfile
+    - GH_TOKEN=${GITHUB_TOKEN} yarn lerna version ${LERNA_ARGS:="--yes"}
+

--- a/.gitlab-ci/stages/prepare.yml
+++ b/.gitlab-ci/stages/prepare.yml
@@ -4,7 +4,9 @@
   extends: .base_register_stage
   stage: "Prepare"
   dependencies: []
-
+  except:
+    variables:
+      - $PRODUCTION
 #
 
 Register socialgouv/cdtn base image:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,20 +58,14 @@ jobs:
       stage: Release
       if: env(RELEASE)
       name: Make a new release 🎉
-      git:
-        # NOTE(douglasduteil): disable git --depth
-        # Try to have all the commits for the release Change Log
-        # see travis-ci/travis-ci#3412
-        depth: 9999999 # Over 9000 !
       env:
         - *github_keys
-      before_script:
-        - git checkout ${TRAVIS_BRANCH}
-        - git config user.name "Social Groovy Bot"
-        - git config user.email "45039513+SocialGroovyBot@users.noreply.github.com"
-        - git remote set-url origin https://${GITHUB_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
-      script:
-        - GH_TOKEN=${GITHUB_TOKEN} yarn lerna version ${LERNA_ARGS:=--yes}
+      script: >-
+        curl -X POST
+        -F token=${GITLAB_TOKEN}
+        -F ref=${TRAVIS_BRANCH}
+        -F "variables[RELEASE]=true"
+        https://gitlab.factory.social.gouv.fr/api/v4/projects/51/trigger/pipeline
 
     - stage: Go Prod
       if: env(PRODUCTION)


### PR DESCRIPTION
- update travis release job from travis to trigger a pipeline on a branch with the RELEASE var
- add a Release Job in gitlab to make release
- update deploy job to put tag or branch with PRODUCTION variable

The purpose is to be able to 
- trigger a RELEASE from a branch using the "Run Pipeline" button
- trigger a deploy branch in PRODUCTION using the "Run Pipeline" button
