### PR TITLE
ci(pipeline): add release/deploy buttons

### DIFF
--- a/.gitlab-ci/env.sh
+++ b/.gitlab-ci/env.sh
@@ -5,7 +5,6 @@
 export BRANCH_NAME=${BRANCH_NAME:=$CI_COMMIT_REF_SLUG}
 export COMMIT_TAG=${COMMIT_TAG:=$CI_COMMIT_TAG}
 export COMMIT=${COMMIT:=$CI_COMMIT_SHA}
-export ENVIRONMENT=${ENVIRONMENT:="dev.factory"};
 export HASH_SIZE=${HASH_SIZE:=7}
 export JOB_ID=${JOB_ID:=$CI_JOB_ID}
 export PROJECT_PATH=${PROJECT_PATH:=$CI_PROJECT_PATH}
@@ -14,8 +13,6 @@ export VERSION=${VERSION:=$CI_COMMIT_REF_NAME}
 
 BRANCH_NAME_HASHED=$( printf "${BRANCH_NAME}" | sha1sum | cut -c1-${HASH_SIZE} )
 export BRANCH_HASH=${BRANCH_HASH:=$BRANCH_NAME_HASHED}
-
-export DOMAIN="code-du-travail-numerique.${ENVIRONMENT}.social.gouv.fr";
 
 #
 
@@ -32,8 +29,9 @@ fi
 
 if [[ -n "${PRODUCTION+x}" ]]; then
   export BRANCH_HASH=prod;
+  export DOMAIN="code-du-travail-numerique.incubateur.social.gouv.fr";
 else
-  export DOMAIN="${BRANCH_HASH}.${DOMAIN}";
+  export DOMAIN="${BRANCH_HASH}.code-du-travail-numerique.dev.factory.social.gouv.fr";
 fi
 
 
@@ -61,7 +59,7 @@ else
 fi
 
 printenv | grep -E \
-  "BRANCH_HASH|BRANCH_NAME|BRANCH_HASH_DOT|COMMIT|COMMIT_TAG|ENVIRONMENT|CLUSTER_NAME|HASH_SIZE|JOB_ID" \
+  "BRANCH_HASH|BRANCH_NAME|BRANCH_HASH_DOT|COMMIT|COMMIT_TAG|DOMAIN|CLUSTER_NAME|HASH_SIZE|JOB_ID" \
   | sort
 printenv | grep -E \
   "API_HOST|API_URL|ELASTICSEARCH_HOST|FRONTEND_HOST|FRONTEND_URL|NLP_HOST|NLP_URL" \

--- a/.gitlab-ci/extends.yml
+++ b/.gitlab-ci/extends.yml
@@ -3,11 +3,6 @@
   services:
     - docker:$DOCKER_VERSION-dind
 
-.base-docker-compose-image-stage:
-  image: docker/compose:$DOCKER_COMPOSE_VERSION
-  services:
-    - docker:$DOCKER_VERSION-dind
-
 #
 
 .base_docker_kube_image_stage:

--- a/.gitlab-ci/stages/deploy.yml
+++ b/.gitlab-ci/stages/deploy.yml
@@ -23,18 +23,19 @@ include:
     name: incubateur
   only:
     refs:
-      - tags
+      - triggers
     variables:
       - $PRODUCTION
+
+#
 
 .dev_stage: &dev_stage
   environment:
     name: dev
-  except:
+  only:
     refs:
       - tags
-    variables:
-      - $PRODUCTION
+      - branches
 
 #
 #

--- a/.gitlab-ci/stages/notify.yml
+++ b/.gitlab-ci/stages/notify.yml
@@ -75,7 +75,6 @@ Release:
 Production:
   <<: *notify_stage
   stage: "Notify Finished Deployment"
-  image: $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
   when: manual
   only:
     - tags

--- a/.gitlab-ci/stages/notify.yml
+++ b/.gitlab-ci/stages/notify.yml
@@ -34,6 +34,8 @@ Notify Fail:
     - export URL="http://${FRONTEND_HOST}"
     - sh ./.k8s/scripts/send-url.sh $(cat $DEPLOY_ID_FILE) failure
 
+#
+
 Notify Success:
   <<: *notify_stage
   stage: "Notify Finished Deployment"
@@ -45,12 +47,15 @@ Notify Success:
     - export URL="http://${FRONTEND_HOST}"
     - sh ./.k8s/scripts/send-url.sh $(cat $DEPLOY_ID_FILE) success
 
+#
+#
+#
+
 Release:
   stage: "Notify Finished Deployment"
-  image: node:10
+  image: $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
   only:
-    variables:
-      - $RELEASE
+    - master
   when: manual
   variables:
     GIT_COMMITTER_EMAIL: $CI_GIT_AUTHOR_EMAIL
@@ -61,6 +66,26 @@ Release:
     - git config user.email ${CI_GIT_AUTHOR_EMAIL}
     - git remote set-url origin https://${GITHUB_TOKEN}@github.com/${CI_PROJECT_PATH}.git
   script:
-    - yarn --frozen-lockfile
     - GH_TOKEN=${GITHUB_TOKEN} yarn lerna version ${LERNA_ARGS:="--force-publish --yes"}
 
