### PR TITLE
fix(frontend): fix line-height on agreement  page

### DIFF
--- a/packages/code-du-travail-frontend/src/conventions/Convention/Info.js
+++ b/packages/code-du-travail-frontend/src/conventions/Convention/Info.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import Link from "next/link";
 import styled from "styled-components";
+import { theme } from "@socialgouv/react-ui";
 import { format, parseISO } from "date-fns";
 import { formatIdcc } from "@cdt/data/lib";
 
@@ -21,12 +22,12 @@ const Info = ({ convention: { num, title, date_publi, url } }) => (
         {format(parseISO(date_publi), "dd/MM/yyyy")}
       </Detail>
     )}
-    <p>
+    <p data-no-glossary>
       <a target="_blank" rel="noopener noreferrer nofollow" href={url}>
         Voir la convention sur Légifrance
       </a>
     </p>
-    <p>
+    <p data-no-glossary>
       <Link href="/glossaire/convention-collective" passHref>
         <a target="_blank" rel="noopener noreferrer nofollow">
           Qu’est-ce qu’une convention collective&nbsp;?
@@ -36,8 +37,10 @@ const Info = ({ convention: { num, title, date_publi, url } }) => (
   </React.Fragment>
 );
 
+const { spacings } = theme;
+
 const StyledDetail = styled.div`
-  line-height: 3em;
+  margin-bottom: ${spacings.medium};
 `;
 
 const DetailLabel = styled.div`

--- a/packages/code-du-travail-frontend/src/conventions/Convention/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/code-du-travail-frontend/src/conventions/Convention/__tests__/__snapshots__/index.test.js.snap
@@ -425,7 +425,7 @@ exports[`<Convention /> renders 1`] = `
 }
 
 .c0 {
-  line-height: 3em;
+  margin-bottom: 2rem;
 }
 
 .c1 {
@@ -635,7 +635,9 @@ exports[`<Convention /> renders 1`] = `
     </div>
     01/07/2018
   </div>
-  <p>
+  <p
+    data-no-glossary="true"
+  >
     <a
       href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
       rel="noopener noreferrer nofollow"
@@ -644,7 +646,9 @@ exports[`<Convention /> renders 1`] = `
       Voir la convention sur Légifrance
     </a>
   </p>
-  <p>
+  <p
+    data-no-glossary="true"
+  >
     <a
       href="/glossaire/convention-collective"
       rel="noopener noreferrer nofollow"

--- a/packages/code-du-travail-frontend/src/glossary/index.js
+++ b/packages/code-du-travail-frontend/src/glossary/index.js
@@ -52,7 +52,7 @@ export default function useGlossary(children, html) {
   useEffect(() => {
     const nodes = Array.from(
       document.querySelectorAll(
-        "[data-main-content] p, [data-main-content] li:not([role=tab])"
+        "[data-main-content] p:not([data-no-glossary]), [data-main-content] li:not([role=tab]) "
       )
     ).reduce((state, node) => {
       const internalRefMap = new Map();


### PR DESCRIPTION
- ajout d'un data-no-glossary pour marquer précisément un tag à exclure
- replacement du `line-height` par un `margin-bottom`

fix #2116