### PR TITLE
feat(matomo): add suggestionCandidate and resultsCandidate in matomo

### DIFF
--- a/packages/code-du-travail-frontend/__mocks__/next/router.js
+++ b/packages/code-du-travail-frontend/__mocks__/next/router.js
@@ -1,25 +1,28 @@
+const route = jest.fn();
+const router = {
+  asPath: "mock",
+  route,
+  pathname: "mock",
+  query: { q: undefined },
+  push: jest.fn(path => {
+    route(path);
+    return Promise.resolve();
+  })
+};
+
 module.exports = {
+  router,
+  mocked: true,
   events: {
     on() {},
     off() {},
     trigger() {}
   },
-  useRouter: () => ({
-    asPath: "mock",
-    route: "mock",
-    pathname: "mock",
-    query: {}
-  }),
-  push: jest.fn(),
+  useRouter: () => router,
   withRouter: component => {
     component.defaultProps = {
       ...component.defaultProps,
-      router: {
-        asPath: "mock",
-        route: "mock",
-        pathname: "mock",
-        query: {}
-      }
+      router
     };
     return component;
   }

--- a/packages/code-du-travail-frontend/__tests__/recherche.test.js
+++ b/packages/code-du-travail-frontend/__tests__/recherche.test.js
@@ -2,6 +2,10 @@ import React from "react";
 import { render } from "@testing-library/react";
 import Recherche from "../pages/recherche.js";
 
+jest.mock("../src/piwik", () => ({
+  matopush: jest.fn()
+}));
+
 describe("<Recherche />", () => {
   it("should render", () => {
     const { container } = render(<Recherche />);

--- a/packages/code-du-travail-frontend/src/__tests__/piwik.test.js
+++ b/packages/code-du-travail-frontend/src/__tests__/piwik.test.js
@@ -12,52 +12,18 @@ describe("initPiwik", () => {
     expect(global._paq).toMatchInlineSnapshot(`
       Array [
         Array [
-          "setSiteId",
-          "42",
-        ],
-        Array [
-          "setTrackerUrl",
-          "YO/piwik.php",
+          "trackPageView",
         ],
         Array [
           "enableLinkTracking",
         ],
         Array [
-          "setCustomUrl",
-          "/",
+          "setTrackerUrl",
+          "YO/matomo.php",
         ],
-        Array [
-          "trackPageView",
-        ],
-      ]
-    `);
-  });
-  it("should set campaign if there is a campaign urlparam", () => {
-    fakeLocation("https://code.travail.gouv.fr/?utm_campaign=fire");
-    initPiwik({ siteId: "42", piwikUrl: "YO" });
-    expect(global._paq).toMatchInlineSnapshot(`
-      Array [
         Array [
           "setSiteId",
           "42",
-        ],
-        Array [
-          "setTrackerUrl",
-          "YO/piwik.php",
-        ],
-        Array [
-          "enableLinkTracking",
-        ],
-        Array [
-          "setCampaignNameKey",
-          "fire",
-        ],
-        Array [
-          "setCustomUrl",
-          "/",
-        ],
-        Array [
-          "trackPageView",
         ],
       ]
     `);
@@ -77,20 +43,3 @@ describe("matopush", () => {
     `);
   });
 });
-
-function fakeLocation(url) {
-  const a = document.createElement("a");
-  a.setAttribute("href", url);
-  const { host, hostname, href, origin, pathname, port, search, protocol } = a;
-  delete window.location;
-  global.location = {
-    host,
-    hostname,
-    href,
-    origin,
-    pathname,
-    protocol,
-    port,
-    search
-  };
-}

--- a/packages/code-du-travail-frontend/src/__tests__/piwik.test.js
+++ b/packages/code-du-travail-frontend/src/__tests__/piwik.test.js
@@ -1,33 +1,66 @@
 import { initPiwik, matopush } from "../piwik";
 
 describe("initPiwik", () => {
+  beforeEach(() => {
+    global._paq = [];
+  });
   it("should create a js tag", () => {
     // we need to add a fake script node so
     // initPiwik can insert piwik tracker code before it
     document.head.appendChild(document.createElement("script"));
     initPiwik({ siteId: "42", piwikUrl: "YO" });
-    expect(window._paq).toMatchInlineSnapshot(`
-Array [
-  Array [
-    "setSiteId",
-    "42",
-  ],
-  Array [
-    "setTrackerUrl",
-    "YO/piwik.php",
-  ],
-  Array [
-    "enableLinkTracking",
-  ],
-  Array [
-    "setCustomUrl",
-    "/",
-  ],
-  Array [
-    "trackPageView",
-  ],
-]
-`);
+    expect(global._paq).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "setSiteId",
+          "42",
+        ],
+        Array [
+          "setTrackerUrl",
+          "YO/piwik.php",
+        ],
+        Array [
+          "enableLinkTracking",
+        ],
+        Array [
+          "setCustomUrl",
+          "/",
+        ],
+        Array [
+          "trackPageView",
+        ],
+      ]
+    `);
+  });
+  it("should set campaign if there is a campaign urlparam", () => {
+    fakeLocation("https://code.travail.gouv.fr/?utm_campaign=fire");
+    initPiwik({ siteId: "42", piwikUrl: "YO" });
+    expect(global._paq).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "setSiteId",
+          "42",
+        ],
+        Array [
+          "setTrackerUrl",
+          "YO/piwik.php",
+        ],
+        Array [
+          "enableLinkTracking",
+        ],
+        Array [
+          "setCampaignNameKey",
+          "fire",
+        ],
+        Array [
+          "setCustomUrl",
+          "/",
+        ],
+        Array [
+          "trackPageView",
+        ],
+      ]
+    `);
   });
 });
 
@@ -36,11 +69,28 @@ describe("matopush", () => {
     window._paq = [];
     matopush(["test"]);
     expect(window._paq).toMatchInlineSnapshot(`
-Array [
-  Array [
-    "test",
-  ],
-]
-`);
+      Array [
+        Array [
+          "test",
+        ],
+      ]
+    `);
   });
 });
+
+function fakeLocation(url) {
+  const a = document.createElement("a");
+  a.setAttribute("href", url);
+  const { host, hostname, href, origin, pathname, port, search, protocol } = a;
+  delete window.location;
+  global.location = {
+    host,
+    hostname,
+    href,
+    origin,
+    pathname,
+    protocol,
+    port,
+    search
+  };
+}

--- a/packages/code-du-travail-frontend/src/common/Answer.js
+++ b/packages/code-du-travail-frontend/src/common/Answer.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import Head from "next/head";
 import Link from "next/link";
 import { withRouter } from "next/router";
@@ -20,6 +20,7 @@ import Disclaimer from "./Disclaimer";
 import { Feedback } from "./Feedback";
 import Html from "./Html";
 import { ThemeBreadcrumbs } from "./ThemeBreadcrumbs";
+import { matopush } from "../piwik";
 
 const BigError = ({ children }) => (
   <StyledErrorContainer>
@@ -28,12 +29,27 @@ const BigError = ({ children }) => (
 );
 
 const BackToResultsLink = ({ query }) => {
-  if (!query.q) return null;
+  const { q } = query;
+  const onClick = useCallback(() => {
+    matopush(["trackEvent", "backResults", q]);
+  }, [q]);
+  const onKeyPress = useCallback(
+    event => {
+      if (event.keyCode === 13)
+        // Enter
+        matopush(["trackEvent", "backResults", q]);
+    },
+    [q]
+  );
+
+  if (!q) return null;
 
   return (
     <BacklinkContainer>
       <Link href={{ pathname: "/recherche", query }}>
-        <a>{"< Retour aux résultats"}</a>
+        <a role="link" tabIndex={0} onClick={onClick} onKeyPress={onKeyPress}>
+          {"< Retour aux résultats"}
+        </a>
       </Link>
     </BacklinkContainer>
   );

--- a/packages/code-du-travail-frontend/src/common/Answer.js
+++ b/packages/code-du-travail-frontend/src/common/Answer.js
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import Head from "next/head";
 import Link from "next/link";
-import { withRouter } from "next/router";
+import { useRouter } from "next/router";
 import styled from "styled-components";
 import { SOURCES, getRouteBySource } from "@cdt/sources";
 import {
@@ -28,7 +28,7 @@ const BigError = ({ children }) => (
   </StyledErrorContainer>
 );
 
-const BackToResultsLink = ({ query }) => {
+export const BackToResultsLink = ({ query }) => {
   const { q } = query;
   const onClick = useCallback(() => {
     matopush(["trackEvent", "backResults", q]);
@@ -48,7 +48,7 @@ const BackToResultsLink = ({ query }) => {
     <BacklinkContainer>
       <Link href={{ pathname: "/recherche", query }}>
         <a role="link" tabIndex={0} onClick={onClick} onKeyPress={onKeyPress}>
-          {"< Retour aux résultats"}
+          <span aria-hidden>‹</span> Retour aux résultats
         </a>
       </Link>
     </BacklinkContainer>
@@ -56,7 +56,6 @@ const BackToResultsLink = ({ query }) => {
 };
 
 function Answer({
-  router,
   title,
   intro = null,
   html = null,
@@ -71,7 +70,7 @@ function Answer({
   emptyMessage = "Aucun résultat"
 }) {
   const glossaryItems = useGlossary(children, html);
-
+  const router = useRouter();
   const { relatedTools, relatedLetters, relatedArticles } = relatedItems.reduce(
     (accumulator, item) => {
       const itemSource = item.source;
@@ -192,7 +191,7 @@ function Answer({
   );
 }
 
-export default withRouter(Answer);
+export default Answer;
 
 const { box, breakpoints, colors, fonts, spacing } = theme;
 

--- a/packages/code-du-travail-frontend/src/common/__tests__/Answer.test.js
+++ b/packages/code-du-travail-frontend/src/common/__tests__/Answer.test.js
@@ -3,145 +3,110 @@ import { render } from "@testing-library/react";
 import { SOURCES } from "@cdt/sources";
 
 import Answer from "../Answer";
+import Router from "next/router";
 
+function renderAnswer(props) {
+  return render(
+    <Answer
+      title="Article du code"
+      intro="intro de l'article"
+      html="<p class='test-content'>Contenu au format <strong>html</strong></p>"
+      footer="pied de page"
+      date="03/11/1979"
+      sourceType="social groove"
+      {...props}
+    >
+      <div>Contenu supplémentaire</div>
+    </Answer>
+  );
+}
 describe("<Answer />", () => {
-  it("renders", () => {
-    const { container } = render(
-      <Answer
-        title="Article du code"
-        intro="intro de l'article"
-        html="<p class='test-content'>Contenu au format <strong>html</strong></p>"
-        footer="pied de page"
-        date="03/11/1979"
-        sourceType="social groove"
-      >
-        <div>Contenu supplémentaire</div>
-      </Answer>
-    );
+  it("should renders", () => {
+    const { container } = renderAnswer();
     expect(container).toMatchSnapshot();
   });
-  it("renders a breadcrumbs", () => {
-    const { container } = render(
-      <Answer
-        title="Article du code"
-        intro="intro de l'article"
-        html="<p class='test-content'>Contenu au format <strong>html</strong></p>"
-        footer="pied de page"
-        date="03/11/1979"
-        sourceType="social groove"
-        breadcrumbs={[
-          { title: "tag1", slug: "tag-1" },
-          { title: "tag2", slug: "tag-2" }
-        ]}
-      >
-        <div>Contenu supplémentaire</div>
-      </Answer>
-    );
+  it("should renders a breadcrumbs", () => {
+    const { container } = renderAnswer({
+      breadcrumbs: [
+        { title: "tag1", slug: "tag-1" },
+        { title: "tag2", slug: "tag-2" }
+      ]
+    });
     expect(container).toMatchSnapshot();
   });
-  it("renders tooltip", () => {
-    const { container } = render(
-      <Answer
-        title="Article du code"
-        intro="intro de l'article"
-        html="<p class='test-content'>Contenu au format <strong>html</strong> contenant des tooltip sur certains mot comme rescrit. match aussi les abbréviation comme APE mais pas ape ou ses variantes comme code ape</p>"
-        footer="pied de page"
-        date="03/11/1979"
-        sourceType="social groove"
-      >
-        <div>Contenu supplémentaire</div>
-      </Answer>
-    );
+  it("should renders tooltip", () => {
+    const { container } = renderAnswer({
+      html:
+        "<p class='test-content'>Contenu au format <strong>html</strong> contenant des tooltip sur certains mot comme rescrit. match aussi les abbréviation comme APE mais pas ape ou ses variantes comme code ape</p>"
+    });
     expect(container).toMatchSnapshot();
   });
-  it("renders tooltip for words with diacritics without breaking html", () => {
-    const { container } = render(
-      <Answer
-        title="Article du code"
-        intro="intro de l'article"
-        html="<p class='test-content'>Contenu au format <strong>indemnités</strong>comme code ape</p>"
-        footer="pied de page"
-        date="03/11/1979"
-        sourceType="social groove"
-      >
-        <div>Contenu supplémentaire</div>
-      </Answer>
-    );
+
+  it("should renders tooltip for words with diacritics without breaking html", () => {
+    const { container } = renderAnswer({
+      html:
+        "<p class='test-content'>Contenu au format <strong>indemnités</strong>comme code ape</p>"
+    });
     expect(container).toMatchSnapshot();
   });
-  it("renders tooltip without breaking previous word", () => {
-    const { container } = render(
-      <Answer
-        title="Article du code"
-        intro="intro de l'article"
-        html="<p class='test-content'>annualisation du temps de travail. Annualisation de l'annualisation.</p>"
-        footer="pied de page"
-        date="03/11/1979"
-        sourceType="social groove"
-      >
-        <div>Contenu supplémentaire</div>
-      </Answer>
-    );
+  it("should renders tooltip without breaking previous word", () => {
+    const { container } = renderAnswer({
+      html:
+        "<p class='test-content'>annualisation du temps de travail. Annualisation de l'annualisation.</p>"
+    });
     expect(container).toMatchSnapshot();
   });
-  it("renders related content", () => {
+  it("should renders related content", () => {
     const SLUG_LINK_BASE = "LINK_";
     const SLUG_TOOL_BASE = "TOOL_";
     const SLUG_LETTER_BASE = "LETTER_";
-    const { container } = render(
-      <Answer
-        title="Article du code"
-        intro="intro de l'article"
-        html="<p class='test-content'>annualisation du temps de travail. Annualisation de l'annualisation.</p>"
-        footer="pied de page"
-        date="03/11/1979"
-        sourceType="social groove"
-        relatedItems={[
-          {
-            source: SOURCES.SHEET_SP,
-            slug: `${SLUG_LINK_BASE}1`,
-            title: "related sheet sp title 1"
-          },
-          {
-            source: SOURCES.SHEET_MT,
-            slug: `${SLUG_LINK_BASE}2`,
-            title: "related sheet mt title 1"
-          },
-          {
-            source: SOURCES.EXTERNALS,
-            slug: `${SLUG_LINK_BASE}3`,
-            title: "related external title 1"
-          },
-          {
-            source: SOURCES.SHEET_SP,
-            slug: `${SLUG_LINK_BASE}4`,
-            title: "related sheet sp title 2"
-          },
-          {
-            source: SOURCES.TOOLS,
-            slug: `${SLUG_TOOL_BASE}1`,
-            title: "related tool title 1"
-          },
-          {
-            source: SOURCES.TOOLS,
-            slug: `${SLUG_TOOL_BASE}2`,
-            title: "related tool title 2"
-          },
-          {
-            source: SOURCES.LETTERS,
-            slug: `${SLUG_LETTER_BASE}1`,
-            title: "related letter title 1"
-          },
-          {
-            source: SOURCES.LETTERS,
-            slug: `${SLUG_LETTER_BASE}2`,
-            title: "related letter title 2"
-          }
-        ]}
-      >
-        <div>Contenu supplémentaire</div>
-      </Answer>
-    );
+    const { container } = renderAnswer({
+      html:
+        "<p class='test-content'>annualisation du temps de travail. Annualisation de l'annualisation.</p>",
+      relatedItems: [
+        {
+          source: SOURCES.SHEET_SP,
+          slug: `${SLUG_LINK_BASE}1`,
+          title: "related sheet sp title 1"
+        },
+        {
+          source: SOURCES.SHEET_MT,
+          slug: `${SLUG_LINK_BASE}2`,
+          title: "related sheet mt title 1"
+        },
+        {
+          source: SOURCES.EXTERNALS,
+          slug: `${SLUG_LINK_BASE}3`,
+          title: "related external title 1"
+        },
+        {
+          source: SOURCES.SHEET_SP,
+          slug: `${SLUG_LINK_BASE}4`,
+          title: "related sheet sp title 2"
+        },
+        {
+          source: SOURCES.TOOLS,
+          slug: `${SLUG_TOOL_BASE}1`,
+          title: "related tool title 1"
+        },
+        {
+          source: SOURCES.TOOLS,
+          slug: `${SLUG_TOOL_BASE}2`,
+          title: "related tool title 2"
+        },
+        {
+          source: SOURCES.LETTERS,
+          slug: `${SLUG_LETTER_BASE}1`,
+          title: "related letter title 1"
+        },
+        {
+          source: SOURCES.LETTERS,
+          slug: `${SLUG_LETTER_BASE}2`,
+          title: "related letter title 2"
+        }
+      ]
+    });
+
     expect(
       container.querySelectorAll(`[href*="${SLUG_LINK_BASE}"]`).length
     ).toBe(3);
@@ -151,6 +116,12 @@ describe("<Answer />", () => {
     expect(
       container.querySelectorAll(`[href*="${SLUG_TOOL_BASE}"]`).length
     ).toBe(1);
+    expect(container).toMatchSnapshot();
+  });
+
+  it("should renders back to results link", () => {
+    Router.router.query.q = "camion";
+    const { container } = renderAnswer();
     expect(container).toMatchSnapshot();
   });
 });

--- a/packages/code-du-travail-frontend/src/common/__tests__/BackLink.test.js
+++ b/packages/code-du-travail-frontend/src/common/__tests__/BackLink.test.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+
+import { BackToResultsLink } from "../Answer";
+import { matopush } from "../../piwik";
+
+jest.mock("../../piwik", () => ({ matopush: jest.fn() }));
+jest.mock("next/link", () => {
+  return ({ children }) => children;
+});
+
+describe("backLink", () => {
+  it("should push tracking events on click", () => {
+    const { getByText } = render(<BackToResultsLink query={{ q: "camion" }} />);
+    const link = getByText(/retour aux résultats/i);
+    link.click();
+
+    expect(matopush).toHaveBeenCalledWith([
+      "trackEvent",
+      "backResults",
+      "camion"
+    ]);
+  });
+  it("should push tracking events on keyboard navigation", () => {
+    const { getByText } = render(<BackToResultsLink query={{ q: "camion" }} />);
+    const link = getByText(/retour aux résultats/i);
+    fireEvent.keyPress(link, { event: { keyCode: 13 } });
+
+    expect(matopush).toHaveBeenCalledWith([
+      "trackEvent",
+      "backResults",
+      "camion"
+    ]);
+  });
+});

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/Answer.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/Answer.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Answer /> renders 1`] = `
+exports[`<Answer /> should renders 1`] = `
 .c3 {
   max-width: 1200px;
   margin: 0 auto;
@@ -691,7 +691,7 @@ exports[`<Answer /> renders 1`] = `
 </div>
 `;
 
-exports[`<Answer /> renders a breadcrumbs 1`] = `
+exports[`<Answer /> should renders a breadcrumbs 1`] = `
 .c11 {
   max-width: 1200px;
   margin: 0 auto;
@@ -1584,7 +1584,736 @@ exports[`<Answer /> renders a breadcrumbs 1`] = `
 </div>
 `;
 
-exports[`<Answer /> renders related content 1`] = `
+exports[`<Answer /> should renders back to results link 1`] = `
+.c4 {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.25rem;
+}
+
+.c4 > *:first-child {
+  margin-top: 0;
+}
+
+.c4 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c12 {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.25rem;
+  max-width: 46.25rem;
+  padding: 0;
+}
+
+.c12 > *:first-child {
+  margin-top: 0;
+}
+
+.c12 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c3 {
+  padding: 1.25rem 0;
+  color: #434956;
+}
+
+.c5 {
+  padding: 0.625rem 1.25rem;
+  color: #434956;
+  border: 1px solid #c9d3df;
+  border-radius: 0.25rem;
+  background-color: #fff;
+}
+
+.c5 > *:first-child {
+  margin-top: 0;
+}
+
+.c5 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c15 {
+  padding: 0.625rem 1.25rem;
+  color: #434956;
+  border: 1px solid #c9d3df;
+  border-radius: 0.25rem;
+  background-color: #ebeff3;
+}
+
+.c15 > *:first-child {
+  margin-top: 0;
+}
+
+.c15 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c18 {
+  display: inline-block;
+  padding: 0.625rem 1.5rem;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: inherit;
+  text-align: center;
+  vertical-align: middle;
+  border: 1px solid;
+  border-radius: 1.5rem;
+  cursor: pointer;
+  -webkit-transition: background-color 250ms ease;
+  transition: background-color 250ms ease;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  color: #0c0c0e;
+  background: #ebeff3;
+  border-color: #ebeff3;
+}
+
+.c18:link,
+.c18:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #0c0c0e;
+}
+
+.c18:not([disabled]):hover,
+.c18:not([disabled]):active,
+.c18:not([disabled]):focus {
+  color: #18181c;
+  background: #fbfcfd;
+  border-color: #dbe2e9;
+}
+
+.c18[disabled] {
+  color: rgba(12,12,14,0.4);
+  cursor: not-allowed;
+}
+
+.c21 {
+  display: inline-block;
+  padding: 0.625rem 1.5rem;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: inherit;
+  text-align: center;
+  vertical-align: middle;
+  border: 1px solid;
+  border-radius: 1.5rem;
+  cursor: pointer;
+  -webkit-transition: background-color 250ms ease;
+  transition: background-color 250ms ease;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  color: #fff;
+  background: #006be6;
+  border-color: #006be6;
+}
+
+.c21:link,
+.c21:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #fff;
+}
+
+.c21:not([disabled]):hover,
+.c21:not([disabled]):active,
+.c21:not([disabled]):focus {
+  color: #fff;
+  background: #07f;
+  border-color: #005fcd;
+}
+
+.c21[disabled] {
+  color: rgba(255,255,255,0.4);
+  cursor: not-allowed;
+}
+
+.c28 {
+  display: inline-block;
+  padding: 0.625rem 1.5rem;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: inherit;
+  text-align: center;
+  vertical-align: middle;
+  border: 1px solid;
+  border-radius: 1.5rem;
+  cursor: pointer;
+  -webkit-transition: background-color 250ms ease;
+  transition: background-color 250ms ease;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  padding: 1rem;
+  color: #434956;
+  line-height: 0;
+  background-color: transparent;
+  border: none;
+}
+
+.c28:hover {
+  color: #8c94a6;
+}
+
+.c23 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 48px;
+  color: #434956;
+  background-color: #fff;
+  border-color: #fee5ad;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.25rem;
+  box-shadow: 0 5px 10px 0 #ebeff3;
+  -webkit-animation: iowhYu 300ms ease-out;
+  animation: iowhYu 300ms ease-out;
+}
+
+.c24 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 1rem;
+  background-color: #fee5ad;
+}
+
+.c25 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  padding: 1rem;
+  color: #434956;
+  text-align: left;
+}
+
+.c27 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c6 {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.25rem;
+  max-width: 46.25rem;
+  padding: 0;
+  position: relative;
+  margin-bottom: 1.25rem;
+}
+
+.c6 > *:first-child {
+  margin-top: 0;
+}
+
+.c6 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c8 {
+  color: #4c5467;
+  font-weight: 600;
+}
+
+.c9 {
+  display: inline-block;
+  margin-left: 1rem;
+  color: #4c5467;
+  font-size: 0.875rem;
+}
+
+.c10 {
+  color: #4c5467;
+  font-weight: 600;
+}
+
+.c11 {
+  margin-left: -10px;
+}
+
+.c22 {
+  position: fixed;
+  bottom: 0;
+  z-index: 1000;
+  width: 100%;
+  padding: 1rem;
+}
+
+.c26 {
+  padding: 0 0.25rem;
+}
+
+.c16 {
+  margin-bottom: 1rem;
+}
+
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+}
+
+.c20 {
+  min-width: 7rem;
+}
+
+.c20 + .c19 {
+  margin-left: 1rem;
+}
+
+.c1 {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.25rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+  padding: 0;
+}
+
+.c1 > *:first-child {
+  margin-top: 0;
+}
+
+.c1 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c2 {
+  width: 80%;
+}
+
+.c0 {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.25rem;
+  padding-top: 1rem;
+}
+
+.c0 > *:first-child {
+  margin-top: 0;
+}
+
+.c0 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c13 {
+  padding: 0.625rem 1.25rem;
+  color: #434956;
+  border: 1px solid #c9d3df;
+  border-radius: 0.25rem;
+  background-color: #ebeff3;
+  margin: 1rem auto;
+}
+
+.c13 > *:first-child {
+  margin-top: 0;
+}
+
+.c13 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c14 {
+  margin-top: 2.5rem;
+  padding: 1rem;
+  background-color: #f9f9fc;
+  border-radius: 0.25rem;
+}
+
+@media print {
+  .c4 {
+    max-width: 100%;
+    padding: 0;
+  }
+}
+
+@media print {
+  .c12 {
+    max-width: 100%;
+    padding: 0;
+  }
+}
+
+@media (max-width:600px) {
+  .c5 {
+    padding: 0.625rem 1.25rem;
+  }
+}
+
+@media print {
+  .c5 {
+    padding: 0 5pt;
+    border: none;
+  }
+}
+
+@media (max-width:600px) {
+  .c15 {
+    padding: 0.625rem 1.25rem;
+  }
+}
+
+@media print {
+  .c15 {
+    padding: 0 5pt;
+    border: none;
+  }
+}
+
+@media print {
+  .c6 {
+    max-width: 100%;
+    padding: 0;
+  }
+}
+
+@media (max-width:600px) {
+  .c7 {
+    -webkit-flex-flow: column;
+    -ms-flex-flow: column;
+    flex-flow: column;
+    -webkit-align-items: flex-start;
+    -webkit-box-align: flex-start;
+    -ms-flex-align: flex-start;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width:600px) {
+  .c9 {
+    margin-left: 0;
+  }
+}
+
+@media print {
+  .c1 {
+    max-width: 100%;
+    padding: 0;
+  }
+}
+
+@media (max-width:980px) {
+  .c2 {
+    width: 100%;
+  }
+}
+
+@media print {
+  .c0 {
+    max-width: 100%;
+    padding: 0;
+  }
+}
+
+@media (max-width:600px) {
+  .c13 {
+    padding: 0.625rem 1.25rem;
+  }
+}
+
+@media print {
+  .c13 {
+    padding: 0 5pt;
+    border: none;
+  }
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <a
+      href="/recherche?q=camion"
+      role="link"
+      tabindex="0"
+    >
+      <span
+        aria-hidden="true"
+      >
+        ‹
+      </span>
+       Retour aux résultats
+    </a>
+  </div>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3"
+        data-main-content="true"
+      >
+        <div
+          class="c4"
+        >
+          <div
+            class="c5"
+          >
+            <div
+              class="c3"
+            >
+              <div
+                class="c6"
+              >
+                <h1>
+                  Article du code
+                </h1>
+                <div
+                  class="c7"
+                >
+                  <span
+                    class="c8"
+                  >
+                    social groove
+                  </span>
+                  <span
+                    class="c9"
+                  >
+                    Mis à jour le : 
+                    <span
+                      class="c10"
+                    >
+                      03/11/1979
+                    </span>
+                  </span>
+                </div>
+                <div
+                  class="c11"
+                />
+              </div>
+              <div
+                class="c12"
+              >
+                <div
+                  class="c13"
+                >
+                  intro de l'article
+                </div>
+                <div>
+                  <p
+                    class="test-content"
+                  >
+                    Contenu au format 
+                    <strong>
+                      html
+                    </strong>
+                  </p>
+                </div>
+                <div>
+                  Contenu supplémentaire
+                </div>
+                <div
+                  class="c14"
+                >
+                  pied de page
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="c3"
+      >
+        <div
+          class="c4"
+        >
+          <div
+            class="c15"
+          >
+            <h3
+              class="c16"
+            >
+              Avez-vous trouvé la réponse à votre question ?
+            </h3>
+            <p
+              class="c17"
+            >
+              <button
+                class="c18 c19 c20"
+              >
+                Non
+              </button>
+              <button
+                class="c21 c19 c20"
+              >
+                Oui
+              </button>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="c22"
+  >
+    <div
+      class="c23"
+    >
+      <div
+        class="c24"
+      >
+        <svg
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"
+          />
+          <line
+            x1="12"
+            x2="12"
+            y1="9"
+            y2="13"
+          />
+          <line
+            x1="12"
+            x2="12"
+            y1="17"
+            y2="17"
+          />
+        </svg>
+      </div>
+      <div
+        class="c25"
+        role="alert"
+      >
+        Ce site est en cours de construction, la fiabilité des réponses qui s’y trouvent ne sont pas garanties.
+        <a
+          class="c26"
+          href="https://www.legifrance.gouv.fr/affichTexteArticle.do;jsessionid=AE9DCF75DDCF0465784CEE0E7D62729F.tplgfr37s_2?idArticle=JORFARTI000035607420&cidTexte=JORFTEXT000035607388&dateTexte=29990101&categorieLien=id"
+          rel="noopener noreferrer"
+          target="_blank"
+          title="consulter l'ordonance"
+        >
+          L’ouverture officielle du site
+        </a>
+        est prévue pour 2020.
+      </div>
+      <div
+        class="c27"
+      >
+        <button
+          aria-label="Fermer"
+          class="c28"
+        >
+          <svg
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <line
+              x1="18"
+              x2="6"
+              y1="6"
+              y2="18"
+            />
+            <line
+              x1="6"
+              x2="18"
+              y1="6"
+              y2="18"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Answer /> should renders related content 1`] = `
 .c3 {
   max-width: 1200px;
   margin: 0 auto;
@@ -2516,7 +3245,7 @@ exports[`<Answer /> renders related content 1`] = `
 </div>
 `;
 
-exports[`<Answer /> renders tooltip 1`] = `
+exports[`<Answer /> should renders tooltip 1`] = `
 .c3 {
   max-width: 1200px;
   margin: 0 auto;
@@ -3247,7 +3976,7 @@ exports[`<Answer /> renders tooltip 1`] = `
 </div>
 `;
 
-exports[`<Answer /> renders tooltip for words with diacritics without breaking html 1`] = `
+exports[`<Answer /> should renders tooltip for words with diacritics without breaking html 1`] = `
 .c3 {
   max-width: 1200px;
   margin: 0 auto;
@@ -3964,7 +4693,7 @@ exports[`<Answer /> renders tooltip for words with diacritics without breaking h
 </div>
 `;
 
-exports[`<Answer /> renders tooltip without breaking previous word 1`] = `
+exports[`<Answer /> should renders tooltip without breaking previous word 1`] = `
 .c3 {
   max-width: 1200px;
   margin: 0 auto;

--- a/packages/code-du-travail-frontend/src/piwik.js
+++ b/packages/code-du-travail-frontend/src/piwik.js
@@ -12,6 +12,13 @@ export function initPiwik({
   matopush(["setTrackerUrl", `${piwikUrl}/${phpTrackerFile}`]);
   matopush(["enableLinkTracking"]);
 
+  const campaign = location.search.match(
+    /(?:pk_campaign|utm_campaign)=([^&]+)&?/
+  );
+  if (campaign && campaign.length) {
+    const [, campaignKey] = campaign;
+    matopush(["setCampaignNameKey", campaignKey]);
+  }
   /**
    * for intial loading we use the location.pathname
    * as the first url visited.
@@ -37,7 +44,7 @@ export function initPiwik({
     // In order to ensure that the page title had been updated,
     // we delayed pushing the tracking to the next tick.
     setTimeout(() => {
-      const { q, source } = Router.query;
+      const { q } = Router.query;
       if (previousPath) {
         matopush(["setReferrerUrl", `${previousPath}`]);
       }
@@ -46,7 +53,7 @@ export function initPiwik({
       matopush(["deleteCustomVariables", "page"]);
       matopush(["setGenerationTimeMs", 0]);
       if (/^\/recherche/.test(pathname)) {
-        matopush(["trackSiteSearch", q, source]);
+        matopush(["trackSiteSearch", q]);
       } else {
         matopush(["trackPageView"]);
       }
@@ -58,8 +65,4 @@ export function initPiwik({
 
 export function matopush(args) {
   window._paq.push(args);
-}
-
-export function pof() {
-  return 42;
 }

--- a/packages/code-du-travail-frontend/src/piwik.js
+++ b/packages/code-du-travail-frontend/src/piwik.js
@@ -3,30 +3,24 @@ import Router from "next/router";
 export function initPiwik({
   siteId,
   piwikUrl,
-  jsTrackerFile = "piwik.js",
-  phpTrackerFile = "piwik.php"
+  jsTrackerFile = "matomo.js",
+  phpTrackerFile = "matomo.php"
 }) {
   window._paq = window._paq || [];
   let previousPath = "";
-  matopush(["setSiteId", siteId]);
-  matopush(["setTrackerUrl", `${piwikUrl}/${phpTrackerFile}`]);
+  // order is important -_- so campaign are detected
+  matopush(["trackPageView"]);
   matopush(["enableLinkTracking"]);
+  matopush(["setTrackerUrl", `${piwikUrl}/${phpTrackerFile}`]);
+  matopush(["setSiteId", siteId]);
 
-  const campaign = location.search.match(
-    /(?:pk_campaign|utm_campaign)=([^&]+)&?/
-  );
-  if (campaign && campaign.length) {
-    const [, campaignKey] = campaign;
-    matopush(["setCampaignNameKey", campaignKey]);
-  }
   /**
    * for intial loading we use the location.pathname
    * as the first url visited.
    * Once user navigate accross the site,
    * we rely on Router.pathname
    */
-  matopush(["setCustomUrl", location.pathname]);
-  matopush(["trackPageView"]);
+
   const scriptElement = document.createElement("script");
   const refElement = document.getElementsByTagName("script")[0];
   scriptElement.type = "text/javascript";
@@ -38,7 +32,7 @@ export function initPiwik({
 
   Router.events.on("routeChangeComplete", path => {
     // We use only the part of the url without the querystring to ensure piwik is happy
-    // It seems that piwiki doesn't track well page with querystring
+    // It seems that piwik doesn't track well page with querystring
     const [pathname] = path.split("?");
 
     // In order to ensure that the page title had been updated,

--- a/packages/code-du-travail-frontend/src/search/SearchBar/index.js
+++ b/packages/code-du-travail-frontend/src/search/SearchBar/index.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import styled from "styled-components";
-import Router, { useRouter } from "next/router";
+import { useRouter } from "next/router";
 import { Button, theme } from "@socialgouv/react-ui";
 
 import SearchIcon from "../../icons/SearchIcon";
@@ -23,7 +23,7 @@ const SearchBar = ({ hasFocus = false, inputId, hasButton = false }) => {
   const onFormSubmit = e => {
     e.preventDefault();
     if (query) {
-      Router.push({
+      router.push({
         pathname: "/recherche",
         query: {
           q: query
@@ -41,7 +41,7 @@ const SearchBar = ({ hasFocus = false, inputId, hasButton = false }) => {
     event.preventDefault();
     matopush(["trackEvent", "selectedSuggestion", query, suggestion]);
     matopush(["trackEvent", "candidateSuggestions", suggestions.join("###")]);
-    Router.push({
+    router.push({
       pathname: "/recherche",
       query: { q: suggestion }
     });

--- a/packages/code-du-travail-frontend/src/search/SearchBar/index.js
+++ b/packages/code-du-travail-frontend/src/search/SearchBar/index.js
@@ -40,6 +40,7 @@ const SearchBar = ({ hasFocus = false, inputId, hasButton = false }) => {
     // prevent onSubmit to be call
     event.preventDefault();
     matopush(["trackEvent", "selectedSuggestion", query, suggestion]);
+    matopush(["trackEvent", "candidateSuggestions", suggestions.join("###")]);
     Router.push({
       pathname: "/recherche",
       query: { q: suggestion }

--- a/packages/code-du-travail-frontend/src/search/SearchResults/Results.js
+++ b/packages/code-du-travail-frontend/src/search/SearchResults/Results.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import Link from "next/link";
@@ -13,7 +13,9 @@ import {
 
 import { LinkContent } from "./LinkContent";
 
-const ListLink = ({
+import { matopush } from "../../piwik";
+
+export const ListLink = ({
   focused,
   item: { source, slug, url },
   query,
@@ -25,6 +27,20 @@ const ListLink = ({
       ref.current.focus();
     }
   }, [focused]);
+  const trackedUrl =
+    source === SOURCES.EXTERNALS ? url : `/${getRouteBySource(source)}/${slug}`;
+
+  const onClick = useCallback(() => {
+    matopush(["trackEvent", "selectResult", trackedUrl]);
+  }, [trackedUrl]);
+  const onKeyPress = useCallback(
+    event => {
+      if (event.keyCode === 13)
+        // Enter
+        matopush(["trackEvent", "selectResult", trackedUrl]);
+    },
+    [trackedUrl]
+  );
   if (source === SOURCES.EXTERNALS) {
     return (
       <LargeLink
@@ -32,6 +48,8 @@ const ListLink = ({
         href={url}
         target="_blank"
         className="no-after"
+        onClick={onClick}
+        onKeyPress={onKeyPress}
         {...otherProps}
       />
     );
@@ -48,6 +66,8 @@ const ListLink = ({
     >
       <LargeLink
         ref={ref}
+        onClick={onClick}
+        onKeyPress={onKeyPress}
         variant={source === SOURCES.TOOLS ? "highlight" : "light"}
         {...otherProps}
       />

--- a/packages/code-du-travail-frontend/src/search/SearchResults/index.js
+++ b/packages/code-du-travail-frontend/src/search/SearchResults/index.js
@@ -1,15 +1,26 @@
-import React from "react";
+import React, { useEffect } from "react";
 import PropTypes from "prop-types";
-
+import { useRouter } from "next/router";
 import { Results } from "./Results";
 import { Law } from "./Law";
 import { Themes } from "./Themes";
+import { matopush } from "../../piwik";
 
 const SearchResults = ({
   items: { documents, themes, articles },
   isSearch,
   query
 }) => {
+  const router = useRouter();
+  useEffect(() => {
+    const toSlug = ({ source, slug }) => `${source}/${slug}`;
+    const results = JSON.stringify({
+      documents: documents.map(toSlug),
+      themes: themes.map(toSlug),
+      articles: articles.map(toSlug)
+    });
+    matopush(["trackEvent", "candidateResults", router.query.q, results]);
+  });
   return (
     <>
       {documents.length > 0 && (

--- a/packages/code-du-travail-frontend/src/search/__tests__/ListLink.test.js
+++ b/packages/code-du-travail-frontend/src/search/__tests__/ListLink.test.js
@@ -1,0 +1,42 @@
+import React from "react";
+import { ListLink } from "../SearchResults/Results";
+import { render } from "@testing-library/react";
+import { matopush } from "../../piwik";
+
+jest.mock("../../piwik", () => ({
+  matopush: jest.fn()
+}));
+
+jest.mock("next/link", () => {
+  return ({ children }) => children;
+});
+
+const item = {
+  source: "fiches_service_public",
+  title: "Mer il est fou!",
+  slug: "mer-il-est-fou",
+  description: "description",
+  breadcrumbs: [
+    { slug: "theme-root", title: "test content" },
+    { slug: "theme-test", title: "test theme content" }
+  ]
+};
+
+describe("ListLink", () => {
+  it("should track event selectResult on click", () => {
+    jest.resetAllMocks();
+    const { getByText } = render(
+      <ListLink item={item} query="demission">
+        {item.title}
+      </ListLink>
+    );
+
+    const link = getByText(/Mer il est fou!/);
+    link.click();
+    expect(matopush).toHaveBeenCalledWith([
+      "trackEvent",
+      "selectResult",
+      "/fiche-service-public/mer-il-est-fou"
+    ]);
+  });
+});

--- a/packages/code-du-travail-frontend/src/search/__tests__/SearchResults.test.js
+++ b/packages/code-du-travail-frontend/src/search/__tests__/SearchResults.test.js
@@ -2,6 +2,10 @@ import React from "react";
 import { SearchResults } from "../SearchResults";
 import { render } from "@testing-library/react";
 
+jest.mock("../../piwik", () => ({
+  matopush: jest.fn()
+}));
+
 const items = {
   documents: [
     {

--- a/packages/code-du-travail-frontend/src/search/__tests__/SearchResults.test.js
+++ b/packages/code-du-travail-frontend/src/search/__tests__/SearchResults.test.js
@@ -28,7 +28,7 @@ const items = {
     },
     {
       source: "external",
-      title: "fich",
+      title: "telerc",
       url:
         "https://www.telerc.travail.gouv.fr/RuptureConventionnellePortailPublic/jsp/site/Portal.jsp?page_id=14",
       slug: "simulateur-licenciement-telerc",

--- a/packages/code-du-travail-frontend/src/search/__tests__/SearchResults.test.js
+++ b/packages/code-du-travail-frontend/src/search/__tests__/SearchResults.test.js
@@ -1,6 +1,8 @@
 import React from "react";
+import Router from "next/router";
 import { SearchResults } from "../SearchResults";
 import { render } from "@testing-library/react";
+import { matopush } from "../../piwik";
 
 jest.mock("../../piwik", () => ({
   matopush: jest.fn()
@@ -72,6 +74,9 @@ const emptyItems = {
   themes: []
 };
 describe("<SearchResults/>", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
   it("should render no results", () => {
     const { container } = render(
       <SearchResults items={emptyItems} query="search test" />
@@ -83,5 +88,15 @@ describe("<SearchResults/>", () => {
       <SearchResults items={items} query="search test" />
     );
     expect(container).toMatchSnapshot();
+  });
+
+  it("should track event candidateResults", () => {
+    Router.router.query.q = "démission";
+    render(<SearchResults items={items} query="search test" />);
+
+    const trackParams = matopush.mock.calls[0];
+    expect(trackParams[0]).toEqual(
+      expect.arrayContaining(["trackEvent", "candidateResults", "démission"])
+    );
   });
 });

--- a/packages/code-du-travail-frontend/src/search/__tests__/__snapshots__/SearchResults.test.js.snap
+++ b/packages/code-du-travail-frontend/src/search/__tests__/__snapshots__/SearchResults.test.js.snap
@@ -408,7 +408,7 @@ exports[`<SearchResults/> should render results 1`] = `
             <h3
               class="c3"
             >
-              fich
+              telerc
             </h3>
             <p
               class="c4"


### PR DESCRIPTION
better tracking of provided info to user
- send candidateResults when display a SERP (Search Engine Result Page)
- send candidateSuggestion when clicking a suggestion.
- handle campaign id
- log back to results
- log selectResult 

this will help us better know what suggestions are better clicked 

ref #1624