### PR TITLE
feat: dedicated CCN search page

### DIFF
--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/index.test.js.snap
@@ -1169,6 +1169,102 @@ exports[`<Home /> should render 1`] = `
           >
             <a
               class="c34"
+              href="/modeles-de-courriers"
+              title="Consulter tous les modèles de courriers"
+            >
+              <div
+                class="c35"
+              >
+                Modèles de courriers
+              </div>
+              <div
+                class="c36"
+              >
+                <div
+                  class="c37"
+                >
+                  Consulter
+                </div>
+              </div>
+            </a>
+          </li>
+          <li
+            class="c33"
+          >
+            <a
+              class="c34"
+              href="/convention-collective/recherche"
+              title="Recherchez votre convention collective"
+            >
+              <div
+                class="c35"
+              >
+                Conventions collectives
+              </div>
+              <div
+                class="c36"
+              >
+                <div
+                  class="c37"
+                >
+                  Consulter
+                </div>
+              </div>
+            </a>
+          </li>
+          <li
+            class="c33"
+          >
+            <a
+              class="c34"
+              href="/outils/simulateur-embauche"
+              title="Démarrer une simulation de salaire lors d'une embauche"
+            >
+              <div
+                class="c35"
+              >
+                Simulateur d'embauche
+              </div>
+              <div
+                class="c36"
+              >
+                <div
+                  class="c37"
+                >
+                  Démarrer
+                </div>
+              </div>
+            </a>
+          </li>
+          <li
+            class="c33"
+          >
+            <a
+              class="c34"
+              href="/outils/preavis-demission"
+              title="Démarrer une simulation de durée de préavis de démission"
+            >
+              <div
+                class="c35"
+              >
+                Simulateur de durée de préavis de démission
+              </div>
+              <div
+                class="c36"
+              >
+                <div
+                  class="c37"
+                >
+                  Démarrer
+                </div>
+              </div>
+            </a>
+          </li>
+          <li
+            class="c33"
+          >
+            <a
+              class="c34"
               href="/outils/indemnite-licenciement"
               title="Démarrer une simulation d'indemnités de licenciements"
             >
@@ -1217,78 +1313,6 @@ exports[`<Home /> should render 1`] = `
           >
             <a
               class="c34"
-              href="/outils/preavis-demission"
-              title="Démarrer une simulation de durée de préavis de démission"
-            >
-              <div
-                class="c35"
-              >
-                Simulateur de durée de préavis de démission
-              </div>
-              <div
-                class="c36"
-              >
-                <div
-                  class="c37"
-                >
-                  Démarrer
-                </div>
-              </div>
-            </a>
-          </li>
-          <li
-            class="c33"
-          >
-            <a
-              class="c34"
-              href="/modeles-de-courriers"
-              title="Consulter tous les modèles de courriers"
-            >
-              <div
-                class="c35"
-              >
-                Modèles de courriers
-              </div>
-              <div
-                class="c36"
-              >
-                <div
-                  class="c37"
-                >
-                  Consulter
-                </div>
-              </div>
-            </a>
-          </li>
-          <li
-            class="c33"
-          >
-            <a
-              class="c34"
-              href="/outils/simulateur-embauche"
-              title="Démarrer une simulation de salaire lors d'une embauche"
-            >
-              <div
-                class="c35"
-              >
-                Simulateur d'embauche
-              </div>
-              <div
-                class="c36"
-              >
-                <div
-                  class="c37"
-                >
-                  Démarrer
-                </div>
-              </div>
-            </a>
-          </li>
-          <li
-            class="c33"
-          >
-            <a
-              class="c34"
               href="/outils/indemnite-precarite"
               title="Démarrer une simulation de la prime de précarité"
             >
