### PR TITLE
fix: another stab at #1928

### DIFF
--- a/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/ReferenceList.js
+++ b/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/ReferenceList.js
@@ -4,8 +4,14 @@ import { ArrowLink, FlatList, theme } from "@socialgouv/react-ui";
 import Link from "next/link";
 import TYPE_REFERENCE from "./typeReference";
 
+const sanitizeCdtSlug = slug => slug.replace(/[^LRD\d-]+/gi, "").toLowerCase();
+
 const CodeDuTravailLink = ({ title, slug }) => (
-  <Link href="/code-du-travail/[slug]" as={`/code-du-travail/${slug}`} passHref>
+  <Link
+    href="/code-du-travail/[slug]"
+    as={`/code-du-travail/${sanitizeCdtSlug(slug)}`}
+    passHref
+  >
     <StyledArrowLink arrowPosition="left">{title}</StyledArrowLink>
   </Link>
 );

--- a/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/ReferenceList.js
+++ b/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/ReferenceList.js
@@ -1,15 +1,15 @@
 import React from "react";
 import styled from "styled-components";
-import { ArrowLink, FlatList, theme } from "@socialgouv/react-ui";
 import Link from "next/link";
+import { ArrowLink, FlatList, theme } from "@socialgouv/react-ui";
+import { SOURCES, getRouteBySource } from "@cdt/sources";
 import TYPE_REFERENCE from "./typeReference";
