### PR TITLE
feat(rgpd): add matomo iframe

### DIFF
--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/politique-confidentialite.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/politique-confidentialite.test.js.snap
@@ -1328,7 +1328,7 @@ exports[`<CookiePolicy /> should render 1`] = `
             À tout moment, vous pouvez refuser l’utilisation des cookies et désactiver le dépôt sur votre ordinateur en utilisant la fonction dédiée de votre navigateur (fonction disponible notamment sur Microsoft Internet Explorer 11, Google Chrome, Mozilla Firefox, Apple Safari et Opera).
           </p>
           <p>
-            Pour l'outil Matomo, vous pouvez décider de ne jamais être suivi, y compris anonymement :
+            Pour l'outil Matomo, vous pouvez décider de ne jamais être suivi, y compris anonymement&nbsp;:
           </p>
           <iframe
             src="https://matomo.fabrique.social.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr&backgroundColor=&fontColor=&fontSize=&fontFamily="

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/politique-confidentialite.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/politique-confidentialite.test.js.snap
@@ -1328,7 +1328,7 @@ exports[`<CookiePolicy /> should render 1`] = `
             À tout moment, vous pouvez refuser l’utilisation des cookies et désactiver le dépôt sur votre ordinateur en utilisant la fonction dédiée de votre navigateur (fonction disponible notamment sur Microsoft Internet Explorer 11, Google Chrome, Mozilla Firefox, Apple Safari et Opera).
           </p>
           <p>
-            Pour l'outil Matomo, vous pouvez décider de ne jamais être suivi, y compris anonymement&nbsp;:
+            Pour l'outil Matomo, vous pouvez décider de ne jamais être suivi, y compris anonymement :
           </p>
           <iframe
             src="https://matomo.fabrique.social.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr&backgroundColor=&fontColor=&fontSize=&fontFamily="

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/politique-confidentialite.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/politique-confidentialite.test.js.snap
@@ -1331,7 +1331,7 @@ exports[`<CookiePolicy /> should render 1`] = `
             Pour l'outil Matomo, vous pouvez décider de ne jamais être suivi, y compris anonymement :
           </p>
           <iframe
-            src="https://matomo.fabrique.social.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr&backgroundColor=&fontColor=&fontSize=&fontFamily="
+            src="https://matomo.fabrique.social.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr&backgroundColor=&fontColor=2f3b6c&fontSize=16px&fontFamily=sans-serif"
             style="border: 0px; width: 100%;"
             title="matomo optout"
           />

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/politique-confidentialite.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/politique-confidentialite.test.js.snap
@@ -1328,6 +1328,14 @@ exports[`<CookiePolicy /> should render 1`] = `
             À tout moment, vous pouvez refuser l’utilisation des cookies et désactiver le dépôt sur votre ordinateur en utilisant la fonction dédiée de votre navigateur (fonction disponible notamment sur Microsoft Internet Explorer 11, Google Chrome, Mozilla Firefox, Apple Safari et Opera).
           </p>
           <p>
+            Pour l'outil Matomo, vous pouvez décider de ne jamais être suivi, y compris anonymement :
+          </p>
+          <iframe
+            src="https://matomo.fabrique.social.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr&backgroundColor=&fontColor=&fontSize=&fontFamily="
+            style="border: 0px; width: 100%;"
+            title="matomo optout"
+          />
+          <p>
             Pour aller plus loin, vous pouvez consulter les fiches proposées par la Commission Nationale de l’Informatique et des Libertés (CNIL) :
           </p>
           <ul>

--- a/packages/code-du-travail-frontend/pages/politique-confidentialite.js
+++ b/packages/code-du-travail-frontend/pages/politique-confidentialite.js
@@ -153,7 +153,7 @@ const CookiePolicy = ({ pageUrl, ogImage }) => {
             </p>
             <p>
               Pour l&apos;outil Matomo, vous pouvez décider de ne jamais être
-              suivi, y compris anonymement :
+              suivi, y compris anonymement&nbsp;:
             </p>
             <iframe
               title="matomo optout"

--- a/packages/code-du-travail-frontend/pages/politique-confidentialite.js
+++ b/packages/code-du-travail-frontend/pages/politique-confidentialite.js
@@ -152,6 +152,16 @@ const CookiePolicy = ({ pageUrl, ogImage }) => {
               Apple Safari et Opera).
             </p>
             <p>
+              Pour l&apos;outil Matomo, vous pouvez décider de ne jamais être
+              suivi, y compris anonymement :
+            </p>
+            <iframe
+              title="matomo optout"
+              style={{ border: 0, width: "100%" }}
+              src="https://matomo.fabrique.social.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr&backgroundColor=&fontColor=&fontSize=&fontFamily="
+            ></iframe>
+
+            <p>
               Pour aller plus loin, vous pouvez consulter les fiches proposées
               par la Commission Nationale de l’Informatique et des Libertés
               (CNIL)&nbsp;:

--- a/packages/code-du-travail-frontend/pages/politique-confidentialite.js
+++ b/packages/code-du-travail-frontend/pages/politique-confidentialite.js
@@ -158,7 +158,7 @@ const CookiePolicy = ({ pageUrl, ogImage }) => {
             <iframe
               title="matomo optout"
               style={{ border: 0, width: "100%" }}
-              src="https://matomo.fabrique.social.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr&backgroundColor=&fontColor=&fontSize=&fontFamily="
+              src="https://matomo.fabrique.social.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr&backgroundColor=&fontColor=2f3b6c&fontSize=16px&fontFamily=sans-serif"
             ></iframe>
 
             <p>

--- a/packages/code-du-travail-frontend/src/search/SearchBar/index.js
+++ b/packages/code-du-travail-frontend/src/search/SearchBar/index.js
@@ -32,7 +32,7 @@ const SearchBar = ({
       router.push({
         pathname: "/recherche",
         query: {
-          q: encodeURIComponent(query)
+          q: query
         }
       });
     }

--- a/packages/code-du-travail-nlp/requirements.txt
+++ b/packages/code-du-travail-nlp/requirements.txt
@@ -1,7 +1,7 @@
 Flask==1.1.1
 flask-cors==3.0.8
 gunicorn==20.0.4
-tensorflow==2.0.0
+tensorflow==2.0.1
 tensorflow_text>=2.0.1
 tensorflow_hub
 gevent


### PR DESCRIPTION
Ajout iframe Matomo dans politique de confidentialité

cc @ThomasMenant 

Par contre c'est pas très beau car l'iframe est complètement styleless

<img width="688" alt="Capture d’écran 2020-01-28 à 15 21 30" src="https://user-images.githubusercontent.com/124937/73272965-856b3a00-41e3-11ea-93a2-27cdae6d9ac3.png">
