### PR TITLE
fix: change h2 to h3 in à propos page

### DIFF
--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/a-propos.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/a-propos.test.js.snap
@@ -1328,18 +1328,11 @@ exports[`<About /> should render 1`] = `
             </a>
             .
           </p>
-          <header
-            class="c25 c26"
+          <h3
+            class="c29"
           >
-            <h2
-              class="c27"
-            >
-              <div
-                class="c28"
-              />
-              Notre méthode
-            </h2>
-          </header>
+            Nos méthodes
+          </h3>
           <p>
             Le service est développé en lien étroit avec les utilisateurs (employeurs et salariés) et les praticiens du droit du travail (services du ministère du Travail en région, conseillers du salarié, maisons d’accès au droit, professeurs en droit du travail...).
           </p>

--- a/packages/code-du-travail-frontend/pages/a-propos.js
+++ b/packages/code-du-travail-frontend/pages/a-propos.js
@@ -125,7 +125,7 @@ const About = ({ ogImage, pageUrl }) => (
             </a>
             .
           </p>
-          <StyledTitle shift={theme.spacings.larger}>Notre méthode</StyledTitle>
+          <Heading>Nos méthodes</Heading>
           <p>
             Le service est développé en lien étroit avec les utilisateurs
             (employeurs et salariés) et les praticiens du droit du travail


### PR DESCRIPTION
change h2 to h3 and use plural to make it coherent with the subtitle of the page ("Apprenez-en plus sur notre histoire, notre équipe et nos méthodes")