### PR TITLE
fix(contributions): rm trailing 0 when no answer references fix #1777 

### DIFF
--- a/packages/code-du-travail-frontend/src/contributions/Contribution.js
+++ b/packages/code-du-travail-frontend/src/contributions/Contribution.js
@@ -53,7 +53,7 @@ const References = ({ references }) => {
 
   return (
     <React.Fragment>
-      {references && references.length && (
+      {references && references.length !== 0 && (
         <React.Fragment>
           <h3>Références</h3>
           {/* group CCs references */}


### PR DESCRIPTION
fix #1777 