### PR TITLE
fix(ci): force ENVIRONMENT=production in frontend fix #1493

### DIFF
--- a/.k8s/frontend/deployment.prod.yml
+++ b/.k8s/frontend/deployment.prod.yml
@@ -37,7 +37,7 @@ spec:
             - name: API_URL
               value: "${API_URL}/api/v1"
             - name: ENVIRONMENT
-              value: ${ENVIRONMENT}
+              value: production
             - name: FRONTEND_HOST
               value: ${FRONTEND_HOST}
             - name: PIWIK_SITE_ID


### PR DESCRIPTION
make sure ENVIRONMENT=production in frontend production deployments.

for https://github.com/SocialGouv/code-du-travail-numerique/blob/d9b6ee0a483c6b563432c2df9f8a347f9347fbd5/packages/code-du-travail-frontend/server/server.js#L10


fix  #1493