-
 const sanitizeCdtSlug = slug => slug.replace(/[^LRD\d-]+/gi, "").toLowerCase();
 
 const CodeDuTravailLink = ({ title, slug }) => (
   <Link
-    href="/code-du-travail/[slug]"
-    as={`/code-du-travail/${sanitizeCdtSlug(slug)}`}
+    href={`/${getRouteBySource(SOURCES.CDT)}/[slug]`}
+    as={`/${getRouteBySource(SOURCES.CDT)}/${sanitizeCdtSlug(slug)}`}
     passHref
   >
     <StyledArrowLink arrowPosition="left">{title}</StyledArrowLink>
@@ -18,8 +18,8 @@ const CodeDuTravailLink = ({ title, slug }) => (
 
 const ConventionLink = ({ title, slug }) => (
   <Link
-    href="/convention-collective/[slug]"
-    as={`/convention-collective/${slug}`}
+    href={`/${getRouteBySource(SOURCES.CCN)}/[slug]`}
+    as={`/${getRouteBySource(SOURCES.CCN)}/${slug}`}
     passHref
   >
     <StyledArrowLink arrowPosition="left">{`Convention collective: ${title}`}</StyledArrowLink>

--- a/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/__tests__/ReferenceList.test.js
+++ b/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/__tests__/ReferenceList.test.js
@@ -7,7 +7,7 @@ const references = [
   {
     title: "Article xxx du code du travail",
     type: TYPE_REFERENCE.codeDuTravail,
-    id: "xxx"
+    id: "L2323-4"
   },
   {
     title: "Article yyy du JO",
@@ -19,6 +19,11 @@ const references = [
     type: TYPE_REFERENCE.conventionCollective,
     id: "zzz",
     slug: "ma-convention-collective"
+  },
+  {
+    title: "Article zzz de la CC",
+    type: TYPE_REFERENCE.codeDuTravail,
+    id: "R * 3321-2"
   }
 ];
 

--- a/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/__tests__/ReferencesJuridiques.test.js
+++ b/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/__tests__/ReferencesJuridiques.test.js
@@ -12,7 +12,7 @@ const references = [
   {
     title: "Article L1244-4 du code du travail",
     type: TYPE_REFERENCE.codeDuTravail,
-    id: "l1244-4"
+    id: "r*1244-4"
   },
   {
     title: "Article L3121-44 du JO",

--- a/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/__tests__/__snapshots__/ReferenceList.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/__tests__/__snapshots__/ReferenceList.test.js.snap
@@ -58,7 +58,7 @@ exports[`<ReferenceList /> should render 1`] = `
     <li>
       <a
         class="c1 c2 c3"
-        href="/code-du-travail/xxx"
+        href="/code-du-travail/L2323-4"
       >
         <svg
           class="c4"
@@ -119,6 +119,28 @@ exports[`<ReferenceList /> should render 1`] = `
           class="c5"
         >
           Convention collective: Article zzz de la CC
+        </span>
+      </a>
+    </li>
+    <li>
+      <a
+        class="c1 c2 c3"
+        href="/code-du-travail/R3321-2"
+      >
+        <svg
+          class="c4"
+          fill="none"
+          viewBox="0 0 28 15"
+        >
+          <path
+            d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
+            fill="currentColor"
+          />
+        </svg>
+        <span
+          class="c5"
+        >
+          Article zzz de la CC
         </span>
       </a>
     </li>

--- a/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/__tests__/__snapshots__/ReferenceList.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/__tests__/__snapshots__/ReferenceList.test.js.snap
@@ -58,7 +58,7 @@ exports[`<ReferenceList /> should render 1`] = `
     <li>
       <a
         class="c1 c2 c3"
-        href="/code-du-travail/L2323-4"
+        href="/code-du-travail/l2323-4"
       >
         <svg
           class="c4"
@@ -125,7 +125,7 @@ exports[`<ReferenceList /> should render 1`] = `
     <li>
       <a
         class="c1 c2 c3"
-        href="/code-du-travail/R3321-2"
+        href="/code-du-travail/r3321-2"
       >
         <svg
           class="c4"

--- a/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/__tests__/__snapshots__/ReferencesJuridiques.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/__tests__/__snapshots__/ReferencesJuridiques.test.js.snap
@@ -306,7 +306,7 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
                 <li>
                   <a
                     class="c11 c12 c13"
-                    href="/code-du-travail/l1244-4"
+                    href="/code-du-travail/r1244-4"
                   >
                     <svg
                       class="c14"

--- a/packages/code-du-travail-frontend/src/lib/__tests__/__snapshots__/replaceArticlesRefs.test.js.snap
+++ b/packages/code-du-travail-frontend/src/lib/__tests__/__snapshots__/replaceArticlesRefs.test.js.snap
@@ -1,11 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`replaceArticlesRefs Should NOT replace L2213-2 in text 1`] = `"Some content with linke to L2213-2"`;
+exports[`replaceArticlesRefs Should NOT replace raw L2213-2 in text 1`] = `"Some content with link to L2213-2"`;
 
-exports[`replaceArticlesRefs Should replace L2213-2 link in HTML 1`] = `"Some content with links to <a href=\\"/code-du-travail/l2213-2\\">Article L2213-2</a>."`;
+exports[`replaceArticlesRefs Should replace L. 1242-2 links in HTML 1`] = `"Some content and a link to <a href=\\"/code-du-travail/l1242-2\\">L. 1242-2</a> and some other one <a href=\\"/code-du-travail/l1242-2\\">L. 1242-2</a> and other stuff."`;
 
-exports[`replaceArticlesRefs Should replace l'Article L2213-2 links in HTML 1`] = `"Some content with links to <a href=\\"/code-du-travail/l2213-2\\">l'Article L2213-2</a>."`;
+exports[`replaceArticlesRefs Should replace L2213-2 links in HTML 1`] = `"Some content and a link to <a href=\\"/code-du-travail/l2213-2\\">L2213-2</a> and some other one <a href=\\"/code-du-travail/l2213-2\\">L2213-2</a> and other stuff."`;
 
-exports[`replaceArticlesRefs Should replace l'article L. 1242-2 link in HTML 1`] = `"Some content with links to <a href=\\"/code-du-travail/l1242-2\\">l'article L. 1242-2</a>."`;
+exports[`replaceArticlesRefs Should replace article R. * 3231-2. links in HTML 1`] = `"Some content and a link to <a href=\\"/code-du-travail/r3231-2\\">article R. * 3231-2</a> and some other one <a href=\\"/code-du-travail/r3231-2\\">article R. * 3231-2</a> and other stuff."`;
 
-exports[`replaceArticlesRefs Should replace multiple articles links in HTML 1`] = `"Some content with links to <a href=\\"/code-du-travail/l2213-2\\">Article L2213-2</a> and <a href=\\"/code-du-travail/l2312-1\\">L.2312-1</a>"`;
+exports[`replaceArticlesRefs Should replace article R-3231-2 links in HTML 1`] = `"Some content and a link to <a href=\\"/code-du-travail/r3231-2\\">article R-3231-2</a> and some other one <a href=\\"/code-du-travail/r3231-2\\">article R-3231-2</a> and other stuff."`;
+
+exports[`replaceArticlesRefs Should replace l'Article L2213-2 links in HTML 1`] = `"Some content and a link to <a href=\\"/code-du-travail/l2213-2\\">l'Article L2213-2</a> and some other one <a href=\\"/code-du-travail/l2213-2\\">l'Article L2213-2</a> and other stuff."`;

--- a/packages/code-du-travail-frontend/src/lib/__tests__/replaceArticlesRefs.test.js
+++ b/packages/code-du-travail-frontend/src/lib/__tests__/replaceArticlesRefs.test.js
@@ -1,24 +1,22 @@
 import { replaceArticlesRefs } from "../replaceArticlesRefs";
 
+const cases = [
+  "L2213-2",
+  "L. 1242-2",
+  "l'Article L2213-2",
+  "article R. * 3231-2.",
+  "article R-3231-2"
+];
+
 describe("replaceArticlesRefs", () => {
-  test("Should NOT replace L2213-2 in text", () => {
-    const html = `Some content with linke to L2213-2`;
+  test("Should NOT replace raw L2213-2 in text", () => {
+    const html = `Some content with link to L2213-2`;
     expect(replaceArticlesRefs(html)).toMatchSnapshot();
   });
-  test("Should replace L2213-2 link in HTML", () => {
-    const html = `Some content with links to <a href="#1">Article L2213-2</a>.`;
-    expect(replaceArticlesRefs(html)).toMatchSnapshot();
-  });
-  test("Should replace l'article L. 1242-2 link in HTML", () => {
-    const html = `Some content with links to <a href="#1">l'article L. 1242-2</a>.`;
-    expect(replaceArticlesRefs(html)).toMatchSnapshot();
-  });
-  test("Should replace l'Article L2213-2 links in HTML", () => {
-    const html = `Some content with links to <a href="#1">l'Article L2213-2</a>.`;
-    expect(replaceArticlesRefs(html)).toMatchSnapshot();
-  });
-  test("Should replace multiple articles links in HTML", () => {
-    const html = `Some content with links to <a href="#1">Article L2213-2</a> and <a href="#2">L.2312-1</a>`;
-    expect(replaceArticlesRefs(html)).toMatchSnapshot();
+  cases.forEach(t => {
+    test(`Should replace ${t} links in HTML`, () => {
+      const html = `Some content and a link to <a href="#whatever">${t}</a> and some other one <a href="#whatelse">${t}</a> and other stuff.`;
+      expect(replaceArticlesRefs(html)).toMatchSnapshot();
+    });
   });
 });

--- a/packages/code-du-travail-frontend/src/lib/replaceArticlesRefs.js
+++ b/packages/code-du-travail-frontend/src/lib/replaceArticlesRefs.js
@@ -1,7 +1,7 @@
 // assume we only have code-du-travail articles
 
 // match basic article references
-const RE_ARTICLE_NUM = /<a[^>]+>(((l' *)?article )?([LRD])[\s-.]*([\d-]+))\s*<\/a>/gim;
+const RE_ARTICLE_NUM = /<a[^>]+>(((l' *)?article )?([LRD])[\s-.*]*([\d-]+))[\s.]*<\/a>/gim;
 //(?:article )?
 
 // fix single articles reference


### PR DESCRIPTION
On a apparemment dans les données du CDT des `article.num` un peu plus exotiques que prévu côté DILA, ex : `R*1233-3-4`

cette PR ajoute le support de ce format pour les liens des refs juridiques et les liens dans les articles de code

ref #1928