@@ -1307,29 +1331,6 @@ exports[`<Home /> should render 1`] = `
                 </div>
               </div>
             </a>
-          </li>
-          <li
-            class="c33"
-          >
-            <button
-              class="c34"
-              href=""
-            >
-              <div
-                class="c35"
-              >
-                Votre convention collective
-              </div>
-              <div
-                class="c36"
-              >
-                <div
-                  class="c37"
-                >
-                  Rechercher
-                </div>
-              </div>
-            </button>
           </li>
           <li
             class="c33"

--- a/packages/code-du-travail-frontend/pages/convention-collective/recherche.js
+++ b/packages/code-du-travail-frontend/pages/convention-collective/recherche.js
@@ -18,6 +18,16 @@ const SearchConvention = ({ ogImage, pageUrl }) => (
           <PageTitle>Recherchez votre convention collective</PageTitle>
           <ConventionForm />
         </Wrapper>
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
       </Container>
     </Section>
   </Layout>

--- a/packages/code-du-travail-frontend/pages/convention-collective/recherche.js
+++ b/packages/code-du-travail-frontend/pages/convention-collective/recherche.js
@@ -1,0 +1,26 @@
+import React from "react";
+import { Container, PageTitle, Section, Wrapper } from "@socialgouv/react-ui";
+import { Layout } from "../../src/layout/Layout";
+import Metas from "../../src/common/Metas";
+import ConventionForm from "../../src/conventions/Search/Form";
+
+const SearchConvention = ({ ogImage, pageUrl }) => (
+  <Layout currentPage="about">
+    <Metas
+      url={pageUrl}
+      title="Recherche de convention collective"
+      description="Recherchez une convention collective par Entreprise, SIRET, Nom ou numéro IDCC."
+      image={ogImage}
+    />
+    <Section>
+      <Container narrow>
+        <Wrapper variant="light">
+          <PageTitle>Recherchez votre convention collective</PageTitle>
+          <ConventionForm />
+        </Wrapper>
+      </Container>
+    </Section>
+  </Layout>
+);
+
+export default SearchConvention;

--- a/packages/code-du-travail-frontend/src/common/Outils.js
+++ b/packages/code-du-travail-frontend/src/common/Outils.js
@@ -3,9 +3,39 @@ import Link from "next/link";
 
 import { Container, Section, CardList, Tile } from "@socialgouv/react-ui";
 
-import ConventionModal from "../conventions/Search/Modal";
-
 export const outils = [
+  {
+    title: "Modèles de courriers",
+    hrefTitle: "Consulter tous les modèles de courriers",
+    button: "Consulter",
+    text:
+      "Utilisez des modèles pré-remplis pour vos courriers liés au droit du travail",
+    href: "/modeles-de-courriers"
+  },
+  {
+    title: "Conventions collectives",
+    hrefTitle: "Recherchez votre convention collective",
+    button: "Consulter",
+    text:
+      "Recherchez une convention collective par Entreprise, SIRET, Nom ou numéro IDCC.",
+    href: "/convention-collective/recherche"
+  },
+  {
+    title: "Simulateur d'embauche",
+    hrefTitle: "Démarrer une simulation de salaire lors d'une embauche",
+    button: "Démarrer",
+    text: "Estimez le salaire lors d'une embauche : total employeur, brut, net",
+    href: "/outils/[slug]",
+    slug: "/outils/simulateur-embauche"
+  },
+  {
+    title: "Simulateur de durée de préavis de démission",
+    hrefTitle: "Démarrer une simulation de durée de préavis de démission",
+    button: "Démarrer",
+    text: "Connaître la durée du préavis de démission.",
+    href: "/outils/[slug]",
+    slug: "/outils/preavis-demission"
+  },
   {
     title: "Simulateur d'indemnités de licenciements",
     hrefTitle: "Démarrer une simulation d'indemnités de licenciements",
@@ -23,30 +53,6 @@ export const outils = [
       "Estimez simplement la durée du préavis dans le cadre d'un licenciement",
     href: "/outils/[slug]",
     slug: "/outils/preavis-licenciement"
-  },
-  {
-    title: "Simulateur de durée de préavis de démission",
-    hrefTitle: "Démarrer une simulation de durée de préavis de démission",
-    button: "Démarrer",
-    text: "Connaître la durée du préavis de démission.",
-    href: "/outils/[slug]",
-    slug: "/outils/preavis-demission"
-  },
-  {
-    title: "Modèles de courriers",
-    hrefTitle: "Consulter tous les modèles de courriers",
-    button: "Consulter",
-    text:
-      "Utilisez des modèles pré-remplis pour vos courriers liés au droit du travail",
-    href: "/modeles-de-courriers"
-  },
-  {
-    title: "Simulateur d'embauche",
-    hrefTitle: "Démarrer une simulation de salaire lors d'une embauche",
-    button: "Démarrer",
-    text: "Estimez le salaire lors d'une embauche : total employeur, brut, net",
-    href: "/outils/[slug]",
-    slug: "/outils/simulateur-embauche"
   },
   {
     title: "Simulateur de prime de précarité",
@@ -76,13 +82,6 @@ function Outils() {
               </Link>
             ))
             .concat(
-              <ConventionModal key="convention-modal">
-                {openModal => (
-                  <Tile button="Rechercher" onClick={openModal}>
-                    Votre convention collective
-                  </Tile>
-                )}
-              </ConventionModal>,
               <Tile key="next-tools">
                 Bientôt d’autres outils disponibles...
               </Tile>

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/Outils.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/Outils.test.js.snap
@@ -296,6 +296,102 @@ exports[`<Outils /> should render 1`] = `
         >
           <a
             class="c8"
