### PR TITLE
build(docker): update git andd curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM node:10-alpine
+FROM node:10.17.0-alpine3.10
 
 # NOTE(douglasduteil): add `curl` in the master image
 # `curl` is very useful for later health check tests ;)
-RUN apk add --no-cache --update git=2.20.1-r0 curl=7.64.0-r3
+RUN apk add --no-cache --update git=2.22.0-r0 curl=7.66.0-r0
 
 #
 


### PR DESCRIPTION
<img src=https://media.giphy.com/media/kBSOfIERSIljUUNk5v/giphy.gif width=693>

---

Resolves

```
$ apk add --no-cache --update git=2.20.1-r0 curl=7.64.0-r3
 ---> Running in 94b5061dc5af
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  curl-7.66.0-r0:
    breaks: world[curl=7.64.0-r3]
  git-2.22.0-r0:
    breaks: world[git=2.20.1-r0]
```