### PR TITLE
fix(simulateur): fix when infoCC is null

### DIFF
--- a/packages/code-du-travail-frontend/src/outils/common/InfosCCn.js
+++ b/packages/code-du-travail-frontend/src/outils/common/InfosCCn.js
@@ -17,7 +17,7 @@ function StepInfoCCn({ form, isOptionnal = true }) {
   const [ccInfo, setCcInfo] = useConventionState({});
   useEffect(() => {
     form.batch(() => {
-      form.change(CCN, ccInfo.convention);
+      form.change(CCN, ccInfo ? ccInfo.convention : null);
     });
   }, [ccInfo, form]);
   return (


### PR DESCRIPTION
fix if infoCC is null, reading convention from it throw :(
related to #1851