### PR TITLE
feat(contributions): link to legifrance and rm button

### DIFF
--- a/packages/code-du-travail-frontend/src/contributions/Contribution.js
+++ b/packages/code-du-travail-frontend/src/contributions/Contribution.js
@@ -1,9 +1,7 @@
 import React from "react";
-import Link from "next/link";
 import styled from "styled-components";
 import createPersistedState from "use-persisted-state";
 
-import slugify from "@cdt/data/slugify";
 import { Accordion, Alert, Button, theme } from "@socialgouv/react-ui";
 
 import SearchConvention from "../../src/conventions/Search/Form";
@@ -11,6 +9,10 @@ import Mdx from "../../src/common/Mdx";
 
 // store selected convention in localStorage
 const useConventionState = createPersistedState("convention");
+
+const getConventionUrl = id =>
+  `https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=${id}`;
+// `https://beta.legifrance.gouv.fr/conv_coll/id/${id}/`;
 
 // hack: todo: remove
 // will be fixed at source level
@@ -53,24 +55,6 @@ const components = {
   section: AnswerSection
 };
 
-// following data/populate.js slug rules
-const getConventionSlug = ({ num, title }) =>
-  slugify(`${num}-${title}`.substring(0, 80));
-
-const LinkConvention = ({ num, title }) => {
-  const slugConvention = getConventionSlug({ num, title });
-  return (
-    <Link
-      href="/convention-collective/[slug]"
-      as={`/convention-collective/${slugConvention}`}
-    >
-      <ButtonConvention variant="secondary">
-        Consulter la convention collective
-      </ButtonConvention>
-    </Link>
-  );
-};
-
 const RefLink = ({ value, url }) => (
   <LineRef>
     <a href={url} target="_blank" rel="noopener noreferrer">
@@ -98,7 +82,7 @@ const References = ({ references }) => {
                 <RefLink
                   key={ref.id}
                   value={ref.value}
-                  url={ref.agreement.url}
+                  url={getConventionUrl(ref.agreement.id)}
                 />
               ))}
             </React.Fragment>
