### PR TITLE
fix: handle API error on CCN picker

### DIFF
--- a/packages/code-du-travail-frontend/src/conventions/Search/Form.js
+++ b/packages/code-du-travail-frontend/src/conventions/Search/Form.js
@@ -130,7 +130,7 @@ const Search = ({
                   </div>
                 )}
                 {status === "error" && (
-                  <div>La convention collective n&apos;a pas été trouvée.</div>
+                  <div>La convention collective n‘a pas été trouvée.</div>
                 )}
                 {status === "success" && results && results.length !== 0 && (
                   <FixedTable>

--- a/packages/code-du-travail-frontend/src/conventions/Search/Form.js
+++ b/packages/code-du-travail-frontend/src/conventions/Search/Form.js
@@ -130,7 +130,7 @@ const Search = ({
                   </div>
                 )}
                 {status === "error" && (
-                  <div>La convention collective n'a pas été trouvée.</div>
+                  <div>La convention collective n&apos;a pas été trouvée.</div>
                 )}
                 {status === "success" && results && results.length !== 0 && (
                   <FixedTable>

--- a/packages/code-du-travail-frontend/src/conventions/Search/Form.js
+++ b/packages/code-du-travail-frontend/src/conventions/Search/Form.js
@@ -130,7 +130,7 @@ const Search = ({
                   </div>
                 )}
                 {status === "error" && (
-                  <div>Aucun résultat pour votre recherche.</div>
+                  <div>La convention collective n'a pas été trouvée.</div>
                 )}
                 {status === "success" && results && results.length !== 0 && (
                   <FixedTable>

--- a/packages/code-du-travail-frontend/src/conventions/Search/SearchCC.js
+++ b/packages/code-du-travail-frontend/src/conventions/Search/SearchCC.js
@@ -14,14 +14,18 @@ const SearchCC = ({ query, render }) => {
       if (query) {
         setStatus("loading");
         setResults([]);
-        const results = await loadResults(query);
-        if (shouldUpdate) {
-          setResults(results);
-          if (results && results.length) {
-            setStatus("success");
-          } else {
-            setStatus("error");
+        try {
+          const results = await loadResults(query);
+          if (shouldUpdate) {
+            setResults(results);
+            if (results && results.length) {
+              setStatus("success");
+            } else {
+              setStatus("error");
+            }
           }
+        } catch (e) {
+          setStatus("error");
         }
       } else {
         setResults([]);

--- a/packages/code-du-travail-frontend/src/conventions/Search/__tests__/__snapshots__/Search.test.js.snap
+++ b/packages/code-du-travail-frontend/src/conventions/Search/__tests__/__snapshots__/Search.test.js.snap
@@ -692,7 +692,7 @@ exports[`<Search /> should show no results when no result 1`] = `
       class="c4"
     >
       <div>
-        Aucun résultat pour votre recherche.
+        La convention collective n'a pas été trouvée.
       </div>
     </div>
   </div>

--- a/packages/code-du-travail-frontend/src/conventions/Search/__tests__/__snapshots__/Search.test.js.snap
+++ b/packages/code-du-travail-frontend/src/conventions/Search/__tests__/__snapshots__/Search.test.js.snap
@@ -692,7 +692,7 @@ exports[`<Search /> should show no results when no result 1`] = `
       class="c4"
     >
       <div>
-        La convention collective n'a pas été trouvée.
+        La convention collective n‘a pas été trouvée.
       </div>
     </div>
   </div>


### PR DESCRIPTION
When API is down, CCN picker stays in 'loading' mode. this fix display a message when API is unreachable.