### PR TITLE
fix(indexing): better error message

### DIFF
--- a/packages/code-du-travail-data/indexing/index.js
+++ b/packages/code-du-travail-data/indexing/index.js
@@ -100,7 +100,7 @@ async function main() {
 
 main().catch(response => {
   if (response.body) {
-    logger.error(response.body.error);
+    logger.error(response.body.error.reason);
   } else {
     logger.error(response);
   }


### PR DESCRIPTION
if not we get `[Object object]`