@@ -135,10 +119,16 @@ const AnswersConventions = ({ answers }) => {
             <span role="img" aria-label="Icone convention collective">
               📖
             </span>{" "}
-            {ccInfo.title}
-            {ccInfo.num && (
-              <React.Fragment> (IDCC {ccInfo.num})</React.Fragment>
-            )}
+            <a
+              href={getConventionUrl(ccInfo.id)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {ccInfo.title}
+              {ccInfo.num && (
+                <React.Fragment> (IDCC {ccInfo.num})</React.Fragment>
+              )}
+            </a>
           </h6>
           {(answer && (
             <React.Fragment>
@@ -148,7 +138,6 @@ const AnswersConventions = ({ answers }) => {
               />
 
               <References references={answer.references} />
-              <LinkConvention num={ccInfo.num} title={ccInfo.title} />
             </React.Fragment>
           )) || (
             <React.Fragment>
@@ -156,7 +145,6 @@ const AnswersConventions = ({ answers }) => {
                 Désolé nous n&apos;avons pas de réponse pour cette convention
                 collective
               </NoConventionAlert>
-              <LinkConvention num={ccInfo.num} title={ccInfo.title} />
             </React.Fragment>
           )}
           <br />
@@ -192,10 +180,6 @@ const Contribution = ({ answers }) => (
 );
 
 const { box, spacing } = theme;
-
-const ButtonConvention = styled(Button)`
-  margin: ${spacing.medium} 0;
-`;
 
 const LineRef = styled.li`
   margin: 5px 0;

--- a/packages/code-du-travail-frontend/src/contributions/__tests__/Contribution.test.js
+++ b/packages/code-du-travail-frontend/src/contributions/__tests__/Contribution.test.js
@@ -54,7 +54,8 @@ describe("<Contribution />", () => {
   it("should render preselected convention", () => {
     mockPreselectedConvention = {
       title: "preselected convention",
-      num: "idcc-preselected"
+      num: "idcc-preselected",
+      id: 123
     };
     const answers = {
       generic: { markdown: "hello **generic**" },
@@ -74,7 +75,8 @@ describe("<Contribution />", () => {
   it("should NOT render invalid preselected convention", () => {
     mockPreselectedConvention = {
       title: "unknown convention",
-      num: "idcc-unknown"
+      num: "idcc-unknown",
+      id: 456
     };
     const answers = {
       generic: { markdown: "hello **generic**" },
@@ -94,7 +96,8 @@ describe("<Contribution />", () => {
   it("should render answer references", () => {
     mockPreselectedConvention = {
       title: "preselected convention",
-      num: "idcc-preselected"
+      num: "idcc-preselected",
+      id: 123
     };
     const answers = {
       generic: { markdown: "hello **generic**" },
@@ -113,6 +116,7 @@ describe("<Contribution />", () => {
               id: 422,
               value: "reference CC 1",
               agreement: {
+                id: 123,
                 url: "http://path/to/agreement"
               }
             }

--- a/packages/code-du-travail-frontend/src/contributions/__tests__/__snapshots__/Contribution.test.js.snap
+++ b/packages/code-du-travail-frontend/src/contributions/__tests__/__snapshots__/Contribution.test.js.snap
@@ -17,60 +17,22 @@ exports[`<Contribution /> should NOT render invalid preselected convention 1`] =
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  color: #0c0c0e;
-  background: #ebeff3;
-  border-color: #ebeff3;
-}
-
-.c2:not([disabled]):hover,
-.c2:not([disabled]):active,
-.c2:not([disabled]):focus {
-  color: #18181c;
-  background: #fbfcfd;
-  border-color: #dbe2e9;
-}
-
-.c2[disabled] {
-  color: rgba(12,12,14,0.4);
-  cursor: not-allowed;
-}
-
-.c4 {
-  display: inline-block;
-  padding: 0.625rem 1.5rem;
-  font-weight: 600;
-  font-size: 1rem;
-  line-height: inherit;
-  text-align: center;
-  vertical-align: middle;
-  border: 1px solid;
-  border-radius: 1.5rem;
-  cursor: pointer;
-  -webkit-transition: background-color 250ms ease;
-  transition: background-color 250ms ease;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
   color: #fff;
   background: #005994;
   border-color: #005994;
 }
 
-.c4:not([disabled]):hover,
-.c4:not([disabled]):active,
-.c4:not([disabled]):focus {
+.c2:not([disabled]):hover,
+.c2:not([disabled]):active,
+.c2:not([disabled]):focus {
   color: #fff;
   background: #0068ae;
   border-color: #004a7b;
 }
 
-.c4[disabled] {
+.c2[disabled] {
   color: rgba(255,255,255,0.4);
   cursor: not-allowed;
-}
-
-.c3 {
-  margin: 1.25rem 0;
 }
 
 .c1 {
@@ -128,25 +90,26 @@ exports[`<Contribution /> should NOT render invalid preselected convention 1`] =
           📖
         </span>
          
-        unknown convention
-         (IDCC 
-        idcc-unknown
-        )
+        <a
+          href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=456"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          unknown convention
+           (IDCC 
+          idcc-unknown
+          )
+        </a>
       </h6>
       <div
         class="c1"
       >
         Désolé nous n'avons pas de réponse pour cette convention collective
       </div>
-      <button
-        class="c2 c3"
-      >
-        Consulter la convention collective
-      </button>
       <br />
       <br />
       <button
-        class="c4"
+        class="c2"
       >
         Changer de convention collective
       </button>
@@ -172,60 +135,22 @@ exports[`<Contribution /> should render answer references 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  color: #0c0c0e;
-  background: #ebeff3;
-  border-color: #ebeff3;
-}
-
-.c2:not([disabled]):hover,
-.c2:not([disabled]):active,
-.c2:not([disabled]):focus {
-  color: #18181c;
-  background: #fbfcfd;
-  border-color: #dbe2e9;
-}
-
-.c2[disabled] {
-  color: rgba(12,12,14,0.4);
-  cursor: not-allowed;
-}
-
-.c4 {
-  display: inline-block;
-  padding: 0.625rem 1.5rem;
-  font-weight: 600;
-  font-size: 1rem;
-  line-height: inherit;
-  text-align: center;
-  vertical-align: middle;
-  border: 1px solid;
-  border-radius: 1.5rem;
-  cursor: pointer;
-  -webkit-transition: background-color 250ms ease;
-  transition: background-color 250ms ease;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
   color: #fff;
   background: #005994;
   border-color: #005994;
 }
 
-.c4:not([disabled]):hover,
-.c4:not([disabled]):active,
-.c4:not([disabled]):focus {
+.c2:not([disabled]):hover,
+.c2:not([disabled]):active,
+.c2:not([disabled]):focus {
   color: #fff;
   background: #0068ae;
   border-color: #004a7b;
 }
 
-.c4[disabled] {
+.c2[disabled] {
   color: rgba(255,255,255,0.4);
   cursor: not-allowed;
-}
-
-.c3 {
-  margin: 1.25rem 0;
 }
 
 .c1 {
@@ -269,10 +194,16 @@ exports[`<Contribution /> should render answer references 1`] = `
           📖
         </span>
          
-        preselected convention
-         (IDCC 
-        idcc-preselected
-        )
+        <a
+          href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=123"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          preselected convention
+           (IDCC 
+          idcc-preselected
+          )
+        </a>
       </h6>
       <div>
         <p>
@@ -292,7 +223,7 @@ exports[`<Contribution /> should render answer references 1`] = `
         class="c1"
       >
         <a
-          href="http://path/to/agreement"
+          href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=123"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -313,15 +244,10 @@ exports[`<Contribution /> should render answer references 1`] = `
           reference externe 1
         </a>
       </li>
-      <button
-        class="c2 c3"
-      >
-        Consulter la convention collective
-      </button>
       <br />
       <br />
       <button
-        class="c4"
+        class="c2"
       >
         Changer de convention collective
       </button>
@@ -347,60 +273,22 @@ exports[`<Contribution /> should render preselected convention 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  color: #0c0c0e;
-  background: #ebeff3;
-  border-color: #ebeff3;
-}
-
-.c1:not([disabled]):hover,
-.c1:not([disabled]):active,
-.c1:not([disabled]):focus {
-  color: #18181c;
-  background: #fbfcfd;
-  border-color: #dbe2e9;
-}
-
-.c1[disabled] {
-  color: rgba(12,12,14,0.4);
-  cursor: not-allowed;
-}
-
-.c3 {
-  display: inline-block;
-  padding: 0.625rem 1.5rem;
-  font-weight: 600;
-  font-size: 1rem;
-  line-height: inherit;
-  text-align: center;
-  vertical-align: middle;
-  border: 1px solid;
-  border-radius: 1.5rem;
-  cursor: pointer;
-  -webkit-transition: background-color 250ms ease;
-  transition: background-color 250ms ease;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
   color: #fff;
   background: #005994;
   border-color: #005994;
 }
 
-.c3:not([disabled]):hover,
-.c3:not([disabled]):active,
-.c3:not([disabled]):focus {
+.c1:not([disabled]):hover,
+.c1:not([disabled]):active,
+.c1:not([disabled]):focus {
   color: #fff;
   background: #0068ae;
   border-color: #004a7b;
 }
 
-.c3[disabled] {
+.c1[disabled] {
   color: rgba(255,255,255,0.4);
   cursor: not-allowed;
-}
-
-.c2 {
-  margin: 1.25rem 0;
 }
 
 .c0 {
@@ -439,10 +327,16 @@ exports[`<Contribution /> should render preselected convention 1`] = `
           📖
         </span>
          
-        preselected convention
-         (IDCC 
-        idcc-preselected
-        )
+        <a
+          href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=123"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          preselected convention
+           (IDCC 
+          idcc-preselected
+          )
+        </a>
       </h6>
       <div>
         <p>
@@ -452,15 +346,10 @@ exports[`<Contribution /> should render preselected convention 1`] = `
           </strong>
         </p>
       </div>
-      <button
-        class="c1 c2"
-      >
-        Consulter la convention collective
-      </button>
       <br />
       <br />
       <button
-        class="c3"
+        class="c1"
       >
         Changer de convention collective
       </button>


### PR DESCRIPTION
au lieu d'afficher un bouton CCN, mets un lien vers legifrance sur le nom de la convention

je propose qu'on utilise le lien vers la beta ou il y a la recherche etc... ex : https://beta.legifrance.gouv.fr/conv_coll/id/KALICONT000005635480

---

<img width="726" alt="Capture d’écran 2019-11-07 à 18 10 35" src="https://user-images.githubusercontent.com/124937/68411071-19e87200-018a-11ea-9bbe-12a98acb0150.png">
