### PR TITLE
chore: add renovate/group:allNonMajor

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -2,6 +2,7 @@
   "enabled": true,
   "extends": [
     "github>SocialGouv/renovate-config",
+    "group:allNonMajor",
     ":automergeAll"
   ],
   "packageRules": [


### PR DESCRIPTION
removed from github>SocialGouv/renovate-config