+#
+#
+#
+
+Production:
+  <<: *notify_stage
+  stage: "Notify Finished Deployment"
+  image: $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
+  when: manual
+  only:
+    - tags
+  except:
+    variables:
+      - $PRODUCTION
+  script:
+    - echo "Put ${CI_COMMIT_REF_NAME}@${CI_COMMIT_SHORT_SHA} in production"
+    - curl --request POST
+        --form ref="${CI_COMMIT_REF_NAME}"
+        --form token="${CI_DEPLOY_TRIGGER}"
+        --form variables[PRODUCTION]="true"
+        https://gitlab.factory.social.gouv.fr/api/v4/projects/51/trigger/pipeline

--- a/.gitlab-ci/stages/prepare.yml
+++ b/.gitlab-ci/stages/prepare.yml
@@ -4,16 +4,52 @@
   extends: .base_register_stage
   stage: "Prepare"
   dependencies: []
-  except:
-    variables:
-      - $PRODUCTION
+
 #
 
-Register socialgouv/cdtn base image:
+Register new socialgouv/cdtn base image:
   <<: *prepare_stage
   variables:
     CONTEXT: .
     IMAGE_NAME: $CI_REGISTRY_IMAGE
+  only:
+    changes:
+      - yarn.lock
+      - package.lock
+      - packages/**/package.lock
+  except:
+    variables:
+      - $PRODUCTION
+
+
+Register previous socialgouv/cdtn base image:
+  <<: *prepare_stage
+  variables:
+    CONTEXT: .
+    IMAGE_NAME: $CI_REGISTRY_IMAGE
+  except:
+    changes:
+      - yarn.lock
+      - package.lock
+      - packages/**/package.lock
+    variables:
+      - $PRODUCTION
+  script:
+    - >
+      if [[ -n "${CI_COMMIT_TAG}" ]]; then
+        export TAG=$(printf "${CI_COMMIT_TAG}" | sed "s/^v//")
+      else
+        export TAG=$CI_COMMIT_REF_SLUG
+      fi
+    #
+    - docker pull $IMAGE_NAME:master || true
+    - echo "> docker tag ${IMAGE_NAME}:master ${IMAGE_NAME}:${TAG}"
+    - docker tag $IMAGE_NAME:master $IMAGE_NAME:$CI_COMMIT_SHA
+    - echo "> docker tag ${IMAGE_NAME}:master ${IMAGE_NAME}:${CI_COMMIT_SHA}"
+    - docker tag $IMAGE_NAME:master $IMAGE_NAME:$TAG
+    - docker push $IMAGE_NAME:$CI_COMMIT_SHA
+    - docker push $IMAGE_NAME:$TAG
+#
 
 Register elasticsearch image:
   <<: *prepare_stage

--- a/.gitlab-ci/stages/prepare.yml
+++ b/.gitlab-ci/stages/prepare.yml
@@ -17,6 +17,7 @@ Register new socialgouv/cdtn base image:
       - yarn.lock
       - package.lock
       - packages/**/package.lock
+      - packages/code-du-travail-data/**/*.js
   except:
     variables:
       - $PRODUCTION
@@ -32,6 +33,7 @@ Register previous socialgouv/cdtn base image:
       - yarn.lock
       - package.lock
       - packages/**/package.lock
+      - packages/code-du-travail-data/**/*.js
     variables:
       - $PRODUCTION
   script:

--- a/.gitlab-ci/stages/quality.yml
+++ b/.gitlab-ci/stages/quality.yml
@@ -3,6 +3,9 @@
 .quality_stage: &quality_stage
   stage: "Code Quality"
   dependencies: []
+  except:
+    variables:
+      - $PRODUCTION
 
 .master_based_stage: &master_based_stage
   variables:

--- a/.gitlab-ci/stages/register.yml
+++ b/.gitlab-ci/stages/register.yml
@@ -3,6 +3,9 @@
 .build_and_push_stage: &build_and_push_stage
   extends: .base_register_stage
   stage: "Registration"
+  except:
+    variables:
+      - $PRODUCTION
 
 Register api image:
   <<: *build_and_push_stage

--- a/.k8s/scripts/get-deploy-id.sh
+++ b/.k8s/scripts/get-deploy-id.sh
@@ -20,6 +20,8 @@ fi
 if [[ -n "${PRODUCTION+x}" ]]; then
   ENVIRONMENT=production
   PRODUCTION_ENVIRONMENT=true
+else
+  ENVIRONMENT=development
 fi
 
 curl -0 -sS \

--- a/.k8s/scripts/send-url.sh
+++ b/.k8s/scripts/send-url.sh
@@ -10,6 +10,8 @@ PROJECT_PATH=${PROJECT_PATH:=$CI_PROJECT_PATH}
 
 if [[ -n "${PRODUCTION+x}" ]]; then
   ENVIRONMENT=production
+else
+  ENVIRONMENT=development
 fi
 
 if [[ -z ${DEPLOY_ID} ]] || ! [[ ${STATE} = "success" || ${STATE} = "failure" ]]; then


### PR DESCRIPTION
this PR 
- replace `ENVIRONMENT` by `DOMAIN`
- add deploy button in pipeline that will run trigger with production=true
- reuse master's monorepo image if there no `package.json` update 
- reuse monorepo image when release a version
- skip stages prepare, quality, register when deploy in production, 