### PR TITLE
chore: more error reporting

### DIFF
--- a/packages/code-du-travail-data/indexing/index.js
+++ b/packages/code-du-travail-data/indexing/index.js
@@ -130,7 +130,9 @@ async function main() {
 
 main().catch(response => {
   if (response.body) {
-    logger.error(response.body.error.reason || response.body);
+    logger.error(
+      (response.body.error && response.body.error.reason) || response.body
+    );
   } else {
     logger.error(`${response}`);
   }

--- a/packages/code-du-travail-data/indexing/index.js
+++ b/packages/code-du-travail-data/indexing/index.js
@@ -130,9 +130,9 @@ async function main() {
 
 main().catch(response => {
   if (response.body) {
-    logger.error(response.body.error.reason);
+    logger.error(response.body.error.reason || response.body);
   } else {
-    logger.error(response);
+    logger.error(`${response}`);
   }
   process.exit(-1);
 });


### PR DESCRIPTION
better errors in indexing. `logger.error` only accept strings