### PR TITLE
fix: SDR urls linter

### DIFF
--- a/.gitlab-ci/stages/quality.yml
+++ b/.gitlab-ci/stages/quality.yml
@@ -103,7 +103,7 @@ Test @cdtn/frontend SDR data:
   image: alpine:3.10
   allow_failure: true
   before_script:
-    - apk add --no-cache jq=1.6-r0 curl=7.66.0-r0
+    - apk add --no-cache jq=1.6-r0 wget=1.20.3-r0
   script:
     - |-
-      jq ".[].url" ./packages/code-du-travail-frontend/src/data/services-de-renseignement.json | xargs -n 1 curl -L --head --fail > /dev/null
+      jq ".[].url" ./packages/code-du-travail-frontend/src/data/services-de-renseignement.json | xargs -n 1 wget  --spider

--- a/packages/code-du-travail-frontend/src/data/services-de-renseignement.json
+++ b/packages/code-du-travail-frontend/src/data/services-de-renseignement.json
@@ -184,7 +184,7 @@
         "name": "OISE"
     },
     "61": {
-        "url": "http://normandie.direccte.gouv.fr/Contacter-l-inspection-du-travail",
+        "url": "http://normandie.direccte.gouv.fr/Un-numero-unique-pour-contacter-vos-services-de-renseignements-en-droit-du-18314",
         "name": "ORNE"
     },
     "62": {


### PR DESCRIPTION
 - make Ci logs more verbose with wget
 - fix a faulty url