### PR TITLE
fix: wrong url in intro step IDL tool

### DIFF
--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/__tests__/__snapshots__/index.test.js.snap
@@ -476,7 +476,7 @@ exports[`<CalculateurIndemnite /> should render 1`] = `
         Pour en savoir plus sur l’indemnité de licenciement et son mode de calcul, consultez
          
         <a
-          href="/fiche-service-public/indemnite-de-licenciement"
+          href="/fiche-service-public/indemnite-de-licenciement-du-salarie-en-cdi"
         >
           cet article
         </a>

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/Introduction.js
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/Introduction.js
@@ -24,7 +24,7 @@ const StepIntro = () => (
       consultez{" "}
       <Link
         href="/fiche-service-public/[slug]"
-        as={`/fiche-service-public/indemnite-de-licenciement`}
+        as={`/fiche-service-public/indemnite-de-licenciement-du-salarie-en-cdi`}
       >
         <a>cet article</a>
       </Link>

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/__tests__/__snapshots__/Introduction.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/__tests__/__snapshots__/Introduction.test.js.snap
@@ -12,7 +12,7 @@ exports[`<StepIntro /> should render 1`] = `
     Pour en savoir plus sur l’indemnité de licenciement et son mode de calcul, consultez
      
     <a
-      href="/fiche-service-public/indemnite-de-licenciement"
+      href="/fiche-service-public/indemnite-de-licenciement-du-salarie-en-cdi"
     >
       cet article
     </a>


### PR DESCRIPTION
aujourd'hui le lien "cet article" renvoit vers une 404 dans cette page : 
https://code.travail.gouv.fr/outils/indemnite-licenciement