+            href="/modeles-de-courriers"
+            title="Consulter tous les modèles de courriers"
+          >
+            <div
+              class="c9"
+            >
+              Modèles de courriers
+            </div>
+            <div
+              class="c10"
+            >
+              <div
+                class="c11"
+              >
+                Consulter
+              </div>
+            </div>
+          </a>
+        </li>
+        <li
+          class="c7"
+        >
+          <a
+            class="c8"
+            href="/convention-collective/recherche"
+            title="Recherchez votre convention collective"
+          >
+            <div
+              class="c9"
+            >
+              Conventions collectives
+            </div>
+            <div
+              class="c10"
+            >
+              <div
+                class="c11"
+              >
+                Consulter
+              </div>
+            </div>
+          </a>
+        </li>
+        <li
+          class="c7"
+        >
+          <a
+            class="c8"
+            href="/outils/simulateur-embauche"
+            title="Démarrer une simulation de salaire lors d'une embauche"
+          >
+            <div
+              class="c9"
+            >
+              Simulateur d'embauche
+            </div>
+            <div
+              class="c10"
+            >
+              <div
+                class="c11"
+              >
+                Démarrer
+              </div>
+            </div>
+          </a>
+        </li>
+        <li
+          class="c7"
+        >
+          <a
+            class="c8"
+            href="/outils/preavis-demission"
+            title="Démarrer une simulation de durée de préavis de démission"
+          >
+            <div
+              class="c9"
+            >
+              Simulateur de durée de préavis de démission
+            </div>
+            <div
+              class="c10"
+            >
+              <div
+                class="c11"
+              >
+                Démarrer
+              </div>
+            </div>
+          </a>
+        </li>
+        <li
+          class="c7"
+        >
+          <a
+            class="c8"
             href="/outils/indemnite-licenciement"
             title="Démarrer une simulation d'indemnités de licenciements"
           >
@@ -344,78 +440,6 @@ exports[`<Outils /> should render 1`] = `
         >
           <a
             class="c8"
-            href="/outils/preavis-demission"
-            title="Démarrer une simulation de durée de préavis de démission"
-          >
-            <div
-              class="c9"
-            >
-              Simulateur de durée de préavis de démission
-            </div>
-            <div
-              class="c10"
-            >
-              <div
-                class="c11"
-              >
-                Démarrer
-              </div>
-            </div>
-          </a>
-        </li>
-        <li
-          class="c7"
-        >
-          <a
-            class="c8"
-            href="/modeles-de-courriers"
-            title="Consulter tous les modèles de courriers"
-          >
-            <div
-              class="c9"
-            >
-              Modèles de courriers
-            </div>
-            <div
-              class="c10"
-            >
-              <div
-                class="c11"
-              >
-                Consulter
-              </div>
-            </div>
-          </a>
-        </li>
-        <li
-          class="c7"
-        >
-          <a
-            class="c8"
-            href="/outils/simulateur-embauche"
-            title="Démarrer une simulation de salaire lors d'une embauche"
-          >
-            <div
-              class="c9"
-            >
-              Simulateur d'embauche
-            </div>
-            <div
-              class="c10"
-            >
-              <div
-                class="c11"
-              >
-                Démarrer
-              </div>
-            </div>
-          </a>
-        </li>
-        <li
-          class="c7"
-        >
-          <a
-            class="c8"
             href="/outils/indemnite-precarite"
             title="Démarrer une simulation de la prime de précarité"
           >
@@ -434,29 +458,6 @@ exports[`<Outils /> should render 1`] = `
               </div>
             </div>
           </a>
-        </li>
-        <li
-          class="c7"
-        >
-          <button
-            class="c8"
-            href=""
-          >
-            <div
-              class="c9"
-            >
-              Votre convention collective
-            </div>
-            <div
-              class="c10"
-            >
-              <div
-                class="c11"
-              >
-                Rechercher
-              </div>
-            </div>
-          </button>
         </li>
         <li
           class="c7"


### PR DESCRIPTION
Sur la home, remplacement de la modale CCN par une page dédié dans `/convention-collective/recherche`

<img width="1264" alt="Capture d’écran 2019-12-02 à 18 12 21" src="https://user-images.githubusercontent.com/124937/69979906-78a5cf00-152f-11ea-98c8-610ebdd51900.png">
<img width="1221" alt="Capture d’écran 2019-12-02 à 18 12 28" src="https://user-images.githubusercontent.com/124937/69979907-78a5cf00-152f-11ea-9e55-c74bf3deab01.png">
