### PR TITLE
fix: remove useless query escaping

### DIFF
--- a/packages/code-du-travail-frontend/src/search/SearchBar/index.js
+++ b/packages/code-du-travail-frontend/src/search/SearchBar/index.js
@@ -32,7 +32,7 @@ const SearchBar = ({
       router.push({
         pathname: "/recherche",
         query: {
-          q: encodeURIComponent(query)
+          q: query
         }
       });
     }


### PR DESCRIPTION
We dont need to URI encode parameters passed to the router