### PR TITLE
chore(deps): bump nodejs docker image to 12.14

### DIFF
--- a/.gitlab-ci/stages/notify.yml
+++ b/.gitlab-ci/stages/notify.yml
@@ -53,7 +53,7 @@ Notify Success:
 
 Release:
   stage: "Notify Finished Deployment"
-  image: node:12.13-alpine3.10
+  image: node:12.14-alpine3.10
   only:
     - master
   when: manual

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.13-alpine3.10
+FROM node:12.14-alpine3.10
 
 # NOTE(douglasduteil): add `curl` in the master image
 # `curl` is very useful for later health check tests ;)

--- a/packages/code-du-travail-api/Dockerfile
+++ b/packages/code-du-travail-api/Dockerfile
@@ -5,7 +5,7 @@ ARG BASE_IMAGE=${REGISTRY}:${TAG_BASE_IMAGE}
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE} as cdtn-base-image
 
-FROM node:12.13-alpine3.10
+FROM node:12.14-alpine3.10
 
 COPY ./package.json /app/package.json
 

--- a/packages/code-du-travail-data/Dockerfile
+++ b/packages/code-du-travail-data/Dockerfile
@@ -10,7 +10,7 @@ FROM ${BASE_IMAGE} as cdtn-base-image
 # hadolint ignore=DL3006
 FROM ${NLP_IMAGE} as cdtn-nlp-image
 
-FROM node:12.13-alpine3.10
+FROM node:12.14-alpine3.10
 
 RUN apk add --no-cache curl=7.66.0-r0
 


### PR DESCRIPTION
from snyk
``` 
------------ Detected 3 vulnerabilities for node@12.13.1 ------------ 


✗ Low severity vulnerability found in node
  Description: Arbitrary File Overwrite
  Info: https://snyk.io/vuln/SNYK-UPSTREAM-NODE-538285
  Introduced through: node@12.13.1
  From: node@12.13.1
  Introduced by your base image (${REGISTRY}:${TAG_BASE_IMAGE})
  Fixed in: 12.14.0

✗ Low severity vulnerability found in node
  Description: Arbitrary File Write
  Info: https://snyk.io/vuln/SNYK-UPSTREAM-NODE-538286
  Introduced through: node@12.13.1
  From: node@12.13.1
  Introduced by your base image (${REGISTRY}:${TAG_BASE_IMAGE})
  Fixed in: 12.14.0

✗ Low severity vulnerability found in node
  Description: Unauthorized File Access
  Info: https://snyk.io/vuln/SNYK-UPSTREAM-NODE-538287
  Introduced through: node@12.13.1
  From: node@12.13.1
  Introduced by your base image (${REGISTRY}:${TAG_BASE_IMAGE})
  Fixed in: 12.14.0
```