### PR TITLE
refactor(ui): fix forward ref issue with next link

### DIFF
--- a/packages/react-ui/src/Tile/index.js
+++ b/packages/react-ui/src/Tile/index.js
@@ -50,7 +50,7 @@ export const Tile = React.forwardRef(
       as={props.href ? "a" : "button"}
       href={props.href}
       ref={ref}
-      title={props.title}
+      {...props}
     >
       {Icon && (
         <IconWrapper>

--- a/packages/react-ui/src/Tile/index.js
+++ b/packages/react-ui/src/Tile/index.js
@@ -44,26 +44,36 @@ const ButtonWrapper = styled.div`
   margin-top: ${spacing.medium};
 `;
 
-export const Tile = ({ button, children, icon: Icon, ...props }) => (
-  <StyledTile as={props.href ? "a" : "button"} {...props}>
-    {Icon && (
-      <IconWrapper>
-        <Icon />
-      </IconWrapper>
-    )}
-    <OverflowWrapper>{children}</OverflowWrapper>
-    {button && (
-      <ButtonWrapper>
-        <Button noButton>{button}</Button>
-      </ButtonWrapper>
-    )}
-  </StyledTile>
+export const Tile = React.forwardRef(
+  ({ button, children, icon: Icon, ...props }, ref) => (
+    <StyledTile
+      as={props.href ? "a" : "button"}
+      href={props.href}
+      ref={ref}
+      title={props.title}
+    >
+      {Icon && (
+        <IconWrapper>
+          <Icon />
+        </IconWrapper>
+      )}
+      <OverflowWrapper>{children}</OverflowWrapper>
+      {button && (
+        <ButtonWrapper>
+          <Button noButton>{button}</Button>
+        </ButtonWrapper>
+      )}
+    </StyledTile>
+  )
 );
+
+Tile.displayName = "Tile";
 
 Tile.propTypes = {
   children: PropTypes.node.isRequired,
   icon: PropTypes.elementType,
   href: PropTypes.string,
+  title: PropTypes.string,
   button: PropTypes.string
 };
 

--- a/packages/react-ui/src/Tile/index.js
+++ b/packages/react-ui/src/Tile/index.js
@@ -46,12 +46,7 @@ const ButtonWrapper = styled.div`
 
 export const Tile = React.forwardRef(
   ({ button, children, icon: Icon, ...props }, ref) => (
-    <StyledTile
-      as={props.href ? "a" : "button"}
-      href={props.href}
-      ref={ref}
-      {...props}
-    >
+    <StyledTile as={props.href ? "a" : "button"} ref={ref} {...props}>
       {Icon && (
         <IconWrapper>
           <Icon />


### PR DESCRIPTION
Fix warning because of next `Link`not wanting functional component without a forward ref