### PR TITLE
feat(front): ui improvements

### DIFF
--- a/packages/code-du-travail-api/src/server/routes/__tests__/__snapshots__/items.test.js.snap
+++ b/packages/code-du-travail-api/src/server/routes/__tests__/__snapshots__/items.test.js.snap
@@ -638,20 +638,6 @@ Object {
       "source": "outils",
       "title": "Préavis de démission",
     },
-    Object {
-      "description": "La rupture conventionnelle individuelle est une modalité de rupture spécifique du CDI. Elle nécessite le consentement de l’employeur et du salarié, et son homologation par l’administration. La rupture ouvre droit à une indemnité de rupture conventionnelle. Ce modèle permet d’initier la procédure de rupture par l’invitation à un premier entretien.",
-      "slug": "demande-de-rendez-vous-en-vue-dune-rupture-conventionnelle",
-      "source": "modeles_de_courriers",
-      "title": "Demande de rendez-vous en vue d’une rupture conventionnelle",
-    },
-    Object {
-      "action": "Estimer",
-      "description": "Estimez le montant de l’indemnité de licenciement",
-      "icon": "Indemnity",
-      "slug": "indemnite-licenciement",
-      "source": "outils",
-      "title": "Indemnité de licenciement",
-    },
   ],
 }
 `;

--- a/packages/code-du-travail-api/src/server/routes/__tests__/__snapshots__/items.test.js.snap
+++ b/packages/code-du-travail-api/src/server/routes/__tests__/__snapshots__/items.test.js.snap
@@ -638,6 +638,20 @@ Object {
       "source": "outils",
       "title": "Préavis de démission",
     },
+    Object {
+      "description": "La rupture conventionnelle individuelle est une modalité de rupture spécifique du CDI. Elle nécessite le consentement de l’employeur et du salarié, et son homologation par l’administration. La rupture ouvre droit à une indemnité de rupture conventionnelle. Ce modèle permet d’initier la procédure de rupture par l’invitation à un premier entretien.",
+      "slug": "demande-de-rendez-vous-en-vue-dune-rupture-conventionnelle",
+      "source": "modeles_de_courriers",
+      "title": "Demande de rendez-vous en vue d’une rupture conventionnelle",
+    },
+    Object {
+      "action": "Estimer",
+      "description": "Estimez le montant de l’indemnité de licenciement",
+      "icon": "Indemnity",
+      "slug": "indemnite-licenciement",
+      "source": "outils",
+      "title": "Indemnité de licenciement",
+    },
   ],
 }
 `;

--- a/packages/code-du-travail-api/src/server/routes/__tests__/__snapshots__/sheets-mt.test.js.snap
+++ b/packages/code-du-travail-api/src/server/routes/__tests__/__snapshots__/sheets-mt.test.js.snap
@@ -119,21 +119,6 @@ Si l’avis d’inaptitude mentionne expressément que tout maintien du salarié
       "title": "Démission d'une assistante maternelle",
       "url": "https://www.service-public.fr/particuliers/vosdroits/F33164",
     },
-    Object {
-      "description": "La rupture conventionnelle individuelle est une modalité de rupture spécifique du CDI. Elle nécessite le consentement de l’employeur et du salarié, et son homologation par l’administration. La rupture ouvre droit à une indemnité de rupture conventionnelle. Ce modèle permet d’initier la procédure de rupture par l’invitation à un premier entretien.",
-      "slug": "demande-de-rendez-vous-en-vue-dune-rupture-conventionnelle",
-      "source": "modeles_de_courriers",
-      "title": "Demande de rendez-vous en vue d’une rupture conventionnelle",
-    },
-    Object {
-      "action": "Consulter",
-      "description": "Consulter et utiliser ses droits pour la formation",
-      "icon": "Formation",
-      "slug": "mon-compte-formation",
-      "source": "external",
-      "title": "Mon compte formation",
-      "url": "https://www.moncompteformation.gouv.fr",
-    },
   ],
 }
 `;

--- a/packages/code-du-travail-api/src/server/routes/__tests__/__snapshots__/sheets-mt.test.js.snap
+++ b/packages/code-du-travail-api/src/server/routes/__tests__/__snapshots__/sheets-mt.test.js.snap
@@ -119,6 +119,21 @@ Si l’avis d’inaptitude mentionne expressément que tout maintien du salarié
       "title": "Démission d'une assistante maternelle",
       "url": "https://www.service-public.fr/particuliers/vosdroits/F33164",
     },
+    Object {
+      "description": "La rupture conventionnelle individuelle est une modalité de rupture spécifique du CDI. Elle nécessite le consentement de l’employeur et du salarié, et son homologation par l’administration. La rupture ouvre droit à une indemnité de rupture conventionnelle. Ce modèle permet d’initier la procédure de rupture par l’invitation à un premier entretien.",
+      "slug": "demande-de-rendez-vous-en-vue-dune-rupture-conventionnelle",
+      "source": "modeles_de_courriers",
+      "title": "Demande de rendez-vous en vue d’une rupture conventionnelle",
+    },
+    Object {
+      "action": "Consulter",
+      "description": "Consulter et utiliser ses droits pour la formation",
+      "icon": "Formation",
+      "slug": "mon-compte-formation",
+      "source": "external",
+      "title": "Mon compte formation",
+      "url": "https://www.moncompteformation.gouv.fr",
+    },
   ],
 }
 `;

--- a/packages/code-du-travail-api/src/server/routes/items/getRelatedItems.js
+++ b/packages/code-du-travail-api/src/server/routes/items/getRelatedItems.js
@@ -8,7 +8,7 @@ const utils = require("../search/utils");
 const getRelatedItemsBody = require("./relatedItems.elastic");
 const { logger } = require("../../utils/logger");
 
-const MAX_RESULTS = 5;
+const MAX_RESULTS = 7;
 
 const ES_INDEX_PREFIX = process.env.ES_INDEX_PREFIX || "cdtn";
 const index = `${ES_INDEX_PREFIX}_${DOCUMENTS}`;
@@ -16,7 +16,6 @@ const index = `${ES_INDEX_PREFIX}_${DOCUMENTS}`;
 const NLP_URL = process.env.NLP_URL || "http://localhost:5000";
 
 async function getRelatedItems({ title, settings, slug }) {
-  const size = MAX_RESULTS;
   const sources = [
     SOURCES.TOOLS,
     SOURCES.SHEET_SP,
@@ -38,7 +37,7 @@ async function getRelatedItems({ title, settings, slug }) {
   const semBody = getSemBody({
     query_vector,
     // we +1 the size to remove the document source that should match perfectly for the given vector
-    size: size + 1,
+    size: MAX_RESULTS + 1,
     sources
   });
   // we use relatedItem query _source to have the same prop returned

--- a/packages/code-du-travail-api/src/server/routes/items/getRelatedItems.js
+++ b/packages/code-du-travail-api/src/server/routes/items/getRelatedItems.js
@@ -8,7 +8,7 @@ const utils = require("../search/utils");
 const getRelatedItemsBody = require("./relatedItems.elastic");
 const { logger } = require("../../utils/logger");
 
-const MAX_RESULTS = 7;
+const MAX_RESULTS = 5;
 
 const ES_INDEX_PREFIX = process.env.ES_INDEX_PREFIX || "cdtn";
 const index = `${ES_INDEX_PREFIX}_${DOCUMENTS}`;

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/a-propos.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/a-propos.test.js.snap
@@ -677,6 +677,12 @@ exports[`<About /> should render 1`] = `
 }
 
 @media (max-width:600px) {
+  .c19 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c25 {
     padding: 1.6rem 1rem;
   }

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/code-du-travail.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/code-du-travail.test.js.snap
@@ -760,6 +760,12 @@ exports[`<CodeDuTravail /> should render 1`] = `
 }
 
 @media (max-width:600px) {
+  .c23 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c16 {
     font-size: 1.4rem;
   }
@@ -843,7 +849,6 @@ exports[`<CodeDuTravail /> should render 1`] = `
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
     align-items: stretch;
-    max-width: 60rem;
     margin-right: auto;
     margin-left: auto;
   }

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/contribution.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/contribution.test.js.snap
@@ -1166,6 +1166,12 @@ exports[`<FicheContribution /> should render with external content 1`] = `
 }
 
 @media (max-width:600px) {
+  .c48 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c30 {
     padding: 1.6rem 1rem;
   }
@@ -1395,7 +1401,6 @@ exports[`<FicheContribution /> should render with external content 1`] = `
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
     align-items: stretch;
-    max-width: 60rem;
     margin-right: auto;
     margin-left: auto;
   }
@@ -3901,6 +3906,12 @@ exports[`<FicheContribution /> should render without external content 1`] = `
 }
 
 @media (max-width:600px) {
+  .c48 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c30 {
     padding: 1.6rem 1rem;
   }
@@ -4130,7 +4141,6 @@ exports[`<FicheContribution /> should render without external content 1`] = `
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
     align-items: stretch;
-    max-width: 60rem;
     margin-right: auto;
     margin-left: auto;
   }

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/convention-collective.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/convention-collective.test.js.snap
@@ -226,6 +226,12 @@ exports[`<ConventionCollective /> should render 1`] = `
 }
 
 @media (max-width:600px) {
+  .c4 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c11 {
     font-size: 1.4rem;
   }
@@ -272,7 +278,6 @@ exports[`<ConventionCollective /> should render 1`] = `
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
     align-items: stretch;
-    max-width: 60rem;
     margin-right: auto;
     margin-left: auto;
   }

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/droit-du-travail.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/droit-du-travail.test.js.snap
@@ -1508,6 +1508,12 @@ exports[`<DroitDuTravail /> should render 1`] = `
 }
 
 @media (max-width:600px) {
+  .c20 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c39 {
     right: 2rem;
   }

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/fiche-ministere-travail.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/fiche-ministere-travail.test.js.snap
@@ -1042,6 +1042,12 @@ exports[`<FicheMT /> should render 1`] = `
 }
 
 @media (max-width:600px) {
+  .c48 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c30 {
     padding: 1.6rem 1rem;
   }
@@ -1206,7 +1212,6 @@ exports[`<FicheMT /> should render 1`] = `
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
     align-items: stretch;
-    max-width: 60rem;
     margin-right: auto;
     margin-left: auto;
   }

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/fiche-service-public.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/fiche-service-public.test.js.snap
@@ -760,6 +760,12 @@ exports[`<FicheSP /> should render 1`] = `
 }
 
 @media (max-width:600px) {
+  .c23 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c16 {
     font-size: 1.4rem;
   }
@@ -843,7 +849,6 @@ exports[`<FicheSP /> should render 1`] = `
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
     align-items: stretch;
-    max-width: 60rem;
     margin-right: auto;
     margin-left: auto;
   }

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire-[slug].test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire-[slug].test.js.snap
@@ -700,6 +700,12 @@ exports[`<Term /> should render 1`] = `
 }
 
 @media (max-width:600px) {
+  .c19 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c24 {
     padding: 1.6rem 1rem;
   }

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire.test.js.snap
@@ -680,6 +680,12 @@ exports[`<Glossaire /> should render 1`] = `
 }
 
 @media (max-width:600px) {
+  .c19 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c25 {
     padding: 1.6rem 1rem;
   }

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/index.test.js.snap
@@ -302,12 +302,12 @@ exports[`<Home /> should render 1`] = `
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
+  margin: 1rem;
+  padding: 0;
+  width: calc(100% / 4 - 2 * 1rem - 1px);
   -webkit-flex-shrink: 1;
   -ms-flex-negative: 1;
   flex-shrink: 1;
-  width: calc(100% / 4 - 2 * 1rem - 1px);
-  margin: 1rem;
-  padding: 0;
 }
 
 .c34 {
@@ -957,6 +957,12 @@ exports[`<Home /> should render 1`] = `
   .c31 {
     max-width: 100%;
     padding: 0;
+  }
+}
+
+@media (max-width:600px) {
+  .c11 {
+    padding: 2.4rem 0;
   }
 }
 

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/index.test.js.snap
@@ -302,12 +302,12 @@ exports[`<Home /> should render 1`] = `
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  margin: 1rem;
-  padding: 0;
-  width: calc(100% / 4 - 2 * 1rem - 1px);
   -webkit-flex-shrink: 1;
   -ms-flex-negative: 1;
   flex-shrink: 1;
+  margin: 1rem;
+  padding: 0;
+  width: calc(100% / 4 - 2 * 1rem - 1px);
 }
 
 .c34 {
@@ -1032,6 +1032,27 @@ exports[`<Home /> should render 1`] = `
   }
 }
 
+@media (max-width:600px) {
+  .c40 {
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    min-width: 23rem;
+  }
+
+  .c40:first-of-type {
+    margin-left: 2rem;
+  }
+
+  .c40:last-of-type:after {
+    display: block;
+    width: 2rem;
+    height: 100%;
+    background-color: transparent;
+    content: "";
+  }
+}
+
 @media (max-width:1180px) {
   .c40 {
     width: calc( 100% / 3 - 2 * 1rem - 1px );
@@ -1046,23 +1067,7 @@ exports[`<Home /> should render 1`] = `
 
 @media (max-width:600px) {
   .c40 {
-    -webkit-flex-shrink: 0;
-    -ms-flex-negative: 0;
-    flex-shrink: 0;
     width: 60%;
-    min-width: 23rem;
-  }
-
-  .c40:first-of-type {
-    margin-left: 2rem;
-  }
-
-  .c40:last-of-type:after {
-    display: block;
-    width: 2rem;
-    height: 100%;
-    background-color: transparent;
-    content: "";
   }
 }
 

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/mentions-legales.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/mentions-legales.test.js.snap
@@ -693,6 +693,12 @@ exports[`<MentionLegales /> should render 1`] = `
 }
 
 @media (max-width:600px) {
+  .c19 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c24 {
     padding: 1.6rem 1rem;
   }

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers-[slug].test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers-[slug].test.js.snap
@@ -1172,6 +1172,12 @@ exports[`<ModelesDeCourrier /> should render 1`] = `
 }
 
 @media (max-width:600px) {
+  .c41 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c30 {
     padding: 1.6rem 1rem;
   }
@@ -1342,7 +1348,6 @@ exports[`<ModelesDeCourrier /> should render 1`] = `
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
     align-items: stretch;
-    max-width: 60rem;
     margin-right: auto;
     margin-left: auto;
   }
@@ -2111,7 +2116,7 @@ exports[`<ModelesDeCourrier /> should render 1`] = `
                     class="c43"
                   >
                     <a
-                      class="c44"
+                      class="c44 no-after"
                       href="api.url/docs/filename.pdf"
                     >
                       <svg
@@ -2156,7 +2161,7 @@ exports[`<ModelesDeCourrier /> should render 1`] = `
                 class="c49"
               >
                 <a
-                  class="c50"
+                  class="c50 no-after"
                   href="api.url/docs/filename.pdf"
                 >
                   Télécharger le modèle (pdf - 12.35Ko)  

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers.test.js.snap
@@ -817,6 +817,12 @@ exports[`<ModelesDeCourriers /> should render 1`] = `
 }
 
 @media (max-width:600px) {
+  .c19 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c16 {
     font-size: 1.4rem;
   }

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/outils.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/outils.test.js.snap
@@ -302,12 +302,12 @@ exports[`<Outils /> should render 1`] = `
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  margin: 1rem;
-  padding: 0;
-  width: calc(100% / 4 - 2 * 1rem - 1px);
   -webkit-flex-shrink: 1;
   -ms-flex-negative: 1;
   flex-shrink: 1;
+  margin: 1rem;
+  padding: 0;
+  width: calc(100% / 4 - 2 * 1rem - 1px);
 }
 
 .c25 {
@@ -962,6 +962,27 @@ exports[`<Outils /> should render 1`] = `
   }
 }
 
+@media (max-width:600px) {
+  .c30 {
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    min-width: 23rem;
+  }
+
+  .c30:first-of-type {
+    margin-left: 2rem;
+  }
+
+  .c30:last-of-type:after {
+    display: block;
+    width: 2rem;
+    height: 100%;
+    background-color: transparent;
+    content: "";
+  }
+}
+
 @media (max-width:1180px) {
   .c30 {
     width: calc( 100% / 3 - 2 * 1rem - 1px );
@@ -976,23 +997,7 @@ exports[`<Outils /> should render 1`] = `
 
 @media (max-width:600px) {
   .c30 {
-    -webkit-flex-shrink: 0;
-    -ms-flex-negative: 0;
-    flex-shrink: 0;
     width: 60%;
-    min-width: 23rem;
-  }
-
-  .c30:first-of-type {
-    margin-left: 2rem;
-  }
-
-  .c30:last-of-type:after {
-    display: block;
-    width: 2rem;
-    height: 100%;
-    background-color: transparent;
-    content: "";
   }
 }
 

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/outils.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/outils.test.js.snap
@@ -302,12 +302,12 @@ exports[`<Outils /> should render 1`] = `
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
+  margin: 1rem;
+  padding: 0;
+  width: calc(100% / 4 - 2 * 1rem - 1px);
   -webkit-flex-shrink: 1;
   -ms-flex-negative: 1;
   flex-shrink: 1;
-  width: calc(100% / 4 - 2 * 1rem - 1px);
-  margin: 1rem;
-  padding: 0;
 }
 
 .c25 {
@@ -893,6 +893,12 @@ exports[`<Outils /> should render 1`] = `
   .c22 {
     max-width: 100%;
     padding: 0;
+  }
+}
+
+@media (max-width:600px) {
+  .c21 {
+    padding: 2.4rem 0;
   }
 }
 

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/politique-confidentialite.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/politique-confidentialite.test.js.snap
@@ -666,6 +666,12 @@ exports[`<CookiePolicy /> should render 1`] = `
 }
 
 @media (max-width:600px) {
+  .c19 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c24 {
     padding: 1.6rem 1rem;
   }

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/recherche.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/recherche.test.js.snap
@@ -705,6 +705,12 @@ exports[`<Recherche /> should render 1`] = `
 }
 
 @media (max-width:600px) {
+  .c22 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c19 {
     font-size: 1.4rem;
   }

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/stats.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/stats.test.js.snap
@@ -238,12 +238,12 @@ exports[`<Stats /> should render 1`] = `
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  margin: 1rem;
-  padding: 0;
-  width: calc(100% / 3 - 2 * 1rem - 1px);
   -webkit-flex-shrink: 1;
   -ms-flex-negative: 1;
   flex-shrink: 1;
+  margin: 1rem;
+  padding: 0;
+  width: calc(100% / 3 - 2 * 1rem - 1px);
 }
 
 .c23 {
@@ -804,6 +804,27 @@ exports[`<Stats /> should render 1`] = `
   }
 }
 
+@media (max-width:600px) {
+  .c29 {
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    min-width: 23rem;
+  }
+
+  .c29:first-of-type {
+    margin-left: 2rem;
+  }
+
+  .c29:last-of-type:after {
+    display: block;
+    width: 2rem;
+    height: 100%;
+    background-color: transparent;
+    content: "";
+  }
+}
+
 @media (max-width:1180px) {
   .c29 {
     width: calc( 100% / 2 - 2 * 1rem - 1px );
@@ -818,23 +839,7 @@ exports[`<Stats /> should render 1`] = `
 
 @media (max-width:600px) {
   .c29 {
-    -webkit-flex-shrink: 0;
-    -ms-flex-negative: 0;
-    flex-shrink: 0;
     width: 80%;
-    min-width: 23rem;
-  }
-
-  .c29:first-of-type {
-    margin-left: 2rem;
-  }
-
-  .c29:last-of-type:after {
-    display: block;
-    width: 2rem;
-    height: 100%;
-    background-color: transparent;
-    content: "";
   }
 }
 

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/stats.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/stats.test.js.snap
@@ -238,12 +238,12 @@ exports[`<Stats /> should render 1`] = `
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
+  margin: 1rem;
+  padding: 0;
+  width: calc(100% / 3 - 2 * 1rem - 1px);
   -webkit-flex-shrink: 1;
   -ms-flex-negative: 1;
   flex-shrink: 1;
-  width: calc(100% / 3 - 2 * 1rem - 1px);
-  margin: 1rem;
-  padding: 0;
 }
 
 .c23 {
@@ -728,6 +728,12 @@ exports[`<Stats /> should render 1`] = `
   .c20 {
     max-width: 100%;
     padding: 0;
+  }
+}
+
+@media (max-width:600px) {
+  .c19 {
+    padding: 2.4rem 0;
   }
 }
 

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/themes.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/themes.test.js.snap
@@ -579,6 +579,12 @@ exports[`<Theme /> should render 1`] = `
 }
 
 @media (max-width:600px) {
+  .c19 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c16 {
     font-size: 1.4rem;
   }

--- a/packages/code-du-travail-frontend/pages/modeles-de-courriers/[slug].js
+++ b/packages/code-du-travail-frontend/pages/modeles-de-courriers/[slug].js
@@ -83,9 +83,10 @@ class ModeleCourrier extends React.Component {
               <FloatWrapper>
                 <Button
                   as="a"
-                  variant="primary"
-                  narrow
+                  className="no-after"
                   href={`${API_URL}/docs/${filename}`}
+                  narrow
+                  variant="primary"
                 >
                   <Download />
                   <ScreenReaderOnly>
@@ -111,8 +112,9 @@ class ModeleCourrier extends React.Component {
           <Centered>
             <Button
               as="a"
-              variant="primary"
+              className="no-after"
               href={`${API_URL}/docs/${filename}`}
+              variant="primary"
             >
               Télécharger le modèle ({extension} - {filesizeFormated}Ko) &nbsp;
               <Download />

--- a/packages/code-du-travail-frontend/src/common/Feedback/__tests__/__snapshots__/Feedback.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/Feedback/__tests__/__snapshots__/Feedback.test.js.snap
@@ -458,17 +458,17 @@ exports[`<Feedback/> should render form once user answer no 1`] = `
 }
 
 @media (max-width:600px) {
-<<<<<<< HEAD
+  .c0 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
 
 }
 
 @media (max-width:600px) {
 
-=======
-  .c0 {
-    padding: 2.4rem 0;
-  }
->>>>>>> test(front): update snaps
 }
 
 @media (max-width:600px) {
@@ -688,17 +688,17 @@ exports[`<Feedback/> should render form once user answer yes 1`] = `
 }
 
 @media (max-width:600px) {
-<<<<<<< HEAD
+  .c0 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
 
 }
 
 @media (max-width:600px) {
 
-=======
-  .c0 {
-    padding: 2.4rem 0;
-  }
->>>>>>> test(front): update snaps
 }
 
 @media (max-width:600px) {

--- a/packages/code-du-travail-frontend/src/common/Feedback/__tests__/__snapshots__/Feedback.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/Feedback/__tests__/__snapshots__/Feedback.test.js.snap
@@ -174,6 +174,12 @@ exports[`<Feedback/> should render 1`] = `
 }
 
 @media (max-width:600px) {
+  .c0 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c7 {
     font-size: 1.4rem;
   }
@@ -220,7 +226,6 @@ exports[`<Feedback/> should render 1`] = `
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
     align-items: stretch;
-    max-width: 60rem;
     margin-right: auto;
     margin-left: auto;
   }
@@ -453,11 +458,17 @@ exports[`<Feedback/> should render form once user answer no 1`] = `
 }
 
 @media (max-width:600px) {
+<<<<<<< HEAD
 
 }
 
 @media (max-width:600px) {
 
+=======
+  .c0 {
+    padding: 2.4rem 0;
+  }
+>>>>>>> test(front): update snaps
 }
 
 @media (max-width:600px) {
@@ -501,7 +512,6 @@ exports[`<Feedback/> should render form once user answer no 1`] = `
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
     align-items: stretch;
-    max-width: 60rem;
     margin-right: auto;
     margin-left: auto;
   }
@@ -678,11 +688,17 @@ exports[`<Feedback/> should render form once user answer yes 1`] = `
 }
 
 @media (max-width:600px) {
+<<<<<<< HEAD
 
 }
 
 @media (max-width:600px) {
 
+=======
+  .c0 {
+    padding: 2.4rem 0;
+  }
+>>>>>>> test(front): update snaps
 }
 
 @media (max-width:600px) {
@@ -720,7 +736,6 @@ exports[`<Feedback/> should render form once user answer yes 1`] = `
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
     align-items: stretch;
-    max-width: 60rem;
     margin-right: auto;
     margin-left: auto;
   }

--- a/packages/code-du-travail-frontend/src/common/Feedback/index.js
+++ b/packages/code-du-travail-frontend/src/common/Feedback/index.js
@@ -90,7 +90,6 @@ const StyledWrapper = styled(Wrapper)`
   @media (max-width: ${breakpoints.desktop}) {
     flex-direction: column;
     align-items: stretch;
-    max-width: 60rem;
     margin-right: auto;
     margin-left: auto;
   }

--- a/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/__tests__/__snapshots__/ReferencesJuridiques.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/__tests__/__snapshots__/ReferencesJuridiques.test.js.snap
@@ -29,7 +29,7 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
   margin-bottom: 0;
 }
 
-.c9:not(:focus):not(:active) {
+.c10:not(:focus):not(:active) {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -41,7 +41,7 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
   clip: rect(0,0,0,0);
 }
 
-.c6 {
+.c7 {
   position: relative;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -55,25 +55,25 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
   transition: transform 250ms linear;
 }
 
-[aria-expanded="true"] .c6,
-[aria-selected="true"] .c6 {
+[aria-expanded="true"] .c7,
+[aria-selected="true"] .c7 {
   -webkit-transform: rotate(90deg);
   -ms-transform: rotate(90deg);
   transform: rotate(90deg);
 }
 
-.c4 {
+.c5 {
   position: relative;
   z-index: 1;
 }
 
-.c8 {
+.c9 {
   padding: 1.6rem;
   -webkit-animation: dpvxPj 250ms ease-in;
   animation: dpvxPj 250ms ease-in;
 }
 
-.c5 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -90,14 +90,14 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
   cursor: pointer;
 }
 
-.c5:hover,
-.c5:focus,
-.c5:focus-within,
-.c5[aria-expanded="true"] {
+.c6:hover,
+.c6:focus,
+.c6:focus-within,
+.c6[aria-expanded="true"] {
   color: #3e486e;
 }
 
-.c7 {
+.c8 {
   margin: 2rem 0 2rem 1rem;
   color: #2f3b6c;
   font-weight: 600;
@@ -106,15 +106,15 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
   line-height: 1.25;
 }
 
-.c10 > *:first-child {
+.c11 > *:first-child {
   margin-top: 0;
 }
 
-.c10 > *:last-child {
+.c11 > *:last-child {
   margin-bottom: 0;
 }
 
-.c13 {
+.c14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -127,14 +127,14 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
   text-decoration: none;
 }
 
-.c16 {
+.c17 {
   -webkit-flex: 0 1 auto;
   -ms-flex: 0 1 auto;
   flex: 0 1 auto;
   width: auto;
 }
 
-.c15 {
+.c16 {
   -webkit-flex: 0 0 2.8rem;
   -ms-flex: 0 0 2.8rem;
   flex: 0 0 2.8rem;
@@ -148,13 +148,13 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
   transition: transform 250ms linear;
 }
 
-.c12:hover .c15 {
+.c13:hover .c16 {
   -webkit-transform: translateX(4px);
   -ms-transform: translateX(4px);
   transform: translateX(4px);
 }
 
-.c11 {
+.c12 {
   margin: 0;
   padding: 0;
   list-style-type: none;
@@ -170,8 +170,12 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
   line-height: 1.625;
 }
 
-.c14 {
+.c15 {
   padding: 1.6rem 0;
+}
+
+.c4 {
+  color: #4d73b8;
 }
 
 @media (max-width:600px) {
@@ -184,6 +188,12 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
   .c1 {
     max-width: 100%;
     padding: 0;
+  }
+}
+
+@media (max-width:600px) {
+  .c0 {
+    padding: 2.4rem 0;
   }
 }
 
@@ -201,13 +211,13 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
 }
 
 @media (max-width:600px) {
-  .c8 {
+  .c9 {
     padding: 1rem 0;
   }
 }
 
 @media (max-width:600px) {
-  .c7 {
+  .c8 {
     font-size: 1.6rem;
   }
 }
@@ -229,7 +239,7 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
         class="c2"
       >
         <h3
-          class="c3"
+          class="c3 c4"
         >
           Références juridiques
         </h3>
@@ -239,7 +249,7 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
         >
           <div>
             <div
-              class="c4"
+              class="c5"
               data-accordion-component="AccordionItem"
               index="0"
             >
@@ -253,14 +263,14 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
                   aria-controls="accordion__panel-0"
                   aria-disabled="false"
                   aria-expanded="false"
-                  class="c5"
+                  class="c6"
                   data-accordion-component="AccordionItemButton"
                   id="accordion__heading-0"
                   role="button"
                   tabindex="0"
                 >
                   <svg
-                    class="c6"
+                    class="c7"
                     fill="none"
                     height="24"
                     stroke="currentColor"
@@ -276,7 +286,7 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
                     />
                   </svg>
                   <div
-                    class="c7"
+                    class="c8"
                   >
                     Voir les références juridiques concernées
                   </div>
@@ -285,31 +295,31 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
               <div
                 aria-hidden="true"
                 aria-labelledby="accordion__heading-0"
-                class="c8"
+                class="c9"
                 data-accordion-component="AccordionItemPanel"
                 hidden=""
                 id="accordion__panel-0"
               >
                 <div
-                  class="c9"
+                  class="c10"
                 >
                   <h3>
                     Voir les références juridiques concernées
                   </h3>
                 </div>
                 <div
-                  class="c10"
+                  class="c11"
                 >
                   <ul
-                    class="c11"
+                    class="c12"
                   >
                     <li>
                       <a
-                        class="c12 c13 c14"
+                        class="c13 c14 c15"
                         href="/code-du-travail/l1244-3"
                       >
                         <svg
-                          class="c15"
+                          class="c16"
                           fill="none"
                           viewBox="0 0 28 15"
                         >
@@ -319,7 +329,7 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
                           />
                         </svg>
                         <span
-                          class="c16"
+                          class="c17"
                         >
                           Article L1244-3 du code du travail
                         </span>
@@ -327,11 +337,11 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
                     </li>
                     <li>
                       <a
-                        class="c12 c13 c14"
+                        class="c13 c14 c15"
                         href="/code-du-travail/r1244-4"
                       >
                         <svg
-                          class="c15"
+                          class="c16"
                           fill="none"
                           viewBox="0 0 28 15"
                         >
@@ -341,7 +351,7 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
                           />
                         </svg>
                         <span
-                          class="c16"
+                          class="c17"
                         >
                           Article L1244-4 du code du travail
                         </span>
@@ -349,12 +359,12 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
                     </li>
                     <li>
                       <a
-                        class="c12 c13 c14"
+                        class="c13 c14 c15"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
                         <svg
-                          class="c15"
+                          class="c16"
                           fill="none"
                           viewBox="0 0 28 15"
                         >
@@ -364,7 +374,7 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
                           />
                         </svg>
                         <span
-                          class="c16"
+                          class="c17"
                         >
                           Autre: Article L3121-44 du JO
                         </span>
@@ -372,12 +382,12 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
                     </li>
                     <li>
                       <a
-                        class="c12 c13 c14"
+                        class="c13 c14 c15"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
                         <svg
-                          class="c15"
+                          class="c16"
                           fill="none"
                           viewBox="0 0 28 15"
                         >
@@ -387,7 +397,7 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
                           />
                         </svg>
                         <span
-                          class="c16"
+                          class="c17"
                         >
                           Autre: Article xxx du JPO
                         </span>
@@ -395,11 +405,11 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
                     </li>
                     <li>
                       <a
-                        class="c12 c13 c14"
+                        class="c13 c14 c15"
                         href="/convention-collective/ma-convention"
                       >
                         <svg
-                          class="c15"
+                          class="c16"
                           fill="none"
                           viewBox="0 0 28 15"
                         >
@@ -409,7 +419,7 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
                           />
                         </svg>
                         <span
-                          class="c16"
+                          class="c17"
                         >
                           Convention collective: Article yyy de la CC
                         </span>

--- a/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/index.js
+++ b/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import styled from "styled-components";
 import PropTypes from "prop-types";
 import {
   Accordion,
@@ -15,19 +16,23 @@ class ReferencesJuridiques extends React.PureComponent {
     const { references } = this.props;
     if (!references.length) return null;
 
-    const items = [
-      {
-        title: <h3>Voir les références juridiques concernées</h3>,
-        body: <ReferenceList references={references} />
-      }
-    ];
-
     return (
       <Section>
         <Container>
           <Wrapper variant="light">
-            <Heading>Références juridiques</Heading>
-            <Accordion items={items} />
+            <StyledHeading>Références juridiques</StyledHeading>
+            {references.length > 2 ? (
+              <Accordion
+                items={[
+                  {
+                    title: <h3>Voir les références juridiques concernées</h3>,
+                    body: <ReferenceList references={references} />
+                  }
+                ]}
+              />
+            ) : (
+              <ReferenceList references={references} />
+            )}
           </Wrapper>
         </Container>
       </Section>
@@ -50,3 +55,7 @@ ReferencesJuridiques.defaultProps = {
 };
 
 export default ReferencesJuridiques;
+
+const StyledHeading = styled(Heading)`
+  color: ${({ theme }) => theme.altText};
+`;

--- a/packages/code-du-travail-frontend/src/common/RelatedItems.js
+++ b/packages/code-du-travail-frontend/src/common/RelatedItems.js
@@ -1,27 +1,37 @@
 import React from "react";
 import Link from "next/link";
 import styled from "styled-components";
-import { ArrowLink, Tile, icons, theme } from "@socialgouv/react-ui";
+import {
+  ArrowLink,
+  Container,
+  FlatList,
+  Grid,
+  Section,
+  Tile,
+  icons,
+  theme
+} from "@socialgouv/react-ui";
 import { getLabelBySource, getRouteBySource, SOURCES } from "@cdt/sources";
 
 import { CallToActionTile } from "./tiles/CallToAction";
 
 export const RelatedItems = ({ items = [] }) => {
-  const tool = items.find(({ source }) => source === SOURCES.TOOLS);
-  const letter = items.find(({ source }) => source === SOURCES.LETTERS);
-  const external = items.find(({ source }) => source === SOURCES.EXTERNALS);
+  const tools = items.filter(({ source }) => source === SOURCES.TOOLS);
+  const letters = items.filter(({ source }) => source === SOURCES.LETTERS);
+  const externals = items.filter(({ source }) => source === SOURCES.EXTERNALS);
   const relatedItems = items.filter(
     item =>
       ![SOURCES.EXTERNALS, SOURCES.LETTERS, SOURCES.TOOLS].includes(item.source)
   );
 
   return (
-    <StyledList>
-      {letter && (
-        <StyledListItem>
+    <StyledSection>
+      <Grid singleLined>
+        {letters.map(letter => (
           <Link
-            href={`/${getRouteBySource(letter.source)}/[slug]`}
             as={`/${getRouteBySource(letter.source)}/${letter.slug}`}
+            href={`/${getRouteBySource(letter.source)}/[slug]`}
+            key={letter.slug}
             passHref
           >
             <StyledCallToActionTile
@@ -32,13 +42,12 @@ export const RelatedItems = ({ items = [] }) => {
               subtitle={getLabelBySource(letter.source)}
             />
           </Link>
-        </StyledListItem>
-      )}
-      {tool && (
-        <StyledListItem>
+        ))}
+        {tools.map(tool => (
           <Link
-            href={`/${getRouteBySource(tool.source)}/[slug]`}
             as={`/${getRouteBySource(tool.source)}/${tool.slug}`}
+            href={`/${getRouteBySource(tool.source)}/[slug]`}
+            key={tool.slug}
             passHref
           >
             <StyledCallToActionTile
@@ -51,57 +60,59 @@ export const RelatedItems = ({ items = [] }) => {
               {tool.description}
             </StyledCallToActionTile>
           </Link>
-        </StyledListItem>
-      )}
-      {external && (
-        <StyledListItem>
+        ))}
+        {externals.map(external => (
           <StyledTile
             href={external.url}
-            rel="noopener nofollow"
-            target="_blank"
             icon={icons[external.icon]}
-            title={external.title}
+            key={external.url}
+            rel="noopener nofollow"
             subtitle={external.subtitle}
+            target="_blank"
+            title={external.title}
           >
             {external.description}
           </StyledTile>
-        </StyledListItem>
-      )}
+        ))}
+      </Grid>
       {relatedItems.length > 0 && (
-        <span>Les articles pouvant vous intéresser&nbsp;:</span>
+        <Container>
+          <div>Les articles pouvant vous intéresser&nbsp;:</div>
+          <FlatList>
+            {relatedItems.slice(0, 3).map(({ slug, source, title }) => (
+              <StyledListItem key={slug}>
+                <Link
+                  href={`/${getRouteBySource(source)}/[slug]`}
+                  as={`/${getRouteBySource(source)}/${slug}`}
+                  passHref
+                >
+                  <ArrowLink arrowPosition="left">{title}</ArrowLink>
+                </Link>
+              </StyledListItem>
+            ))}
+          </FlatList>
+        </Container>
       )}
-      {relatedItems.slice(0, 3).map(({ slug, source, title }) => (
-        <StyledListItem key={slug}>
-          <Link
-            href={`/${getRouteBySource(source)}/[slug]`}
-            as={`/${getRouteBySource(source)}/${slug}`}
-            passHref
-          >
-            <ArrowLink arrowPosition="left">{title}</ArrowLink>
-          </Link>
-        </StyledListItem>
-      ))}
-    </StyledList>
+    </StyledSection>
   );
 };
 
 const { breakpoints, spacings } = theme;
 
-const StyledList = styled.ul`
+const StyledSection = styled(Section)`
   position: sticky;
   top: 12rem;
-  width: 30%;
-  margin: 0;
-  padding: 0 ${spacings.base} 0 ${spacings.larger};
+  width: calc(30% - ${spacings.larger});
+  margin-left: ${spacings.larger};
+  @media (min-width: ${breakpoints.tablet}) {
+    padding-top: 0;
+  }
   @media (max-width: ${breakpoints.desktop}) {
-    padding-left: ${spacings.base};
+    width: 30%;
+    margin: 0;
   }
   @media (max-width: ${breakpoints.tablet}) {
-    display: none;
-  }
-  list-style-type: none;
-  & > *:first-child {
-    margin-top: 0;
+    width: 100%;
   }
 `;
 

--- a/packages/code-du-travail-frontend/src/common/RelatedItems.js
+++ b/packages/code-du-travail-frontend/src/common/RelatedItems.js
@@ -5,8 +5,8 @@ import {
   ArrowLink,
   Container,
   FlatList,
+  Heading,
   Section,
-  Tile,
   icons,
   theme
 } from "@socialgouv/react-ui";
@@ -26,9 +26,9 @@ export const RelatedItems = ({ items = [] }) => {
   return (
     <StyledSection>
       <Container>
-        <FlatList>
+        <StyledFlatList>
           {relatedTilesItems.slice(0, 2).map(item => (
-            <StyledListItem key={item.slug || item.url}>
+            <StyledTileItem key={item.slug || item.url}>
               {item.source !== SOURCES.EXTERNALS ? (
                 <Link
                   as={`/${getRouteBySource(item.source)}/${item.slug}`}
@@ -63,15 +63,17 @@ export const RelatedItems = ({ items = [] }) => {
                   {item.description}
                 </CallToActionTile>
               )}
-            </StyledListItem>
+            </StyledTileItem>
           ))}
-        </FlatList>
+        </StyledFlatList>
         {relatedLinkItems.length > 0 && (
           <>
-            <div>Les articles pouvant vous intéresser&nbsp;:</div>
+            <Heading as="div">
+              Les articles pouvant vous intéresser&nbsp;:
+            </Heading>
             <FlatList>
               {relatedLinkItems.slice(0, 3).map(({ slug, source, title }) => (
-                <StyledListItem key={slug}>
+                <StyledLinkItem key={slug}>
                   <Link
                     href={`/${getRouteBySource(source)}/[slug]`}
                     as={`/${getRouteBySource(source)}/${slug}`}
@@ -79,7 +81,7 @@ export const RelatedItems = ({ items = [] }) => {
                   >
                     <ArrowLink arrowPosition="left">{title}</ArrowLink>
                   </Link>
-                </StyledListItem>
+                </StyledLinkItem>
               ))}
             </FlatList>
           </>
@@ -108,11 +110,37 @@ const StyledSection = styled(Section)`
   }
 `;
 
-const StyledTile = styled(Tile)`
-  max-width: 28rem;
+const StyledFlatList = styled(FlatList)`
+  @media (max-width: ${breakpoints.tablet}) {
+    display: flex;
+  }
+  @media (max-width: ${breakpoints.mobile}) {
+    flex-direction: column;
+  }
 `;
 
-const StyledListItem = styled.li`
-  margin: ${spacings.base} 0;
+const StyledTileItem = styled.li`
+  margin: 0 0 ${spacings.base} 0;
+  padding: 0;
+  @media (max-width: ${breakpoints.tablet}) {
+    display: flex;
+    flex: 1 0 auto;
+    justify-content: stretch;
+    width: calc((100% - ${spacings.base}) / 2);
+    & + & {
+      margin-left: ${spacings.base};
+    }
+  }
+  @media (max-width: ${breakpoints.mobile}) {
+    flex: 1 0 auto;
+    width: 100%;
+    & + & {
+      margin-left: 0;
+    }
+  }
+`;
+
+const StyledLinkItem = styled.li`
+  margin: 0 0 ${spacings.base} 0;
   padding: 0;
 `;

--- a/packages/code-du-travail-frontend/src/common/RelatedItems.js
+++ b/packages/code-du-travail-frontend/src/common/RelatedItems.js
@@ -5,7 +5,6 @@ import {
   ArrowLink,
   Container,
   FlatList,
-  Grid,
   Section,
   Tile,
   icons,
@@ -16,83 +15,76 @@ import { getLabelBySource, getRouteBySource, SOURCES } from "@cdt/sources";
 import { CallToActionTile } from "./tiles/CallToAction";
 
 export const RelatedItems = ({ items = [] }) => {
-  const tools = items.filter(({ source }) => source === SOURCES.TOOLS);
-  const letters = items.filter(({ source }) => source === SOURCES.LETTERS);
-  const externals = items.filter(({ source }) => source === SOURCES.EXTERNALS);
-  const relatedItems = items.filter(
-    item =>
-      ![SOURCES.EXTERNALS, SOURCES.LETTERS, SOURCES.TOOLS].includes(item.source)
+  const tileSources = [SOURCES.EXTERNALS, SOURCES.LETTERS, SOURCES.TOOLS];
+  const relatedTilesItems = items.filter(item =>
+    tileSources.includes(item.source)
+  );
+  const relatedLinkItems = items.filter(
+    item => !tileSources.includes(item.source)
   );
 
   return (
     <StyledSection>
-      <Grid singleLined>
-        {letters.map(letter => (
-          <Link
-            as={`/${getRouteBySource(letter.source)}/${letter.slug}`}
-            href={`/${getRouteBySource(letter.source)}/[slug]`}
-            key={letter.slug}
-            passHref
-          >
-            <StyledCallToActionTile
-              action="Consulter"
-              custom
-              icon={icons.Document}
-              title={letter.title}
-              subtitle={getLabelBySource(letter.source)}
-            />
-          </Link>
-        ))}
-        {tools.map(tool => (
-          <Link
-            as={`/${getRouteBySource(tool.source)}/${tool.slug}`}
-            href={`/${getRouteBySource(tool.source)}/[slug]`}
-            key={tool.slug}
-            passHref
-          >
-            <StyledCallToActionTile
-              action={tool.action || "Consulter"}
-              custom
-              icon={icons[tool.icon]}
-              title={tool.title}
-              subtitle={getLabelBySource(tool.source)}
-            >
-              {tool.description}
-            </StyledCallToActionTile>
-          </Link>
-        ))}
-        {externals.map(external => (
-          <StyledTile
-            href={external.url}
-            icon={icons[external.icon]}
-            key={external.url}
-            rel="noopener nofollow"
-            subtitle={external.subtitle}
-            target="_blank"
-            title={external.title}
-          >
-            {external.description}
-          </StyledTile>
-        ))}
-      </Grid>
-      {relatedItems.length > 0 && (
-        <Container>
-          <div>Les articles pouvant vous intéresser&nbsp;:</div>
-          <FlatList>
-            {relatedItems.slice(0, 3).map(({ slug, source, title }) => (
-              <StyledListItem key={slug}>
+      <Container>
+        <FlatList>
+          {relatedTilesItems.slice(0, 2).map(item => (
+            <StyledListItem key={item.slug || item.url}>
+              {item.source !== SOURCES.EXTERNALS ? (
                 <Link
-                  href={`/${getRouteBySource(source)}/[slug]`}
-                  as={`/${getRouteBySource(source)}/${slug}`}
+                  as={`/${getRouteBySource(item.source)}/${item.slug}`}
+                  href={`/${getRouteBySource(item.source)}/[slug]`}
                   passHref
                 >
-                  <ArrowLink arrowPosition="left">{title}</ArrowLink>
+                  <CallToActionTile
+                    action={item.action || "Consulter"}
+                    custom
+                    icon={
+                      item.source === SOURCES.LETTERS
+                        ? icons.Document
+                        : icons[item.icon]
+                    }
+                    title={item.title}
+                    subtitle={getLabelBySource(item.source)}
+                  >
+                    {item.description}
+                  </CallToActionTile>
                 </Link>
-              </StyledListItem>
-            ))}
-          </FlatList>
-        </Container>
-      )}
+              ) : (
+                <CallToActionTile
+                  action={item.action || "Consulter"}
+                  custom={false}
+                  href={item.url}
+                  icon={icons[item.icon]}
+                  rel="noopener nofollow"
+                  subtitle={item.subtitle}
+                  target="_blank"
+                  title={item.title}
+                >
+                  {item.description}
+                </CallToActionTile>
+              )}
+            </StyledListItem>
+          ))}
+        </FlatList>
+        {relatedLinkItems.length > 0 && (
+          <>
+            <div>Les articles pouvant vous intéresser&nbsp;:</div>
+            <FlatList>
+              {relatedLinkItems.slice(0, 3).map(({ slug, source, title }) => (
+                <StyledListItem key={slug}>
+                  <Link
+                    href={`/${getRouteBySource(source)}/[slug]`}
+                    as={`/${getRouteBySource(source)}/${slug}`}
+                    passHref
+                  >
+                    <ArrowLink arrowPosition="left">{title}</ArrowLink>
+                  </Link>
+                </StyledListItem>
+              ))}
+            </FlatList>
+          </>
+        )}
+      </Container>
     </StyledSection>
   );
 };
@@ -117,10 +109,6 @@ const StyledSection = styled(Section)`
 `;
 
 const StyledTile = styled(Tile)`
-  max-width: 28rem;
-`;
-
-const StyledCallToActionTile = styled(CallToActionTile)`
   max-width: 28rem;
 `;
 

--- a/packages/code-du-travail-frontend/src/common/__tests__/Answer.test.js
+++ b/packages/code-du-travail-frontend/src/common/__tests__/Answer.test.js
@@ -126,10 +126,10 @@ describe("<Answer />", () => {
     ).toBe(3);
     expect(
       container.querySelectorAll(`[href*="${SLUG_LETTER_BASE}"]`).length
-    ).toBe(1);
+    ).toBe(2);
     expect(
       container.querySelectorAll(`[href*="${SLUG_TOOL_BASE}"]`).length
-    ).toBe(1);
+    ).toBe(2);
     expect(container).toMatchSnapshot();
   });
 

--- a/packages/code-du-travail-frontend/src/common/__tests__/Answer.test.js
+++ b/packages/code-du-travail-frontend/src/common/__tests__/Answer.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { render } from "@testing-library/react";
-import { SOURCES } from "@cdt/sources";
+import { getRouteBySource, SOURCES } from "@cdt/sources";
 
 import Answer from "../Answer";
 import Router from "next/router";
@@ -67,6 +67,7 @@ describe("<Answer />", () => {
     const SLUG_LINK_BASE = "LINK_";
     const SLUG_TOOL_BASE = "TOOL_";
     const SLUG_LETTER_BASE = "LETTER_";
+    const EXTERNAL_URL = "url.extrenal/tool";
     const { container } = renderAnswer({
       html:
         "<p class='test-content'>annualisation du temps de travail. Annualisation de l'annualisation.</p>",
@@ -83,7 +84,6 @@ describe("<Answer />", () => {
         },
         {
           source: SOURCES.EXTERNALS,
-          slug: `${SLUG_LINK_BASE}3`,
           url: "url.extrenal/tool",
           title: "related external title 1",
           action: "extern action",
@@ -124,12 +124,19 @@ describe("<Answer />", () => {
     expect(
       container.querySelectorAll(`[href*="${SLUG_LINK_BASE}"]`).length
     ).toBe(3);
+    expect(container.querySelectorAll(`[href*="${EXTERNAL_URL}"]`).length).toBe(
+      1
+    );
     expect(
-      container.querySelectorAll(`[href*="${SLUG_LETTER_BASE}"]`).length
-    ).toBe(2);
+      container.querySelectorAll(`[href*="${getRouteBySource(SOURCES.TOOLS)}"]`)
+        .length
+    ).toBe(1);
+    // only the first two tile items are picked
     expect(
-      container.querySelectorAll(`[href*="${SLUG_TOOL_BASE}"]`).length
-    ).toBe(2);
+      container.querySelectorAll(
+        `[href*="${getRouteBySource(SOURCES.LETTERS)}"]`
+      ).length
+    ).toBe(0);
     expect(container).toMatchSnapshot();
   });
 

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/Answer.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/Answer.test.js.snap
@@ -294,6 +294,12 @@ exports[`<Answer /> should renders 1`] = `
 }
 
 @media (max-width:600px) {
+  .c11 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c3 {
     padding: 1.6rem 1rem;
   }
@@ -390,7 +396,6 @@ exports[`<Answer /> should renders 1`] = `
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
     align-items: stretch;
-    max-width: 60rem;
     margin-right: auto;
     margin-left: auto;
   }
@@ -975,6 +980,12 @@ exports[`<Answer /> should renders a breadcrumbs 1`] = `
 }
 
 @media (max-width:600px) {
+  .c20 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c11 {
     padding: 1.6rem 1rem;
   }
@@ -1090,7 +1101,6 @@ exports[`<Answer /> should renders a breadcrumbs 1`] = `
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
     align-items: stretch;
-    max-width: 60rem;
     margin-right: auto;
     margin-left: auto;
   }
@@ -1680,6 +1690,12 @@ exports[`<Answer /> should renders back to results link 1`] = `
 }
 
 @media (max-width:600px) {
+  .c11 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c3 {
     padding: 1.6rem 1rem;
   }
@@ -1776,7 +1792,6 @@ exports[`<Answer /> should renders back to results link 1`] = `
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
     align-items: stretch;
-    max-width: 60rem;
     margin-right: auto;
     margin-left: auto;
   }
@@ -1997,7 +2012,7 @@ exports[`<Answer /> should renders related content 1`] = `
   margin-bottom: 0;
 }
 
-.c41 {
+.c47 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2010,14 +2025,14 @@ exports[`<Answer /> should renders related content 1`] = `
   text-decoration: none;
 }
 
-.c43 {
+.c49 {
   -webkit-flex: 0 1 auto;
   -ms-flex: 0 1 auto;
   flex: 0 1 auto;
   width: auto;
 }
 
-.c42 {
+.c48 {
   -webkit-flex: 0 0 2.8rem;
   -ms-flex: 0 0 2.8rem;
   flex: 0 0 2.8rem;
@@ -2031,13 +2046,13 @@ exports[`<Answer /> should renders related content 1`] = `
   transition: transform 250ms linear;
 }
 
-.c40:hover .c42 {
+.c46:hover .c48 {
   -webkit-transform: translateX(4px);
   -ms-transform: translateX(4px);
   transform: translateX(4px);
 }
 
-.c26 {
+.c30 {
   position: absolute;
   top: 0;
   right: 0;
@@ -2048,7 +2063,7 @@ exports[`<Answer /> should renders related content 1`] = `
   border-radius: 0 0.6rem 0 0;
 }
 
-.c26:before {
+.c30:before {
   position: absolute;
   display: block;
   width: 0;
@@ -2059,7 +2074,7 @@ exports[`<Answer /> should renders related content 1`] = `
   content: "";
 }
 
-.c27 {
+.c31 {
   position: absolute;
   top: 0;
   right: 0;
@@ -2131,7 +2146,7 @@ exports[`<Answer /> should renders related content 1`] = `
   cursor: not-allowed;
 }
 
-.c37 {
+.c41 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2172,14 +2187,14 @@ exports[`<Answer /> should renders related content 1`] = `
   overflow: visible;
 }
 
-.c37:focus,
-.c37:hover,
-.c37:active {
+.c41:focus,
+.c41:hover,
+.c41:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c38 {
+.c42 {
   width: 2.6rem;
   height: 1.4rem;
   margin: 0 0.4rem 0 1rem;
@@ -2188,10 +2203,110 @@ exports[`<Answer /> should renders related content 1`] = `
   transition: transform 250ms linear;
 }
 
-.c18:hover .c38 {
+.c18:hover .c42 {
   -webkit-transform: translateX(4px);
   -ms-transform: translateX(4px);
   transform: translateX(4px);
+}
+
+.c23 {
+  position: relative;
+  overflow: hidden;
+}
+
+.c23:before,
+.c23:after {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 1;
+  display: block;
+  width: 4rem;
+  opacity: 0;
+  -webkit-transition: opacity 0.3s linear;
+  transition: opacity 0.3s linear;
+  content: "";
+  pointer-events: none;
+  background: radial-gradient( ellipse at center, #fff 15%, rgba(255,255,255,0) 80% );
+}
+
+.c23:before {
+  left: -2rem;
+}
+
+.c23:after {
+  right: -2rem;
+}
+
+.c25 {
+  overflow-x: auto;
+}
+
+.c26 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  margin-top: 0;
+  margin-right: calc(-1 * 1rem);
+  margin-bottom: 4rem;
+  margin-left: calc(-1 * 1rem);
+  padding: 0;
+  list-style-type: none;
+  margin-right: 0;
+  margin-left: 0;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.c27 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  margin: 1rem;
+  padding: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin-bottom: 0;
+}
+
+.c27:first-of-type {
+  margin-left: 2rem;
+}
+
+.c27:last-of-type:after {
+  display: block;
+  width: 2rem;
+  height: 100%;
+  background-color: transparent;
+  content: "";
+}
+
+.c44 {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
 }
 
 .c7 {
@@ -2232,7 +2347,7 @@ exports[`<Answer /> should renders related content 1`] = `
   padding-left: 2.4rem;
 }
 
-.c32 {
+.c36 {
   position: relative;
   margin: 3.2rem 0 2rem 0;
   color: #2f3b6c;
@@ -2242,7 +2357,7 @@ exports[`<Answer /> should renders related content 1`] = `
   line-height: 1.625;
 }
 
-.c31 {
+.c35 {
   display: block;
   margin: 0 0 1rem 0;
   color: #4d73b8;
@@ -2253,7 +2368,7 @@ exports[`<Answer /> should renders related content 1`] = `
   text-transform: uppercase;
 }
 
-.c24 {
+.c28 {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -2294,9 +2409,9 @@ exports[`<Answer /> should renders related content 1`] = `
   appearance: none;
 }
 
-.c24:hover,
-.c24:active,
-.c24:focus {
+.c28:hover,
+.c28:active,
+.c28:focus {
   color: #3e486e;
   box-shadow: 0 1rem 2rem rgba(121,148,212,0.4);
   -webkit-transform: translateY(-2px);
@@ -2304,7 +2419,7 @@ exports[`<Answer /> should renders related content 1`] = `
   transform: translateY(-2px);
 }
 
-.c29 {
+.c33 {
   display: block;
   width: 7.2rem;
   height: 7.2rem;
@@ -2314,21 +2429,21 @@ exports[`<Answer /> should renders related content 1`] = `
   border-radius: 50%;
 }
 
-.c28 {
+.c32 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
 }
 
-.c30 {
+.c34 {
   padding-right: 1rem;
 }
 
-.c33 {
+.c37 {
   margin: 0;
 }
 
-.c34 {
+.c38 {
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -2428,7 +2543,7 @@ exports[`<Answer /> should renders related content 1`] = `
   margin-left: 4rem;
 }
 
-.c35 {
+.c39 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2443,7 +2558,7 @@ exports[`<Answer /> should renders related content 1`] = `
   height: 100%;
 }
 
-.c36 {
+.c40 {
   margin-top: 1rem;
 }
 
@@ -2451,25 +2566,19 @@ exports[`<Answer /> should renders related content 1`] = `
   position: -webkit-sticky;
   position: sticky;
   top: 12rem;
-  width: 30%;
-  margin: 0;
-  padding: 0 1.6rem 0 4rem;
-  list-style-type: none;
+  width: calc(30% - 4rem);
+  margin-left: 4rem;
 }
 
-.c22 > *:first-child {
-  margin-top: 0;
-}
-
-.c39 {
+.c43 {
   max-width: 28rem;
 }
 
-.c25 {
+.c29 {
   max-width: 28rem;
 }
 
-.c23 {
+.c45 {
   margin: 1.6rem 0;
   padding: 0;
 }
@@ -2535,6 +2644,12 @@ exports[`<Answer /> should renders related content 1`] = `
 }
 
 @media (max-width:600px) {
+  .c12 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c3 {
     padding: 1.6rem 1rem;
   }
@@ -2560,8 +2675,44 @@ exports[`<Answer /> should renders related content 1`] = `
 }
 
 @media (max-width:600px) {
-  .c37 {
+  .c41 {
     font-size: 1.4rem;
+  }
+}
+
+@media (max-width:600px) {
+  .c23 {
+    overflow-x: hidden;
+  }
+}
+
+@media (max-width:600px) {
+  .c23:before,
+  .c23:after {
+    display: block;
+  }
+}
+
+@media (max-width:600px) {
+  .c25 {
+    overflow-x: auto;
+  }
+}
+
+@media (max-width:600px) {
+  .c24 {
+    margin-bottom: 1.6rem;
+  }
+}
+
+@media (max-width:600px) {
+  .c26 {
+    -webkit-flex-wrap: nowrap;
+    -ms-flex-wrap: nowrap;
+    flex-wrap: nowrap;
+    margin-right: 0;
+    margin-bottom: 2rem;
+    margin-left: 0;
   }
 }
 
@@ -2579,13 +2730,13 @@ exports[`<Answer /> should renders related content 1`] = `
 }
 
 @media (max-width:600px) {
-  .c32 {
+  .c36 {
     font-size: 1.6rem;
   }
 }
 
 @media (max-width:600px) {
-  .c24 {
+  .c28 {
     padding: 2rem 1.6rem;
     font-size: 1.4rem;
   }
@@ -2650,7 +2801,6 @@ exports[`<Answer /> should renders related content 1`] = `
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
     align-items: stretch;
-    max-width: 60rem;
     margin-right: auto;
     margin-left: auto;
   }
@@ -2684,15 +2834,22 @@ exports[`<Answer /> should renders related content 1`] = `
   }
 }
 
+@media (min-width:980px) {
+  .c22 {
+    padding-top: 0;
+  }
+}
+
 @media (max-width:1180px) {
   .c22 {
-    padding-left: 1.6rem;
+    width: 30%;
+    margin: 0;
   }
 }
 
 @media (max-width:980px) {
   .c22 {
-    display: none;
+    width: 100%;
   }
 }
 
@@ -2868,341 +3025,565 @@ exports[`<Answer /> should renders related content 1`] = `
         </div>
       </div>
     </div>
-    <ul
-      class="c22"
+    <div
+      class="c12 c22"
     >
-      <li
-        class="c23"
+      <div
+        class="c23 c24"
       >
-        <a
-          class="c24 c25"
-          href="/modeles-de-courriers/LETTER_1"
+        <div
+          class="c25"
         >
-          <div
+          <ul
             class="c26"
           >
-            <div
+            <li
               class="c27"
             >
-              <svg
-                fill="none"
-                viewBox="0 0 32 32"
-              >
-                <path
-                  clip-rule="evenodd"
-                  d="M11.938 16.5a3.548 3.548 0 013.562-3.563 3.548 3.548 0 013.563 3.563 3.548 3.548 0 01-3.563 3.563 3.548 3.548 0 01-3.563-3.563zm2.062 0c0 .84.66 1.5 1.5 1.5s1.5-.66 1.5-1.5-.66-1.5-1.5-1.5-1.5.66-1.5 1.5z"
-                  fill="currentColor"
-                  fill-rule="evenodd"
-                />
-                <path
-                  clip-rule="evenodd"
-                  d="M25 14.838v3.404l-1.663.87-.474 1.109.554 1.82-2.375 2.376-1.9-.555-1.109.476-.87 1.662h-3.405l-.87-1.663-1.109-.474-1.82.554-2.376-2.375.554-1.9-.475-1.109L6 18.163v-3.405l1.662-.87.475-1.109-.554-1.82 2.375-2.376 1.9.554 1.109-.475.87-1.662h3.405l.87 1.662 1.109.475 1.82-.554 2.376 2.375-.555 1.9.476 1.109 1.662.87zm-4.1 5.112l.825-2.025L23 17.25v-1.5l-1.2-.6-.825-2.025.375-1.35-1.05-1.05-1.35.375-2.025-.825L16.25 9h-1.5l-.6 1.2-2.025.825-1.35-.375-1.05 1.05.375 1.35-.825 2.025L8 15.75v1.5l1.2.6.825 2.025-.375 1.35 1.05 1.05 1.35-.375 2.025.825L14.75 24h1.5l.6-1.2 2.025-.825 1.35.375 1.05-1.05-.375-1.35z"
-                  fill="currentColor"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            class="c28"
-          >
-            <div
-              class="c29"
-            >
-              <svg
-                fill="none"
-                viewBox="0 0 52 52"
-              >
-                <path
-                  clip-rule="evenodd"
-                  d="M26.567 3.89L32.544 8H42a1 1 0 011 1v6.188l6.566 4.514a1 1 0 01.434.824V47a1 1 0 01-1 1H3a1 1 0 01-1-1V20.526a1 1 0 01.433-.824L9 15.188V9a1 1 0 011-1h9.455l5.979-4.11a1 1 0 011.133 0zM22.985 8h6.03L26 5.927 22.985 8zM9 17.615l-5 3.437v.323l5 3.438v-7.198zm2 8.573l10.537 7.244 2.873-1.796a3 3 0 013.18 0l2.873 1.796L41 26.188V10H11v16.188zm32-1.375l5-3.438v-.323l-5-3.437v7.198zm5-1.01L32.313 34.586 48 44.392v-20.59zM4 44.391l15.687-9.805L4 23.802v20.59zm21.47-11.06L5.2 46h41.6L26.53 33.332a1 1 0 00-1.06 0z"
-                  fill="#4E6896"
-                  fill-rule="evenodd"
-                />
-                <path
-                  d="M16 17c0-.552.471-1 1.053-1h17.894c.582 0 1.053.448 1.053 1s-.471 1-1.053 1H17.053C16.47 18 16 17.552 16 17zm1.053 5C16.47 22 16 22.448 16 23s.471 1 1.053 1h17.894C35.53 24 36 23.552 36 23s-.471-1-1.053-1H17.053z"
-                  fill="#FF7067"
-                />
-              </svg>
-            </div>
-            <div
-              class="c30"
-            >
-              <span
-                class="c31"
-              >
-                Modèles de documents
-              </span>
-              <h3
-                class="c32 c33"
-              >
-                related letter title 1
-              </h3>
-            </div>
-          </div>
-          <div
-            class="c34"
-          >
-            <div
-              class="c35"
-            >
-              <div
-                class="c36"
+              <a
+                class="c28 c29"
+                href="/modeles-de-courriers/LETTER_1"
               >
                 <div
-                  class="c18 c37"
+                  class="c30"
                 >
-                  Consulter
-                  <svg
-                    class="c38"
-                    fill="none"
-                    viewBox="0 0 28 15"
+                  <div
+                    class="c31"
                   >
-                    <path
-                      d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
-                      fill="currentColor"
-                    />
-                  </svg>
+                    <svg
+                      fill="none"
+                      viewBox="0 0 32 32"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M11.938 16.5a3.548 3.548 0 013.562-3.563 3.548 3.548 0 013.563 3.563 3.548 3.548 0 01-3.563 3.563 3.548 3.548 0 01-3.563-3.563zm2.062 0c0 .84.66 1.5 1.5 1.5s1.5-.66 1.5-1.5-.66-1.5-1.5-1.5-1.5.66-1.5 1.5z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                      />
+                      <path
+                        clip-rule="evenodd"
+                        d="M25 14.838v3.404l-1.663.87-.474 1.109.554 1.82-2.375 2.376-1.9-.555-1.109.476-.87 1.662h-3.405l-.87-1.663-1.109-.474-1.82.554-2.376-2.375.554-1.9-.475-1.109L6 18.163v-3.405l1.662-.87.475-1.109-.554-1.82 2.375-2.376 1.9.554 1.109-.475.87-1.662h3.405l.87 1.662 1.109.475 1.82-.554 2.376 2.375-.555 1.9.476 1.109 1.662.87zm-4.1 5.112l.825-2.025L23 17.25v-1.5l-1.2-.6-.825-2.025.375-1.35-1.05-1.05-1.35.375-2.025-.825L16.25 9h-1.5l-.6 1.2-2.025.825-1.35-.375-1.05 1.05.375 1.35-.825 2.025L8 15.75v1.5l1.2.6.825 2.025-.375 1.35 1.05 1.05 1.35-.375 2.025.825L14.75 24h1.5l.6-1.2 2.025-.825 1.35.375 1.05-1.05-.375-1.35z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
                 </div>
-              </div>
-            </div>
-          </div>
-        </a>
-      </li>
-      <li
-        class="c23"
-      >
-        <a
-          class="c24 c25"
-          href="/outils/TOOL_1"
-        >
-          <div
-            class="c26"
-          >
-            <div
+                <div
+                  class="c32"
+                >
+                  <div
+                    class="c33"
+                  >
+                    <svg
+                      fill="none"
+                      viewBox="0 0 52 52"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M26.567 3.89L32.544 8H42a1 1 0 011 1v6.188l6.566 4.514a1 1 0 01.434.824V47a1 1 0 01-1 1H3a1 1 0 01-1-1V20.526a1 1 0 01.433-.824L9 15.188V9a1 1 0 011-1h9.455l5.979-4.11a1 1 0 011.133 0zM22.985 8h6.03L26 5.927 22.985 8zM9 17.615l-5 3.437v.323l5 3.438v-7.198zm2 8.573l10.537 7.244 2.873-1.796a3 3 0 013.18 0l2.873 1.796L41 26.188V10H11v16.188zm32-1.375l5-3.438v-.323l-5-3.437v7.198zm5-1.01L32.313 34.586 48 44.392v-20.59zM4 44.391l15.687-9.805L4 23.802v20.59zm21.47-11.06L5.2 46h41.6L26.53 33.332a1 1 0 00-1.06 0z"
+                        fill="#4E6896"
+                        fill-rule="evenodd"
+                      />
+                      <path
+                        d="M16 17c0-.552.471-1 1.053-1h17.894c.582 0 1.053.448 1.053 1s-.471 1-1.053 1H17.053C16.47 18 16 17.552 16 17zm1.053 5C16.47 22 16 22.448 16 23s.471 1 1.053 1h17.894C35.53 24 36 23.552 36 23s-.471-1-1.053-1H17.053z"
+                        fill="#FF7067"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="c34"
+                  >
+                    <span
+                      class="c35"
+                    >
+                      Modèles de documents
+                    </span>
+                    <h3
+                      class="c36 c37"
+                    >
+                      related letter title 1
+                    </h3>
+                  </div>
+                </div>
+                <div
+                  class="c38"
+                >
+                  <div
+                    class="c39"
+                  >
+                    <div
+                      class="c40"
+                    >
+                      <div
+                        class="c18 c41"
+                      >
+                        Consulter
+                        <svg
+                          class="c42"
+                          fill="none"
+                          viewBox="0 0 28 15"
+                        >
+                          <path
+                            d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </a>
+            </li>
+            <li
               class="c27"
             >
-              <svg
-                fill="none"
-                viewBox="0 0 32 32"
-              >
-                <path
-                  clip-rule="evenodd"
-                  d="M11.938 16.5a3.548 3.548 0 013.562-3.563 3.548 3.548 0 013.563 3.563 3.548 3.548 0 01-3.563 3.563 3.548 3.548 0 01-3.563-3.563zm2.062 0c0 .84.66 1.5 1.5 1.5s1.5-.66 1.5-1.5-.66-1.5-1.5-1.5-1.5.66-1.5 1.5z"
-                  fill="currentColor"
-                  fill-rule="evenodd"
-                />
-                <path
-                  clip-rule="evenodd"
-                  d="M25 14.838v3.404l-1.663.87-.474 1.109.554 1.82-2.375 2.376-1.9-.555-1.109.476-.87 1.662h-3.405l-.87-1.663-1.109-.474-1.82.554-2.376-2.375.554-1.9-.475-1.109L6 18.163v-3.405l1.662-.87.475-1.109-.554-1.82 2.375-2.376 1.9.554 1.109-.475.87-1.662h3.405l.87 1.662 1.109.475 1.82-.554 2.376 2.375-.555 1.9.476 1.109 1.662.87zm-4.1 5.112l.825-2.025L23 17.25v-1.5l-1.2-.6-.825-2.025.375-1.35-1.05-1.05-1.35.375-2.025-.825L16.25 9h-1.5l-.6 1.2-2.025.825-1.35-.375-1.05 1.05.375 1.35-.825 2.025L8 15.75v1.5l1.2.6.825 2.025-.375 1.35 1.05 1.05 1.35-.375 2.025.825L14.75 24h1.5l.6-1.2 2.025-.825 1.35.375 1.05-1.05-.375-1.35z"
-                  fill="currentColor"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            class="c28"
-          >
-            <div
-              class="c29"
-            >
-              <svg
-                fill="none"
-                viewBox="0 0 52 52"
-              >
-                <path
-                  d="M43.566 34.192a.752.752 0 00-.47-.191.615.615 0 00-.454.173.592.592 0 00-.177.444v3.68H29v4.939h13.467v3.682c0 .163.067.32.185.436a.635.635 0 00.445.181.625.625 0 00.45-.183l6.277-6.143a.645.645 0 000-.885l-6.258-6.133z"
-                  fill="#FF7067"
-                />
-                <path
-                  d="M29.112 4c-.312-.015-.495.131-.698.361-.201.228-.215.563-.214.871L28.195 27 17.8 17a1.176 1.176 0 00-1.205.002c-.182.11-.334.267-.438.456a1.257 1.257 0 00-.157.62V27L4.8 17a1.176 1.176 0 00-1.205.002c-.182.11-.334.267-.438.456a1.258 1.258 0 00-.157.62l.151 30.652c0 .327.127.64.352.871.225.231.53.361.848.361h35.427c.318 0 .623-.13.848-.36a1.25 1.25 0 00.352-.872V46H39v2H5V20l11.157 9.602a1.177 1.177 0 001.204-.003c.183-.109.334-.266.439-.455a1.26 1.26 0 00.156-.62L18 20.5l10.2 9.102a1.177 1.177 0 001.205-.003c.182-.109.334-.266.438-.455a1.25 1.25 0 00.157-.62V6h9v29h1.978V5.232c0-.327-.127-.64-.352-.871a1.185 1.185 0 00-.848-.36H29.112z"
-                  fill="#4E6896"
-                />
-                <path
-                  d="M35 37v-2.809c0-.327-.127-.64-.352-.871a1.184 1.184 0 00-.848-.36h-8.6a1.173 1.173 0 00-.113 0 1.19 1.19 0 00-.776.398 1.251 1.251 0 00-.311.833v8.624c0 .327.127.64.352.871.224.231.53.361.848.361H27V42h-1v-7h7v2h2z"
-                  fill="#4E6896"
-                />
-                <path
-                  clip-rule="evenodd"
-                  d="M10.287 32.96a1.189 1.189 0 00-.776.398 1.25 1.25 0 00-.311.833v8.624c0 .327.126.64.351.871.226.231.53.361.849.361h8.4c.318 0 .623-.13.848-.36a1.25 1.25 0 00.352-.872v-8.624c0-.327-.127-.64-.352-.871a1.184 1.184 0 00-.848-.36h-8.4a1.173 1.173 0 00-.113 0zM11 35h7v7h-7v-7z"
-                  fill="#4E6896"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </div>
-            <div
-              class="c30"
-            >
-              <span
-                class="c31"
-              >
-                Outils
-              </span>
-              <h3
-                class="c32 c33"
-              >
-                related tool title 1
-              </h3>
-            </div>
-          </div>
-          <div
-            class="c34"
-          >
-            <div
-              class="c35"
-            >
-              <div
-                class="c36"
+              <a
+                class="c28 c29"
+                href="/modeles-de-courriers/LETTER_2"
               >
                 <div
-                  class="c18 c37"
+                  class="c30"
                 >
-                  tools action
-                  <svg
-                    class="c38"
-                    fill="none"
-                    viewBox="0 0 28 15"
+                  <div
+                    class="c31"
                   >
-                    <path
-                      d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
-                      fill="currentColor"
-                    />
-                  </svg>
+                    <svg
+                      fill="none"
+                      viewBox="0 0 32 32"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M11.938 16.5a3.548 3.548 0 013.562-3.563 3.548 3.548 0 013.563 3.563 3.548 3.548 0 01-3.563 3.563 3.548 3.548 0 01-3.563-3.563zm2.062 0c0 .84.66 1.5 1.5 1.5s1.5-.66 1.5-1.5-.66-1.5-1.5-1.5-1.5.66-1.5 1.5z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                      />
+                      <path
+                        clip-rule="evenodd"
+                        d="M25 14.838v3.404l-1.663.87-.474 1.109.554 1.82-2.375 2.376-1.9-.555-1.109.476-.87 1.662h-3.405l-.87-1.663-1.109-.474-1.82.554-2.376-2.375.554-1.9-.475-1.109L6 18.163v-3.405l1.662-.87.475-1.109-.554-1.82 2.375-2.376 1.9.554 1.109-.475.87-1.662h3.405l.87 1.662 1.109.475 1.82-.554 2.376 2.375-.555 1.9.476 1.109 1.662.87zm-4.1 5.112l.825-2.025L23 17.25v-1.5l-1.2-.6-.825-2.025.375-1.35-1.05-1.05-1.35.375-2.025-.825L16.25 9h-1.5l-.6 1.2-2.025.825-1.35-.375-1.05 1.05.375 1.35-.825 2.025L8 15.75v1.5l1.2.6.825 2.025-.375 1.35 1.05 1.05 1.35-.375 2.025.825L14.75 24h1.5l.6-1.2 2.025-.825 1.35.375 1.05-1.05-.375-1.35z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
                 </div>
-              </div>
-            </div>
-          </div>
-        </a>
-      </li>
-      <li
-        class="c23"
+                <div
+                  class="c32"
+                >
+                  <div
+                    class="c33"
+                  >
+                    <svg
+                      fill="none"
+                      viewBox="0 0 52 52"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M26.567 3.89L32.544 8H42a1 1 0 011 1v6.188l6.566 4.514a1 1 0 01.434.824V47a1 1 0 01-1 1H3a1 1 0 01-1-1V20.526a1 1 0 01.433-.824L9 15.188V9a1 1 0 011-1h9.455l5.979-4.11a1 1 0 011.133 0zM22.985 8h6.03L26 5.927 22.985 8zM9 17.615l-5 3.437v.323l5 3.438v-7.198zm2 8.573l10.537 7.244 2.873-1.796a3 3 0 013.18 0l2.873 1.796L41 26.188V10H11v16.188zm32-1.375l5-3.438v-.323l-5-3.437v7.198zm5-1.01L32.313 34.586 48 44.392v-20.59zM4 44.391l15.687-9.805L4 23.802v20.59zm21.47-11.06L5.2 46h41.6L26.53 33.332a1 1 0 00-1.06 0z"
+                        fill="#4E6896"
+                        fill-rule="evenodd"
+                      />
+                      <path
+                        d="M16 17c0-.552.471-1 1.053-1h17.894c.582 0 1.053.448 1.053 1s-.471 1-1.053 1H17.053C16.47 18 16 17.552 16 17zm1.053 5C16.47 22 16 22.448 16 23s.471 1 1.053 1h17.894C35.53 24 36 23.552 36 23s-.471-1-1.053-1H17.053z"
+                        fill="#FF7067"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="c34"
+                  >
+                    <span
+                      class="c35"
+                    >
+                      Modèles de documents
+                    </span>
+                    <h3
+                      class="c36 c37"
+                    >
+                      related letter title 2
+                    </h3>
+                  </div>
+                </div>
+                <div
+                  class="c38"
+                >
+                  <div
+                    class="c39"
+                  >
+                    <div
+                      class="c40"
+                    >
+                      <div
+                        class="c18 c41"
+                      >
+                        Consulter
+                        <svg
+                          class="c42"
+                          fill="none"
+                          viewBox="0 0 28 15"
+                        >
+                          <path
+                            d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </a>
+            </li>
+            <li
+              class="c27"
+            >
+              <a
+                class="c28 c29"
+                href="/outils/TOOL_1"
+              >
+                <div
+                  class="c30"
+                >
+                  <div
+                    class="c31"
+                  >
+                    <svg
+                      fill="none"
+                      viewBox="0 0 32 32"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M11.938 16.5a3.548 3.548 0 013.562-3.563 3.548 3.548 0 013.563 3.563 3.548 3.548 0 01-3.563 3.563 3.548 3.548 0 01-3.563-3.563zm2.062 0c0 .84.66 1.5 1.5 1.5s1.5-.66 1.5-1.5-.66-1.5-1.5-1.5-1.5.66-1.5 1.5z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                      />
+                      <path
+                        clip-rule="evenodd"
+                        d="M25 14.838v3.404l-1.663.87-.474 1.109.554 1.82-2.375 2.376-1.9-.555-1.109.476-.87 1.662h-3.405l-.87-1.663-1.109-.474-1.82.554-2.376-2.375.554-1.9-.475-1.109L6 18.163v-3.405l1.662-.87.475-1.109-.554-1.82 2.375-2.376 1.9.554 1.109-.475.87-1.662h3.405l.87 1.662 1.109.475 1.82-.554 2.376 2.375-.555 1.9.476 1.109 1.662.87zm-4.1 5.112l.825-2.025L23 17.25v-1.5l-1.2-.6-.825-2.025.375-1.35-1.05-1.05-1.35.375-2.025-.825L16.25 9h-1.5l-.6 1.2-2.025.825-1.35-.375-1.05 1.05.375 1.35-.825 2.025L8 15.75v1.5l1.2.6.825 2.025-.375 1.35 1.05 1.05 1.35-.375 2.025.825L14.75 24h1.5l.6-1.2 2.025-.825 1.35.375 1.05-1.05-.375-1.35z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  class="c32"
+                >
+                  <div
+                    class="c33"
+                  >
+                    <svg
+                      fill="none"
+                      viewBox="0 0 52 52"
+                    >
+                      <path
+                        d="M43.566 34.192a.752.752 0 00-.47-.191.615.615 0 00-.454.173.592.592 0 00-.177.444v3.68H29v4.939h13.467v3.682c0 .163.067.32.185.436a.635.635 0 00.445.181.625.625 0 00.45-.183l6.277-6.143a.645.645 0 000-.885l-6.258-6.133z"
+                        fill="#FF7067"
+                      />
+                      <path
+                        d="M29.112 4c-.312-.015-.495.131-.698.361-.201.228-.215.563-.214.871L28.195 27 17.8 17a1.176 1.176 0 00-1.205.002c-.182.11-.334.267-.438.456a1.257 1.257 0 00-.157.62V27L4.8 17a1.176 1.176 0 00-1.205.002c-.182.11-.334.267-.438.456a1.258 1.258 0 00-.157.62l.151 30.652c0 .327.127.64.352.871.225.231.53.361.848.361h35.427c.318 0 .623-.13.848-.36a1.25 1.25 0 00.352-.872V46H39v2H5V20l11.157 9.602a1.177 1.177 0 001.204-.003c.183-.109.334-.266.439-.455a1.26 1.26 0 00.156-.62L18 20.5l10.2 9.102a1.177 1.177 0 001.205-.003c.182-.109.334-.266.438-.455a1.25 1.25 0 00.157-.62V6h9v29h1.978V5.232c0-.327-.127-.64-.352-.871a1.185 1.185 0 00-.848-.36H29.112z"
+                        fill="#4E6896"
+                      />
+                      <path
+                        d="M35 37v-2.809c0-.327-.127-.64-.352-.871a1.184 1.184 0 00-.848-.36h-8.6a1.173 1.173 0 00-.113 0 1.19 1.19 0 00-.776.398 1.251 1.251 0 00-.311.833v8.624c0 .327.127.64.352.871.224.231.53.361.848.361H27V42h-1v-7h7v2h2z"
+                        fill="#4E6896"
+                      />
+                      <path
+                        clip-rule="evenodd"
+                        d="M10.287 32.96a1.189 1.189 0 00-.776.398 1.25 1.25 0 00-.311.833v8.624c0 .327.126.64.351.871.226.231.53.361.849.361h8.4c.318 0 .623-.13.848-.36a1.25 1.25 0 00.352-.872v-8.624c0-.327-.127-.64-.352-.871a1.184 1.184 0 00-.848-.36h-8.4a1.173 1.173 0 00-.113 0zM11 35h7v7h-7v-7z"
+                        fill="#4E6896"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="c34"
+                  >
+                    <span
+                      class="c35"
+                    >
+                      Outils
+                    </span>
+                    <h3
+                      class="c36 c37"
+                    >
+                      related tool title 1
+                    </h3>
+                  </div>
+                </div>
+                <div
+                  class="c38"
+                >
+                  <div
+                    class="c39"
+                  >
+                    <div
+                      class="c40"
+                    >
+                      <div
+                        class="c18 c41"
+                      >
+                        tools action
+                        <svg
+                          class="c42"
+                          fill="none"
+                          viewBox="0 0 28 15"
+                        >
+                          <path
+                            d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </a>
+            </li>
+            <li
+              class="c27"
+            >
+              <a
+                class="c28 c29"
+                href="/outils/TOOL_2"
+              >
+                <div
+                  class="c30"
+                >
+                  <div
+                    class="c31"
+                  >
+                    <svg
+                      fill="none"
+                      viewBox="0 0 32 32"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M11.938 16.5a3.548 3.548 0 013.562-3.563 3.548 3.548 0 013.563 3.563 3.548 3.548 0 01-3.563 3.563 3.548 3.548 0 01-3.563-3.563zm2.062 0c0 .84.66 1.5 1.5 1.5s1.5-.66 1.5-1.5-.66-1.5-1.5-1.5-1.5.66-1.5 1.5z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                      />
+                      <path
+                        clip-rule="evenodd"
+                        d="M25 14.838v3.404l-1.663.87-.474 1.109.554 1.82-2.375 2.376-1.9-.555-1.109.476-.87 1.662h-3.405l-.87-1.663-1.109-.474-1.82.554-2.376-2.375.554-1.9-.475-1.109L6 18.163v-3.405l1.662-.87.475-1.109-.554-1.82 2.375-2.376 1.9.554 1.109-.475.87-1.662h3.405l.87 1.662 1.109.475 1.82-.554 2.376 2.375-.555 1.9.476 1.109 1.662.87zm-4.1 5.112l.825-2.025L23 17.25v-1.5l-1.2-.6-.825-2.025.375-1.35-1.05-1.05-1.35.375-2.025-.825L16.25 9h-1.5l-.6 1.2-2.025.825-1.35-.375-1.05 1.05.375 1.35-.825 2.025L8 15.75v1.5l1.2.6.825 2.025-.375 1.35 1.05 1.05 1.35-.375 2.025.825L14.75 24h1.5l.6-1.2 2.025-.825 1.35.375 1.05-1.05-.375-1.35z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  class="c32"
+                >
+                  <div
+                    class="c33"
+                  >
+                    <svg
+                      fill="none"
+                      viewBox="0 0 52 52"
+                    >
+                      <path
+                        d="M43.566 34.192a.752.752 0 00-.47-.191.615.615 0 00-.454.173.592.592 0 00-.177.444v3.68H29v4.939h13.467v3.682c0 .163.067.32.185.436a.635.635 0 00.445.181.625.625 0 00.45-.183l6.277-6.143a.645.645 0 000-.885l-6.258-6.133z"
+                        fill="#FF7067"
+                      />
+                      <path
+                        d="M29.112 4c-.312-.015-.495.131-.698.361-.201.228-.215.563-.214.871L28.195 27 17.8 17a1.176 1.176 0 00-1.205.002c-.182.11-.334.267-.438.456a1.257 1.257 0 00-.157.62V27L4.8 17a1.176 1.176 0 00-1.205.002c-.182.11-.334.267-.438.456a1.258 1.258 0 00-.157.62l.151 30.652c0 .327.127.64.352.871.225.231.53.361.848.361h35.427c.318 0 .623-.13.848-.36a1.25 1.25 0 00.352-.872V46H39v2H5V20l11.157 9.602a1.177 1.177 0 001.204-.003c.183-.109.334-.266.439-.455a1.26 1.26 0 00.156-.62L18 20.5l10.2 9.102a1.177 1.177 0 001.205-.003c.182-.109.334-.266.438-.455a1.25 1.25 0 00.157-.62V6h9v29h1.978V5.232c0-.327-.127-.64-.352-.871a1.185 1.185 0 00-.848-.36H29.112z"
+                        fill="#4E6896"
+                      />
+                      <path
+                        d="M35 37v-2.809c0-.327-.127-.64-.352-.871a1.184 1.184 0 00-.848-.36h-8.6a1.173 1.173 0 00-.113 0 1.19 1.19 0 00-.776.398 1.251 1.251 0 00-.311.833v8.624c0 .327.127.64.352.871.224.231.53.361.848.361H27V42h-1v-7h7v2h2z"
+                        fill="#4E6896"
+                      />
+                      <path
+                        clip-rule="evenodd"
+                        d="M10.287 32.96a1.189 1.189 0 00-.776.398 1.25 1.25 0 00-.311.833v8.624c0 .327.126.64.351.871.226.231.53.361.849.361h8.4c.318 0 .623-.13.848-.36a1.25 1.25 0 00.352-.872v-8.624c0-.327-.127-.64-.352-.871a1.184 1.184 0 00-.848-.36h-8.4a1.173 1.173 0 00-.113 0zM11 35h7v7h-7v-7z"
+                        fill="#4E6896"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="c34"
+                  >
+                    <span
+                      class="c35"
+                    >
+                      Outils
+                    </span>
+                    <h3
+                      class="c36 c37"
+                    >
+                      related tool title 2
+                    </h3>
+                  </div>
+                </div>
+                <div
+                  class="c38"
+                >
+                  <div
+                    class="c39"
+                  >
+                    <div
+                      class="c40"
+                    >
+                      <div
+                        class="c18 c41"
+                      >
+                        tools action 2
+                        <svg
+                          class="c42"
+                          fill="none"
+                          viewBox="0 0 28 15"
+                        >
+                          <path
+                            d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </a>
+            </li>
+            <li
+              class="c27"
+            >
+              <a
+                class="c28 c43"
+                href="url.extrenal/tool"
+                rel="noopener nofollow"
+                target="_blank"
+              >
+                <div
+                  class="c32"
+                >
+                  <div
+                    class="c33"
+                  >
+                    <svg
+                      fill="none"
+                      viewBox="0 0 52 52"
+                    >
+                      <path
+                        d="M41.953 2H9.047A3.05 3.05 0 006 5.047V15c0 .56.455 1 1.016 1 .56 0 1.015-.44 1.015-1V5.047c0-.56.456-1.016 1.016-1.016h32.906c.56 0 1.016.456 1.016 1.016v41.906c0 .56-.456 1.016-1.016 1.016H9.047c-.56 0-1.016-.456-1.016-1.016V23.971a1.016 1.016 0 00-2.031 0v22.982A3.05 3.05 0 009.047 50h32.906A3.05 3.05 0 0045 46.953V5.047A3.05 3.05 0 0041.953 2z"
+                        fill="#4E6896"
+                      />
+                      <path
+                        d="M7.062 18a1.018 1.018 0 011.015 1.015 1.017 1.017 0 01-1.734.719 1.026 1.026 0 01-.297-.72c.001-.268.108-.526.297-.717.19-.19.451-.297.719-.297zm13.063 18.297a1.016 1.016 0 00-1.436 0l-2.7 2.7-1.255-1.255a1.016 1.016 0 00-1.437 1.436l1.974 1.974a1.016 1.016 0 001.436 0l3.418-3.418a1.016 1.016 0 000-1.437zm.06-8a1.016 1.016 0 00-1.436 0l-2.7 2.7-1.256-1.255a1.016 1.016 0 00-1.436 1.436l1.974 1.974a1.016 1.016 0 001.436 0l3.418-3.418a1.016 1.016 0 000-1.437z"
+                        fill="#4E6896"
+                      />
+                      <path
+                        clip-rule="evenodd"
+                        d="M12.016 10h10c.56 0 1.015.455 1.015 1.016v9.968c0 .561-.454 1.016-1.015 1.016h-10A1.016 1.016 0 0111 20.984v-9.968c0-.561.455-1.016 1.016-1.016zM21 19.969h-7.969V12.03H21v7.938z"
+                        fill="#4E6896"
+                        fill-rule="evenodd"
+                      />
+                      <path
+                        d="M29.016 11h9.109a1.016 1.016 0 010 2.031h-9.11a1.016 1.016 0 010-2.031zm0 8h9.109a1.016 1.016 0 010 2.031h-9.11a1.016 1.016 0 010-2.031zm8.96 10H26.024C25.46 29 25 29.448 25 30s.459 1 1.024 1h11.952C38.54 31 39 30.552 39 30s-.459-1-1.024-1zm0 9H26.024C25.46 38 25 38.448 25 39s.459 1 1.024 1h11.952C38.54 40 39 39.552 39 39s-.459-1-1.024-1zm.149-23h-9.11a1.016 1.016 0 000 2.031h9.11a1.016 1.016 0 000-2.031z"
+                        fill="#FF7067"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="c34"
+                  >
+                    
+                    <h3
+                      class="c36 c37"
+                    >
+                      related external title 1
+                    </h3>
+                  </div>
+                </div>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div
+        class="c2"
       >
-        <a
-          class="c24 c39"
-          href="url.extrenal/tool"
-          rel="noopener nofollow"
-          target="_blank"
+        <div>
+          Les articles pouvant vous intéresser :
+        </div>
+        <ul
+          class="c44"
         >
-          <div
-            class="c28"
+          <li
+            class="c45"
           >
-            <div
-              class="c29"
+            <a
+              class="c46 c47"
+              href="/fiche-service-public/LINK_1"
             >
               <svg
+                class="c48"
                 fill="none"
-                viewBox="0 0 52 52"
+                viewBox="0 0 28 15"
               >
                 <path
-                  d="M41.953 2H9.047A3.05 3.05 0 006 5.047V15c0 .56.455 1 1.016 1 .56 0 1.015-.44 1.015-1V5.047c0-.56.456-1.016 1.016-1.016h32.906c.56 0 1.016.456 1.016 1.016v41.906c0 .56-.456 1.016-1.016 1.016H9.047c-.56 0-1.016-.456-1.016-1.016V23.971a1.016 1.016 0 00-2.031 0v22.982A3.05 3.05 0 009.047 50h32.906A3.05 3.05 0 0045 46.953V5.047A3.05 3.05 0 0041.953 2z"
-                  fill="#4E6896"
-                />
-                <path
-                  d="M7.062 18a1.018 1.018 0 011.015 1.015 1.017 1.017 0 01-1.734.719 1.026 1.026 0 01-.297-.72c.001-.268.108-.526.297-.717.19-.19.451-.297.719-.297zm13.063 18.297a1.016 1.016 0 00-1.436 0l-2.7 2.7-1.255-1.255a1.016 1.016 0 00-1.437 1.436l1.974 1.974a1.016 1.016 0 001.436 0l3.418-3.418a1.016 1.016 0 000-1.437zm.06-8a1.016 1.016 0 00-1.436 0l-2.7 2.7-1.256-1.255a1.016 1.016 0 00-1.436 1.436l1.974 1.974a1.016 1.016 0 001.436 0l3.418-3.418a1.016 1.016 0 000-1.437z"
-                  fill="#4E6896"
-                />
-                <path
-                  clip-rule="evenodd"
-                  d="M12.016 10h10c.56 0 1.015.455 1.015 1.016v9.968c0 .561-.454 1.016-1.015 1.016h-10A1.016 1.016 0 0111 20.984v-9.968c0-.561.455-1.016 1.016-1.016zM21 19.969h-7.969V12.03H21v7.938z"
-                  fill="#4E6896"
-                  fill-rule="evenodd"
-                />
-                <path
-                  d="M29.016 11h9.109a1.016 1.016 0 010 2.031h-9.11a1.016 1.016 0 010-2.031zm0 8h9.109a1.016 1.016 0 010 2.031h-9.11a1.016 1.016 0 010-2.031zm8.96 10H26.024C25.46 29 25 29.448 25 30s.459 1 1.024 1h11.952C38.54 31 39 30.552 39 30s-.459-1-1.024-1zm0 9H26.024C25.46 38 25 38.448 25 39s.459 1 1.024 1h11.952C38.54 40 39 39.552 39 39s-.459-1-1.024-1zm.149-23h-9.11a1.016 1.016 0 000 2.031h9.11a1.016 1.016 0 000-2.031z"
-                  fill="#FF7067"
+                  d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
+                  fill="currentColor"
                 />
               </svg>
-            </div>
-            <div
-              class="c30"
-            >
-              
-              <h3
-                class="c32 c33"
+              <span
+                class="c49"
               >
-                related external title 1
-              </h3>
-            </div>
-          </div>
-        </a>
-      </li>
-      <span>
-        Les articles pouvant vous intéresser :
-      </span>
-      <li
-        class="c23"
-      >
-        <a
-          class="c40 c41"
-          href="/fiche-service-public/LINK_1"
-        >
-          <svg
-            class="c42"
-            fill="none"
-            viewBox="0 0 28 15"
+                related sheet sp title 1
+              </span>
+            </a>
+          </li>
+          <li
+            class="c45"
           >
-            <path
-              d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
-              fill="currentColor"
-            />
-          </svg>
-          <span
-            class="c43"
+            <a
+              class="c46 c47"
+              href="/fiche-ministere-travail/LINK_2"
+            >
+              <svg
+                class="c48"
+                fill="none"
+                viewBox="0 0 28 15"
+              >
+                <path
+                  d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
+                  fill="currentColor"
+                />
+              </svg>
+              <span
+                class="c49"
+              >
+                related sheet mt title 1
+              </span>
+            </a>
+          </li>
+          <li
+            class="c45"
           >
-            related sheet sp title 1
-          </span>
-        </a>
-      </li>
-      <li
-        class="c23"
-      >
-        <a
-          class="c40 c41"
-          href="/fiche-ministere-travail/LINK_2"
-        >
-          <svg
-            class="c42"
-            fill="none"
-            viewBox="0 0 28 15"
-          >
-            <path
-              d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
-              fill="currentColor"
-            />
-          </svg>
-          <span
-            class="c43"
-          >
-            related sheet mt title 1
-          </span>
-        </a>
-      </li>
-      <li
-        class="c23"
-      >
-        <a
-          class="c40 c41"
-          href="/fiche-service-public/LINK_4"
-        >
-          <svg
-            class="c42"
-            fill="none"
-            viewBox="0 0 28 15"
-          >
-            <path
-              d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
-              fill="currentColor"
-            />
-          </svg>
-          <span
-            class="c43"
-          >
-            related sheet sp title 2
-          </span>
-        </a>
-      </li>
-    </ul>
+            <a
+              class="c46 c47"
+              href="/fiche-service-public/LINK_4"
+            >
+              <svg
+                class="c48"
+                fill="none"
+                viewBox="0 0 28 15"
+              >
+                <path
+                  d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
+                  fill="currentColor"
+                />
+              </svg>
+              <span
+                class="c49"
+              >
+                related sheet sp title 2
+              </span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -3505,6 +3886,12 @@ exports[`<Answer /> should renders tooltip 1`] = `
 }
 
 @media (max-width:600px) {
+  .c12 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c3 {
     padding: 1.6rem 1rem;
   }
@@ -3601,7 +3988,6 @@ exports[`<Answer /> should renders tooltip 1`] = `
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
     align-items: stretch;
-    max-width: 60rem;
     margin-right: auto;
     margin-left: auto;
   }
@@ -4113,6 +4499,12 @@ exports[`<Answer /> should renders tooltip for words with diacritics without bre
 }
 
 @media (max-width:600px) {
+  .c12 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c3 {
     padding: 1.6rem 1rem;
   }
@@ -4209,7 +4601,6 @@ exports[`<Answer /> should renders tooltip for words with diacritics without bre
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
     align-items: stretch;
-    max-width: 60rem;
     margin-right: auto;
     margin-left: auto;
   }
@@ -4707,6 +5098,12 @@ exports[`<Answer /> should renders tooltip without breaking a tag 1`] = `
 }
 
 @media (max-width:600px) {
+  .c12 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c3 {
     padding: 1.6rem 1rem;
   }
@@ -4803,7 +5200,6 @@ exports[`<Answer /> should renders tooltip without breaking a tag 1`] = `
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
     align-items: stretch;
-    max-width: 60rem;
     margin-right: auto;
     margin-left: auto;
   }
@@ -5292,6 +5688,12 @@ exports[`<Answer /> should renders tooltip without breaking previous word 1`] = 
 }
 
 @media (max-width:600px) {
+  .c12 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c3 {
     padding: 1.6rem 1rem;
   }
@@ -5388,7 +5790,6 @@ exports[`<Answer /> should renders tooltip without breaking previous word 1`] = 
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
     align-items: stretch;
-    max-width: 60rem;
     margin-right: auto;
     margin-left: auto;
   }

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/Answer.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/Answer.test.js.snap
@@ -2012,7 +2012,7 @@ exports[`<Answer /> should renders related content 1`] = `
   margin-bottom: 0;
 }
 
-.c47 {
+.c43 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2025,14 +2025,14 @@ exports[`<Answer /> should renders related content 1`] = `
   text-decoration: none;
 }
 
-.c49 {
+.c45 {
   -webkit-flex: 0 1 auto;
   -ms-flex: 0 1 auto;
   flex: 0 1 auto;
   width: auto;
 }
 
-.c48 {
+.c44 {
   -webkit-flex: 0 0 2.8rem;
   -ms-flex: 0 0 2.8rem;
   flex: 0 0 2.8rem;
@@ -2046,13 +2046,13 @@ exports[`<Answer /> should renders related content 1`] = `
   transition: transform 250ms linear;
 }
 
-.c46:hover .c48 {
+.c42:hover .c44 {
   -webkit-transform: translateX(4px);
   -ms-transform: translateX(4px);
   transform: translateX(4px);
 }
 
-.c30 {
+.c37 {
   position: absolute;
   top: 0;
   right: 0;
@@ -2063,7 +2063,7 @@ exports[`<Answer /> should renders related content 1`] = `
   border-radius: 0 0.6rem 0 0;
 }
 
-.c30:before {
+.c37:before {
   position: absolute;
   display: block;
   width: 0;
@@ -2074,7 +2074,7 @@ exports[`<Answer /> should renders related content 1`] = `
   content: "";
 }
 
-.c31 {
+.c38 {
   position: absolute;
   top: 0;
   right: 0;
@@ -2146,7 +2146,7 @@ exports[`<Answer /> should renders related content 1`] = `
   cursor: not-allowed;
 }
 
-.c41 {
+.c35 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2187,14 +2187,14 @@ exports[`<Answer /> should renders related content 1`] = `
   overflow: visible;
 }
 
-.c41:focus,
-.c41:hover,
-.c41:active {
+.c35:focus,
+.c35:hover,
+.c35:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c42 {
+.c36 {
   width: 2.6rem;
   height: 1.4rem;
   margin: 0 0.4rem 0 1rem;
@@ -2203,107 +2203,13 @@ exports[`<Answer /> should renders related content 1`] = `
   transition: transform 250ms linear;
 }
 
-.c18:hover .c42 {
+.c18:hover .c36 {
   -webkit-transform: translateX(4px);
   -ms-transform: translateX(4px);
   transform: translateX(4px);
 }
 
-.c23 {
-  position: relative;
-  overflow: hidden;
-}
-
-.c23:before,
-.c23:after {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  z-index: 1;
-  display: block;
-  width: 4rem;
-  opacity: 0;
-  -webkit-transition: opacity 0.3s linear;
-  transition: opacity 0.3s linear;
-  content: "";
-  pointer-events: none;
-  background: radial-gradient( ellipse at center, #fff 15%, rgba(255,255,255,0) 80% );
-}
-
-.c23:before {
-  left: -2rem;
-}
-
-.c23:after {
-  right: -2rem;
-}
-
-.c25 {
-  overflow-x: auto;
-}
-
-.c26 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
-  align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  margin-top: 0;
-  margin-right: calc(-1 * 1rem);
-  margin-bottom: 4rem;
-  margin-left: calc(-1 * 1rem);
-  padding: 0;
-  list-style-type: none;
-  margin-right: 0;
-  margin-left: 0;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.c27 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
-  flex-grow: 0;
-  margin: 1rem;
-  padding: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  margin-bottom: 0;
-}
-
-.c27:first-of-type {
-  margin-left: 2rem;
-}
-
-.c27:last-of-type:after {
-  display: block;
-  width: 2rem;
-  height: 100%;
-  background-color: transparent;
-  content: "";
-}
-
-.c44 {
+.c40 {
   margin: 0;
   padding: 0;
   list-style-type: none;
@@ -2347,7 +2253,7 @@ exports[`<Answer /> should renders related content 1`] = `
   padding-left: 2.4rem;
 }
 
-.c36 {
+.c30 {
   position: relative;
   margin: 3.2rem 0 2rem 0;
   color: #2f3b6c;
@@ -2357,7 +2263,7 @@ exports[`<Answer /> should renders related content 1`] = `
   line-height: 1.625;
 }
 
-.c35 {
+.c39 {
   display: block;
   margin: 0 0 1rem 0;
   color: #4d73b8;
@@ -2368,7 +2274,7 @@ exports[`<Answer /> should renders related content 1`] = `
   text-transform: uppercase;
 }
 
-.c28 {
+.c26 {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -2409,9 +2315,9 @@ exports[`<Answer /> should renders related content 1`] = `
   appearance: none;
 }
 
-.c28:hover,
-.c28:active,
-.c28:focus {
+.c26:hover,
+.c26:active,
+.c26:focus {
   color: #3e486e;
   box-shadow: 0 1rem 2rem rgba(121,148,212,0.4);
   -webkit-transform: translateY(-2px);
@@ -2419,7 +2325,7 @@ exports[`<Answer /> should renders related content 1`] = `
   transform: translateY(-2px);
 }
 
-.c33 {
+.c28 {
   display: block;
   width: 7.2rem;
   height: 7.2rem;
@@ -2429,21 +2335,21 @@ exports[`<Answer /> should renders related content 1`] = `
   border-radius: 50%;
 }
 
-.c32 {
+.c27 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
 }
 
-.c34 {
+.c29 {
   padding-right: 1rem;
 }
 
-.c37 {
+.c31 {
   margin: 0;
 }
 
-.c38 {
+.c32 {
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -2543,7 +2449,7 @@ exports[`<Answer /> should renders related content 1`] = `
   margin-left: 4rem;
 }
 
-.c39 {
+.c33 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2558,7 +2464,7 @@ exports[`<Answer /> should renders related content 1`] = `
   height: 100%;
 }
 
-.c40 {
+.c34 {
   margin-top: 1rem;
 }
 
@@ -2570,16 +2476,19 @@ exports[`<Answer /> should renders related content 1`] = `
   margin-left: 4rem;
 }
 
-.c43 {
-  max-width: 28rem;
+.c23 {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
 }
 
-.c29 {
-  max-width: 28rem;
+.c25 {
+  margin: 0 0 1.6rem 0;
+  padding: 0;
 }
 
-.c45 {
-  margin: 1.6rem 0;
+.c41 {
+  margin: 0 0 1.6rem 0;
   padding: 0;
 }
 
@@ -2675,44 +2584,8 @@ exports[`<Answer /> should renders related content 1`] = `
 }
 
 @media (max-width:600px) {
-  .c41 {
+  .c35 {
     font-size: 1.4rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c23 {
-    overflow-x: hidden;
-  }
-}
-
-@media (max-width:600px) {
-  .c23:before,
-  .c23:after {
-    display: block;
-  }
-}
-
-@media (max-width:600px) {
-  .c25 {
-    overflow-x: auto;
-  }
-}
-
-@media (max-width:600px) {
-  .c24 {
-    margin-bottom: 1.6rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c26 {
-    -webkit-flex-wrap: nowrap;
-    -ms-flex-wrap: nowrap;
-    flex-wrap: nowrap;
-    margin-right: 0;
-    margin-bottom: 2rem;
-    margin-left: 0;
   }
 }
 
@@ -2730,13 +2603,13 @@ exports[`<Answer /> should renders related content 1`] = `
 }
 
 @media (max-width:600px) {
-  .c36 {
+  .c30 {
     font-size: 1.6rem;
   }
 }
 
 @media (max-width:600px) {
-  .c28 {
+  .c26 {
     padding: 2rem 1.6rem;
     font-size: 1.4rem;
   }
@@ -2850,6 +2723,57 @@ exports[`<Answer /> should renders related content 1`] = `
 @media (max-width:980px) {
   .c22 {
     width: 100%;
+  }
+}
+
+@media (max-width:980px) {
+  .c23 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (max-width:600px) {
+  .c23 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media (max-width:980px) {
+  .c25 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex: 1 0 auto;
+    -ms-flex: 1 0 auto;
+    flex: 1 0 auto;
+    -webkit-box-pack: stretch;
+    -webkit-justify-content: stretch;
+    -ms-flex-pack: stretch;
+    justify-content: stretch;
+    width: calc((100% - 1.6rem) / 2);
+  }
+
+  .c25 + .c24 {
+    margin-left: 1.6rem;
+  }
+}
+
+@media (max-width:600px) {
+  .c25 {
+    -webkit-flex: 1 0 auto;
+    -ms-flex: 1 0 auto;
+    flex: 1 0 auto;
+    width: 100%;
+  }
+
+  .c25 + .c24 {
+    margin-left: 0;
   }
 }
 
@@ -3029,495 +2953,214 @@ exports[`<Answer /> should renders related content 1`] = `
       class="c12 c22"
     >
       <div
-        class="c23 c24"
-      >
-        <div
-          class="c25"
-        >
-          <ul
-            class="c26"
-          >
-            <li
-              class="c27"
-            >
-              <a
-                class="c28 c29"
-                href="/modeles-de-courriers/LETTER_1"
-              >
-                <div
-                  class="c30"
-                >
-                  <div
-                    class="c31"
-                  >
-                    <svg
-                      fill="none"
-                      viewBox="0 0 32 32"
-                    >
-                      <path
-                        clip-rule="evenodd"
-                        d="M11.938 16.5a3.548 3.548 0 013.562-3.563 3.548 3.548 0 013.563 3.563 3.548 3.548 0 01-3.563 3.563 3.548 3.548 0 01-3.563-3.563zm2.062 0c0 .84.66 1.5 1.5 1.5s1.5-.66 1.5-1.5-.66-1.5-1.5-1.5-1.5.66-1.5 1.5z"
-                        fill="currentColor"
-                        fill-rule="evenodd"
-                      />
-                      <path
-                        clip-rule="evenodd"
-                        d="M25 14.838v3.404l-1.663.87-.474 1.109.554 1.82-2.375 2.376-1.9-.555-1.109.476-.87 1.662h-3.405l-.87-1.663-1.109-.474-1.82.554-2.376-2.375.554-1.9-.475-1.109L6 18.163v-3.405l1.662-.87.475-1.109-.554-1.82 2.375-2.376 1.9.554 1.109-.475.87-1.662h3.405l.87 1.662 1.109.475 1.82-.554 2.376 2.375-.555 1.9.476 1.109 1.662.87zm-4.1 5.112l.825-2.025L23 17.25v-1.5l-1.2-.6-.825-2.025.375-1.35-1.05-1.05-1.35.375-2.025-.825L16.25 9h-1.5l-.6 1.2-2.025.825-1.35-.375-1.05 1.05.375 1.35-.825 2.025L8 15.75v1.5l1.2.6.825 2.025-.375 1.35 1.05 1.05 1.35-.375 2.025.825L14.75 24h1.5l.6-1.2 2.025-.825 1.35.375 1.05-1.05-.375-1.35z"
-                        fill="currentColor"
-                        fill-rule="evenodd"
-                      />
-                    </svg>
-                  </div>
-                </div>
-                <div
-                  class="c32"
-                >
-                  <div
-                    class="c33"
-                  >
-                    <svg
-                      fill="none"
-                      viewBox="0 0 52 52"
-                    >
-                      <path
-                        clip-rule="evenodd"
-                        d="M26.567 3.89L32.544 8H42a1 1 0 011 1v6.188l6.566 4.514a1 1 0 01.434.824V47a1 1 0 01-1 1H3a1 1 0 01-1-1V20.526a1 1 0 01.433-.824L9 15.188V9a1 1 0 011-1h9.455l5.979-4.11a1 1 0 011.133 0zM22.985 8h6.03L26 5.927 22.985 8zM9 17.615l-5 3.437v.323l5 3.438v-7.198zm2 8.573l10.537 7.244 2.873-1.796a3 3 0 013.18 0l2.873 1.796L41 26.188V10H11v16.188zm32-1.375l5-3.438v-.323l-5-3.437v7.198zm5-1.01L32.313 34.586 48 44.392v-20.59zM4 44.391l15.687-9.805L4 23.802v20.59zm21.47-11.06L5.2 46h41.6L26.53 33.332a1 1 0 00-1.06 0z"
-                        fill="#4E6896"
-                        fill-rule="evenodd"
-                      />
-                      <path
-                        d="M16 17c0-.552.471-1 1.053-1h17.894c.582 0 1.053.448 1.053 1s-.471 1-1.053 1H17.053C16.47 18 16 17.552 16 17zm1.053 5C16.47 22 16 22.448 16 23s.471 1 1.053 1h17.894C35.53 24 36 23.552 36 23s-.471-1-1.053-1H17.053z"
-                        fill="#FF7067"
-                      />
-                    </svg>
-                  </div>
-                  <div
-                    class="c34"
-                  >
-                    <span
-                      class="c35"
-                    >
-                      Modèles de documents
-                    </span>
-                    <h3
-                      class="c36 c37"
-                    >
-                      related letter title 1
-                    </h3>
-                  </div>
-                </div>
-                <div
-                  class="c38"
-                >
-                  <div
-                    class="c39"
-                  >
-                    <div
-                      class="c40"
-                    >
-                      <div
-                        class="c18 c41"
-                      >
-                        Consulter
-                        <svg
-                          class="c42"
-                          fill="none"
-                          viewBox="0 0 28 15"
-                        >
-                          <path
-                            d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
-                            fill="currentColor"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </a>
-            </li>
-            <li
-              class="c27"
-            >
-              <a
-                class="c28 c29"
-                href="/modeles-de-courriers/LETTER_2"
-              >
-                <div
-                  class="c30"
-                >
-                  <div
-                    class="c31"
-                  >
-                    <svg
-                      fill="none"
-                      viewBox="0 0 32 32"
-                    >
-                      <path
-                        clip-rule="evenodd"
-                        d="M11.938 16.5a3.548 3.548 0 013.562-3.563 3.548 3.548 0 013.563 3.563 3.548 3.548 0 01-3.563 3.563 3.548 3.548 0 01-3.563-3.563zm2.062 0c0 .84.66 1.5 1.5 1.5s1.5-.66 1.5-1.5-.66-1.5-1.5-1.5-1.5.66-1.5 1.5z"
-                        fill="currentColor"
-                        fill-rule="evenodd"
-                      />
-                      <path
-                        clip-rule="evenodd"
-                        d="M25 14.838v3.404l-1.663.87-.474 1.109.554 1.82-2.375 2.376-1.9-.555-1.109.476-.87 1.662h-3.405l-.87-1.663-1.109-.474-1.82.554-2.376-2.375.554-1.9-.475-1.109L6 18.163v-3.405l1.662-.87.475-1.109-.554-1.82 2.375-2.376 1.9.554 1.109-.475.87-1.662h3.405l.87 1.662 1.109.475 1.82-.554 2.376 2.375-.555 1.9.476 1.109 1.662.87zm-4.1 5.112l.825-2.025L23 17.25v-1.5l-1.2-.6-.825-2.025.375-1.35-1.05-1.05-1.35.375-2.025-.825L16.25 9h-1.5l-.6 1.2-2.025.825-1.35-.375-1.05 1.05.375 1.35-.825 2.025L8 15.75v1.5l1.2.6.825 2.025-.375 1.35 1.05 1.05 1.35-.375 2.025.825L14.75 24h1.5l.6-1.2 2.025-.825 1.35.375 1.05-1.05-.375-1.35z"
-                        fill="currentColor"
-                        fill-rule="evenodd"
-                      />
-                    </svg>
-                  </div>
-                </div>
-                <div
-                  class="c32"
-                >
-                  <div
-                    class="c33"
-                  >
-                    <svg
-                      fill="none"
-                      viewBox="0 0 52 52"
-                    >
-                      <path
-                        clip-rule="evenodd"
-                        d="M26.567 3.89L32.544 8H42a1 1 0 011 1v6.188l6.566 4.514a1 1 0 01.434.824V47a1 1 0 01-1 1H3a1 1 0 01-1-1V20.526a1 1 0 01.433-.824L9 15.188V9a1 1 0 011-1h9.455l5.979-4.11a1 1 0 011.133 0zM22.985 8h6.03L26 5.927 22.985 8zM9 17.615l-5 3.437v.323l5 3.438v-7.198zm2 8.573l10.537 7.244 2.873-1.796a3 3 0 013.18 0l2.873 1.796L41 26.188V10H11v16.188zm32-1.375l5-3.438v-.323l-5-3.437v7.198zm5-1.01L32.313 34.586 48 44.392v-20.59zM4 44.391l15.687-9.805L4 23.802v20.59zm21.47-11.06L5.2 46h41.6L26.53 33.332a1 1 0 00-1.06 0z"
-                        fill="#4E6896"
-                        fill-rule="evenodd"
-                      />
-                      <path
-                        d="M16 17c0-.552.471-1 1.053-1h17.894c.582 0 1.053.448 1.053 1s-.471 1-1.053 1H17.053C16.47 18 16 17.552 16 17zm1.053 5C16.47 22 16 22.448 16 23s.471 1 1.053 1h17.894C35.53 24 36 23.552 36 23s-.471-1-1.053-1H17.053z"
-                        fill="#FF7067"
-                      />
-                    </svg>
-                  </div>
-                  <div
-                    class="c34"
-                  >
-                    <span
-                      class="c35"
-                    >
-                      Modèles de documents
-                    </span>
-                    <h3
-                      class="c36 c37"
-                    >
-                      related letter title 2
-                    </h3>
-                  </div>
-                </div>
-                <div
-                  class="c38"
-                >
-                  <div
-                    class="c39"
-                  >
-                    <div
-                      class="c40"
-                    >
-                      <div
-                        class="c18 c41"
-                      >
-                        Consulter
-                        <svg
-                          class="c42"
-                          fill="none"
-                          viewBox="0 0 28 15"
-                        >
-                          <path
-                            d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
-                            fill="currentColor"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </a>
-            </li>
-            <li
-              class="c27"
-            >
-              <a
-                class="c28 c29"
-                href="/outils/TOOL_1"
-              >
-                <div
-                  class="c30"
-                >
-                  <div
-                    class="c31"
-                  >
-                    <svg
-                      fill="none"
-                      viewBox="0 0 32 32"
-                    >
-                      <path
-                        clip-rule="evenodd"
-                        d="M11.938 16.5a3.548 3.548 0 013.562-3.563 3.548 3.548 0 013.563 3.563 3.548 3.548 0 01-3.563 3.563 3.548 3.548 0 01-3.563-3.563zm2.062 0c0 .84.66 1.5 1.5 1.5s1.5-.66 1.5-1.5-.66-1.5-1.5-1.5-1.5.66-1.5 1.5z"
-                        fill="currentColor"
-                        fill-rule="evenodd"
-                      />
-                      <path
-                        clip-rule="evenodd"
-                        d="M25 14.838v3.404l-1.663.87-.474 1.109.554 1.82-2.375 2.376-1.9-.555-1.109.476-.87 1.662h-3.405l-.87-1.663-1.109-.474-1.82.554-2.376-2.375.554-1.9-.475-1.109L6 18.163v-3.405l1.662-.87.475-1.109-.554-1.82 2.375-2.376 1.9.554 1.109-.475.87-1.662h3.405l.87 1.662 1.109.475 1.82-.554 2.376 2.375-.555 1.9.476 1.109 1.662.87zm-4.1 5.112l.825-2.025L23 17.25v-1.5l-1.2-.6-.825-2.025.375-1.35-1.05-1.05-1.35.375-2.025-.825L16.25 9h-1.5l-.6 1.2-2.025.825-1.35-.375-1.05 1.05.375 1.35-.825 2.025L8 15.75v1.5l1.2.6.825 2.025-.375 1.35 1.05 1.05 1.35-.375 2.025.825L14.75 24h1.5l.6-1.2 2.025-.825 1.35.375 1.05-1.05-.375-1.35z"
-                        fill="currentColor"
-                        fill-rule="evenodd"
-                      />
-                    </svg>
-                  </div>
-                </div>
-                <div
-                  class="c32"
-                >
-                  <div
-                    class="c33"
-                  >
-                    <svg
-                      fill="none"
-                      viewBox="0 0 52 52"
-                    >
-                      <path
-                        d="M43.566 34.192a.752.752 0 00-.47-.191.615.615 0 00-.454.173.592.592 0 00-.177.444v3.68H29v4.939h13.467v3.682c0 .163.067.32.185.436a.635.635 0 00.445.181.625.625 0 00.45-.183l6.277-6.143a.645.645 0 000-.885l-6.258-6.133z"
-                        fill="#FF7067"
-                      />
-                      <path
-                        d="M29.112 4c-.312-.015-.495.131-.698.361-.201.228-.215.563-.214.871L28.195 27 17.8 17a1.176 1.176 0 00-1.205.002c-.182.11-.334.267-.438.456a1.257 1.257 0 00-.157.62V27L4.8 17a1.176 1.176 0 00-1.205.002c-.182.11-.334.267-.438.456a1.258 1.258 0 00-.157.62l.151 30.652c0 .327.127.64.352.871.225.231.53.361.848.361h35.427c.318 0 .623-.13.848-.36a1.25 1.25 0 00.352-.872V46H39v2H5V20l11.157 9.602a1.177 1.177 0 001.204-.003c.183-.109.334-.266.439-.455a1.26 1.26 0 00.156-.62L18 20.5l10.2 9.102a1.177 1.177 0 001.205-.003c.182-.109.334-.266.438-.455a1.25 1.25 0 00.157-.62V6h9v29h1.978V5.232c0-.327-.127-.64-.352-.871a1.185 1.185 0 00-.848-.36H29.112z"
-                        fill="#4E6896"
-                      />
-                      <path
-                        d="M35 37v-2.809c0-.327-.127-.64-.352-.871a1.184 1.184 0 00-.848-.36h-8.6a1.173 1.173 0 00-.113 0 1.19 1.19 0 00-.776.398 1.251 1.251 0 00-.311.833v8.624c0 .327.127.64.352.871.224.231.53.361.848.361H27V42h-1v-7h7v2h2z"
-                        fill="#4E6896"
-                      />
-                      <path
-                        clip-rule="evenodd"
-                        d="M10.287 32.96a1.189 1.189 0 00-.776.398 1.25 1.25 0 00-.311.833v8.624c0 .327.126.64.351.871.226.231.53.361.849.361h8.4c.318 0 .623-.13.848-.36a1.25 1.25 0 00.352-.872v-8.624c0-.327-.127-.64-.352-.871a1.184 1.184 0 00-.848-.36h-8.4a1.173 1.173 0 00-.113 0zM11 35h7v7h-7v-7z"
-                        fill="#4E6896"
-                        fill-rule="evenodd"
-                      />
-                    </svg>
-                  </div>
-                  <div
-                    class="c34"
-                  >
-                    <span
-                      class="c35"
-                    >
-                      Outils
-                    </span>
-                    <h3
-                      class="c36 c37"
-                    >
-                      related tool title 1
-                    </h3>
-                  </div>
-                </div>
-                <div
-                  class="c38"
-                >
-                  <div
-                    class="c39"
-                  >
-                    <div
-                      class="c40"
-                    >
-                      <div
-                        class="c18 c41"
-                      >
-                        tools action
-                        <svg
-                          class="c42"
-                          fill="none"
-                          viewBox="0 0 28 15"
-                        >
-                          <path
-                            d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
-                            fill="currentColor"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </a>
-            </li>
-            <li
-              class="c27"
-            >
-              <a
-                class="c28 c29"
-                href="/outils/TOOL_2"
-              >
-                <div
-                  class="c30"
-                >
-                  <div
-                    class="c31"
-                  >
-                    <svg
-                      fill="none"
-                      viewBox="0 0 32 32"
-                    >
-                      <path
-                        clip-rule="evenodd"
-                        d="M11.938 16.5a3.548 3.548 0 013.562-3.563 3.548 3.548 0 013.563 3.563 3.548 3.548 0 01-3.563 3.563 3.548 3.548 0 01-3.563-3.563zm2.062 0c0 .84.66 1.5 1.5 1.5s1.5-.66 1.5-1.5-.66-1.5-1.5-1.5-1.5.66-1.5 1.5z"
-                        fill="currentColor"
-                        fill-rule="evenodd"
-                      />
-                      <path
-                        clip-rule="evenodd"
-                        d="M25 14.838v3.404l-1.663.87-.474 1.109.554 1.82-2.375 2.376-1.9-.555-1.109.476-.87 1.662h-3.405l-.87-1.663-1.109-.474-1.82.554-2.376-2.375.554-1.9-.475-1.109L6 18.163v-3.405l1.662-.87.475-1.109-.554-1.82 2.375-2.376 1.9.554 1.109-.475.87-1.662h3.405l.87 1.662 1.109.475 1.82-.554 2.376 2.375-.555 1.9.476 1.109 1.662.87zm-4.1 5.112l.825-2.025L23 17.25v-1.5l-1.2-.6-.825-2.025.375-1.35-1.05-1.05-1.35.375-2.025-.825L16.25 9h-1.5l-.6 1.2-2.025.825-1.35-.375-1.05 1.05.375 1.35-.825 2.025L8 15.75v1.5l1.2.6.825 2.025-.375 1.35 1.05 1.05 1.35-.375 2.025.825L14.75 24h1.5l.6-1.2 2.025-.825 1.35.375 1.05-1.05-.375-1.35z"
-                        fill="currentColor"
-                        fill-rule="evenodd"
-                      />
-                    </svg>
-                  </div>
-                </div>
-                <div
-                  class="c32"
-                >
-                  <div
-                    class="c33"
-                  >
-                    <svg
-                      fill="none"
-                      viewBox="0 0 52 52"
-                    >
-                      <path
-                        d="M43.566 34.192a.752.752 0 00-.47-.191.615.615 0 00-.454.173.592.592 0 00-.177.444v3.68H29v4.939h13.467v3.682c0 .163.067.32.185.436a.635.635 0 00.445.181.625.625 0 00.45-.183l6.277-6.143a.645.645 0 000-.885l-6.258-6.133z"
-                        fill="#FF7067"
-                      />
-                      <path
-                        d="M29.112 4c-.312-.015-.495.131-.698.361-.201.228-.215.563-.214.871L28.195 27 17.8 17a1.176 1.176 0 00-1.205.002c-.182.11-.334.267-.438.456a1.257 1.257 0 00-.157.62V27L4.8 17a1.176 1.176 0 00-1.205.002c-.182.11-.334.267-.438.456a1.258 1.258 0 00-.157.62l.151 30.652c0 .327.127.64.352.871.225.231.53.361.848.361h35.427c.318 0 .623-.13.848-.36a1.25 1.25 0 00.352-.872V46H39v2H5V20l11.157 9.602a1.177 1.177 0 001.204-.003c.183-.109.334-.266.439-.455a1.26 1.26 0 00.156-.62L18 20.5l10.2 9.102a1.177 1.177 0 001.205-.003c.182-.109.334-.266.438-.455a1.25 1.25 0 00.157-.62V6h9v29h1.978V5.232c0-.327-.127-.64-.352-.871a1.185 1.185 0 00-.848-.36H29.112z"
-                        fill="#4E6896"
-                      />
-                      <path
-                        d="M35 37v-2.809c0-.327-.127-.64-.352-.871a1.184 1.184 0 00-.848-.36h-8.6a1.173 1.173 0 00-.113 0 1.19 1.19 0 00-.776.398 1.251 1.251 0 00-.311.833v8.624c0 .327.127.64.352.871.224.231.53.361.848.361H27V42h-1v-7h7v2h2z"
-                        fill="#4E6896"
-                      />
-                      <path
-                        clip-rule="evenodd"
-                        d="M10.287 32.96a1.189 1.189 0 00-.776.398 1.25 1.25 0 00-.311.833v8.624c0 .327.126.64.351.871.226.231.53.361.849.361h8.4c.318 0 .623-.13.848-.36a1.25 1.25 0 00.352-.872v-8.624c0-.327-.127-.64-.352-.871a1.184 1.184 0 00-.848-.36h-8.4a1.173 1.173 0 00-.113 0zM11 35h7v7h-7v-7z"
-                        fill="#4E6896"
-                        fill-rule="evenodd"
-                      />
-                    </svg>
-                  </div>
-                  <div
-                    class="c34"
-                  >
-                    <span
-                      class="c35"
-                    >
-                      Outils
-                    </span>
-                    <h3
-                      class="c36 c37"
-                    >
-                      related tool title 2
-                    </h3>
-                  </div>
-                </div>
-                <div
-                  class="c38"
-                >
-                  <div
-                    class="c39"
-                  >
-                    <div
-                      class="c40"
-                    >
-                      <div
-                        class="c18 c41"
-                      >
-                        tools action 2
-                        <svg
-                          class="c42"
-                          fill="none"
-                          viewBox="0 0 28 15"
-                        >
-                          <path
-                            d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
-                            fill="currentColor"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </a>
-            </li>
-            <li
-              class="c27"
-            >
-              <a
-                class="c28 c43"
-                href="url.extrenal/tool"
-                rel="noopener nofollow"
-                target="_blank"
-              >
-                <div
-                  class="c32"
-                >
-                  <div
-                    class="c33"
-                  >
-                    <svg
-                      fill="none"
-                      viewBox="0 0 52 52"
-                    >
-                      <path
-                        d="M41.953 2H9.047A3.05 3.05 0 006 5.047V15c0 .56.455 1 1.016 1 .56 0 1.015-.44 1.015-1V5.047c0-.56.456-1.016 1.016-1.016h32.906c.56 0 1.016.456 1.016 1.016v41.906c0 .56-.456 1.016-1.016 1.016H9.047c-.56 0-1.016-.456-1.016-1.016V23.971a1.016 1.016 0 00-2.031 0v22.982A3.05 3.05 0 009.047 50h32.906A3.05 3.05 0 0045 46.953V5.047A3.05 3.05 0 0041.953 2z"
-                        fill="#4E6896"
-                      />
-                      <path
-                        d="M7.062 18a1.018 1.018 0 011.015 1.015 1.017 1.017 0 01-1.734.719 1.026 1.026 0 01-.297-.72c.001-.268.108-.526.297-.717.19-.19.451-.297.719-.297zm13.063 18.297a1.016 1.016 0 00-1.436 0l-2.7 2.7-1.255-1.255a1.016 1.016 0 00-1.437 1.436l1.974 1.974a1.016 1.016 0 001.436 0l3.418-3.418a1.016 1.016 0 000-1.437zm.06-8a1.016 1.016 0 00-1.436 0l-2.7 2.7-1.256-1.255a1.016 1.016 0 00-1.436 1.436l1.974 1.974a1.016 1.016 0 001.436 0l3.418-3.418a1.016 1.016 0 000-1.437z"
-                        fill="#4E6896"
-                      />
-                      <path
-                        clip-rule="evenodd"
-                        d="M12.016 10h10c.56 0 1.015.455 1.015 1.016v9.968c0 .561-.454 1.016-1.015 1.016h-10A1.016 1.016 0 0111 20.984v-9.968c0-.561.455-1.016 1.016-1.016zM21 19.969h-7.969V12.03H21v7.938z"
-                        fill="#4E6896"
-                        fill-rule="evenodd"
-                      />
-                      <path
-                        d="M29.016 11h9.109a1.016 1.016 0 010 2.031h-9.11a1.016 1.016 0 010-2.031zm0 8h9.109a1.016 1.016 0 010 2.031h-9.11a1.016 1.016 0 010-2.031zm8.96 10H26.024C25.46 29 25 29.448 25 30s.459 1 1.024 1h11.952C38.54 31 39 30.552 39 30s-.459-1-1.024-1zm0 9H26.024C25.46 38 25 38.448 25 39s.459 1 1.024 1h11.952C38.54 40 39 39.552 39 39s-.459-1-1.024-1zm.149-23h-9.11a1.016 1.016 0 000 2.031h9.11a1.016 1.016 0 000-2.031z"
-                        fill="#FF7067"
-                      />
-                    </svg>
-                  </div>
-                  <div
-                    class="c34"
-                  >
-                    
-                    <h3
-                      class="c36 c37"
-                    >
-                      related external title 1
-                    </h3>
-                  </div>
-                </div>
-              </a>
-            </li>
-          </ul>
-        </div>
-      </div>
-      <div
         class="c2"
       >
-        <div>
+        <ul
+          class="c23"
+        >
+          <li
+            class="c24 c25"
+          >
+            <a
+              class="c26"
+              href="url.extrenal/tool"
+              rel="noopener nofollow"
+              target="_blank"
+            >
+              <div
+                class="c27"
+              >
+                <div
+                  class="c28"
+                >
+                  <svg
+                    fill="none"
+                    viewBox="0 0 52 52"
+                  >
+                    <path
+                      d="M41.953 2H9.047A3.05 3.05 0 006 5.047V15c0 .56.455 1 1.016 1 .56 0 1.015-.44 1.015-1V5.047c0-.56.456-1.016 1.016-1.016h32.906c.56 0 1.016.456 1.016 1.016v41.906c0 .56-.456 1.016-1.016 1.016H9.047c-.56 0-1.016-.456-1.016-1.016V23.971a1.016 1.016 0 00-2.031 0v22.982A3.05 3.05 0 009.047 50h32.906A3.05 3.05 0 0045 46.953V5.047A3.05 3.05 0 0041.953 2z"
+                      fill="#4E6896"
+                    />
+                    <path
+                      d="M7.062 18a1.018 1.018 0 011.015 1.015 1.017 1.017 0 01-1.734.719 1.026 1.026 0 01-.297-.72c.001-.268.108-.526.297-.717.19-.19.451-.297.719-.297zm13.063 18.297a1.016 1.016 0 00-1.436 0l-2.7 2.7-1.255-1.255a1.016 1.016 0 00-1.437 1.436l1.974 1.974a1.016 1.016 0 001.436 0l3.418-3.418a1.016 1.016 0 000-1.437zm.06-8a1.016 1.016 0 00-1.436 0l-2.7 2.7-1.256-1.255a1.016 1.016 0 00-1.436 1.436l1.974 1.974a1.016 1.016 0 001.436 0l3.418-3.418a1.016 1.016 0 000-1.437z"
+                      fill="#4E6896"
+                    />
+                    <path
+                      clip-rule="evenodd"
+                      d="M12.016 10h10c.56 0 1.015.455 1.015 1.016v9.968c0 .561-.454 1.016-1.015 1.016h-10A1.016 1.016 0 0111 20.984v-9.968c0-.561.455-1.016 1.016-1.016zM21 19.969h-7.969V12.03H21v7.938z"
+                      fill="#4E6896"
+                      fill-rule="evenodd"
+                    />
+                    <path
+                      d="M29.016 11h9.109a1.016 1.016 0 010 2.031h-9.11a1.016 1.016 0 010-2.031zm0 8h9.109a1.016 1.016 0 010 2.031h-9.11a1.016 1.016 0 010-2.031zm8.96 10H26.024C25.46 29 25 29.448 25 30s.459 1 1.024 1h11.952C38.54 31 39 30.552 39 30s-.459-1-1.024-1zm0 9H26.024C25.46 38 25 38.448 25 39s.459 1 1.024 1h11.952C38.54 40 39 39.552 39 39s-.459-1-1.024-1zm.149-23h-9.11a1.016 1.016 0 000 2.031h9.11a1.016 1.016 0 000-2.031z"
+                      fill="#FF7067"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="c29"
+                >
+                  
+                  <h3
+                    class="c30 c31"
+                  >
+                    related external title 1
+                  </h3>
+                </div>
+              </div>
+              <div
+                class="c32"
+              >
+                <div
+                  class="c33"
+                >
+                  <div
+                    class="c34"
+                  >
+                    <div
+                      class="c18 c35"
+                    >
+                      extern action
+                      <svg
+                        class="c36"
+                        fill="none"
+                        viewBox="0 0 28 15"
+                      >
+                        <path
+                          d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </a>
+          </li>
+          <li
+            class="c24 c25"
+          >
+            <a
+              class="c26"
+              href="/outils/TOOL_1"
+            >
+              <div
+                class="c37"
+              >
+                <div
+                  class="c38"
+                >
+                  <svg
+                    fill="none"
+                    viewBox="0 0 32 32"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M11.938 16.5a3.548 3.548 0 013.562-3.563 3.548 3.548 0 013.563 3.563 3.548 3.548 0 01-3.563 3.563 3.548 3.548 0 01-3.563-3.563zm2.062 0c0 .84.66 1.5 1.5 1.5s1.5-.66 1.5-1.5-.66-1.5-1.5-1.5-1.5.66-1.5 1.5z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                    <path
+                      clip-rule="evenodd"
+                      d="M25 14.838v3.404l-1.663.87-.474 1.109.554 1.82-2.375 2.376-1.9-.555-1.109.476-.87 1.662h-3.405l-.87-1.663-1.109-.474-1.82.554-2.376-2.375.554-1.9-.475-1.109L6 18.163v-3.405l1.662-.87.475-1.109-.554-1.82 2.375-2.376 1.9.554 1.109-.475.87-1.662h3.405l.87 1.662 1.109.475 1.82-.554 2.376 2.375-.555 1.9.476 1.109 1.662.87zm-4.1 5.112l.825-2.025L23 17.25v-1.5l-1.2-.6-.825-2.025.375-1.35-1.05-1.05-1.35.375-2.025-.825L16.25 9h-1.5l-.6 1.2-2.025.825-1.35-.375-1.05 1.05.375 1.35-.825 2.025L8 15.75v1.5l1.2.6.825 2.025-.375 1.35 1.05 1.05 1.35-.375 2.025.825L14.75 24h1.5l.6-1.2 2.025-.825 1.35.375 1.05-1.05-.375-1.35z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div
+                class="c27"
+              >
+                <div
+                  class="c28"
+                >
+                  <svg
+                    fill="none"
+                    viewBox="0 0 52 52"
+                  >
+                    <path
+                      d="M43.566 34.192a.752.752 0 00-.47-.191.615.615 0 00-.454.173.592.592 0 00-.177.444v3.68H29v4.939h13.467v3.682c0 .163.067.32.185.436a.635.635 0 00.445.181.625.625 0 00.45-.183l6.277-6.143a.645.645 0 000-.885l-6.258-6.133z"
+                      fill="#FF7067"
+                    />
+                    <path
+                      d="M29.112 4c-.312-.015-.495.131-.698.361-.201.228-.215.563-.214.871L28.195 27 17.8 17a1.176 1.176 0 00-1.205.002c-.182.11-.334.267-.438.456a1.257 1.257 0 00-.157.62V27L4.8 17a1.176 1.176 0 00-1.205.002c-.182.11-.334.267-.438.456a1.258 1.258 0 00-.157.62l.151 30.652c0 .327.127.64.352.871.225.231.53.361.848.361h35.427c.318 0 .623-.13.848-.36a1.25 1.25 0 00.352-.872V46H39v2H5V20l11.157 9.602a1.177 1.177 0 001.204-.003c.183-.109.334-.266.439-.455a1.26 1.26 0 00.156-.62L18 20.5l10.2 9.102a1.177 1.177 0 001.205-.003c.182-.109.334-.266.438-.455a1.25 1.25 0 00.157-.62V6h9v29h1.978V5.232c0-.327-.127-.64-.352-.871a1.185 1.185 0 00-.848-.36H29.112z"
+                      fill="#4E6896"
+                    />
+                    <path
+                      d="M35 37v-2.809c0-.327-.127-.64-.352-.871a1.184 1.184 0 00-.848-.36h-8.6a1.173 1.173 0 00-.113 0 1.19 1.19 0 00-.776.398 1.251 1.251 0 00-.311.833v8.624c0 .327.127.64.352.871.224.231.53.361.848.361H27V42h-1v-7h7v2h2z"
+                      fill="#4E6896"
+                    />
+                    <path
+                      clip-rule="evenodd"
+                      d="M10.287 32.96a1.189 1.189 0 00-.776.398 1.25 1.25 0 00-.311.833v8.624c0 .327.126.64.351.871.226.231.53.361.849.361h8.4c.318 0 .623-.13.848-.36a1.25 1.25 0 00.352-.872v-8.624c0-.327-.127-.64-.352-.871a1.184 1.184 0 00-.848-.36h-8.4a1.173 1.173 0 00-.113 0zM11 35h7v7h-7v-7z"
+                      fill="#4E6896"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="c29"
+                >
+                  <span
+                    class="c39"
+                  >
+                    Outils
+                  </span>
+                  <h3
+                    class="c30 c31"
+                  >
+                    related tool title 1
+                  </h3>
+                </div>
+              </div>
+              <div
+                class="c32"
+              >
+                <div
+                  class="c33"
+                >
+                  <div
+                    class="c34"
+                  >
+                    <div
+                      class="c18 c35"
+                    >
+                      tools action
+                      <svg
+                        class="c36"
+                        fill="none"
+                        viewBox="0 0 28 15"
+                      >
+                        <path
+                          d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </a>
+          </li>
+        </ul>
+        <div
+          class="c30"
+        >
           Les articles pouvant vous intéresser :
         </div>
         <ul
-          class="c44"
+          class="c40"
         >
           <li
-            class="c45"
+            class="c41"
           >
             <a
-              class="c46 c47"
+              class="c42 c43"
               href="/fiche-service-public/LINK_1"
             >
               <svg
-                class="c48"
+                class="c44"
                 fill="none"
                 viewBox="0 0 28 15"
               >
@@ -3527,21 +3170,21 @@ exports[`<Answer /> should renders related content 1`] = `
                 />
               </svg>
               <span
-                class="c49"
+                class="c45"
               >
                 related sheet sp title 1
               </span>
             </a>
           </li>
           <li
-            class="c45"
+            class="c41"
           >
             <a
-              class="c46 c47"
+              class="c42 c43"
               href="/fiche-ministere-travail/LINK_2"
             >
               <svg
-                class="c48"
+                class="c44"
                 fill="none"
                 viewBox="0 0 28 15"
               >
@@ -3551,21 +3194,21 @@ exports[`<Answer /> should renders related content 1`] = `
                 />
               </svg>
               <span
-                class="c49"
+                class="c45"
               >
                 related sheet mt title 1
               </span>
             </a>
           </li>
           <li
-            class="c45"
+            class="c41"
           >
             <a
-              class="c46 c47"
+              class="c42 c43"
               href="/fiche-service-public/LINK_4"
             >
               <svg
-                class="c48"
+                class="c44"
                 fill="none"
                 viewBox="0 0 28 15"
               >
@@ -3575,7 +3218,7 @@ exports[`<Answer /> should renders related content 1`] = `
                 />
               </svg>
               <span
-                class="c49"
+                class="c45"
               >
                 related sheet sp title 2
               </span>

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/RelatedItems.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/RelatedItems.test.js.snap
@@ -1,7 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Article /> should render 1`] = `
-.c20 {
+.c24 {
+  max-width: 124rem;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+.c0 {
+  padding: 3.2rem 0;
+  background-color: transparent;
+  color: #3e486e;
+}
+
+.c28 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -14,14 +26,14 @@ exports[`<Article /> should render 1`] = `
   text-decoration: none;
 }
 
-.c22 {
+.c30 {
   -webkit-flex: 0 1 auto;
   -ms-flex: 0 1 auto;
   flex: 0 1 auto;
   width: auto;
 }
 
-.c21 {
+.c29 {
   -webkit-flex: 0 0 2.8rem;
   -ms-flex: 0 0 2.8rem;
   flex: 0 0 2.8rem;
@@ -35,13 +47,13 @@ exports[`<Article /> should render 1`] = `
   transition: transform 250ms linear;
 }
 
-.c19:hover .c21 {
+.c27:hover .c29 {
   -webkit-transform: translateX(4px);
   -ms-transform: translateX(4px);
   transform: translateX(4px);
 }
 
-.c4 {
+.c9 {
   position: absolute;
   top: 0;
   right: 0;
@@ -52,7 +64,7 @@ exports[`<Article /> should render 1`] = `
   border-radius: 0 0.6rem 0 0;
 }
 
-.c4:before {
+.c9:before {
   position: absolute;
   display: block;
   width: 0;
@@ -63,7 +75,7 @@ exports[`<Article /> should render 1`] = `
   content: "";
 }
 
-.c5 {
+.c10 {
   position: absolute;
   top: 0;
   right: 0;
@@ -72,7 +84,7 @@ exports[`<Article /> should render 1`] = `
   height: 3rem;
 }
 
-.c16 {
+.c21 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -113,14 +125,14 @@ exports[`<Article /> should render 1`] = `
   overflow: visible;
 }
 
-.c16:focus,
-.c16:hover,
-.c16:active {
+.c21:focus,
+.c21:hover,
+.c21:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c17 {
+.c22 {
   width: 2.6rem;
   height: 1.4rem;
   margin: 0 0.4rem 0 1rem;
@@ -129,13 +141,113 @@ exports[`<Article /> should render 1`] = `
   transition: transform 250ms linear;
 }
 
-.c15:hover .c17 {
+.c20:hover .c22 {
   -webkit-transform: translateX(4px);
   -ms-transform: translateX(4px);
   transform: translateX(4px);
 }
 
-.c10 {
+.c2 {
+  position: relative;
+  overflow: hidden;
+}
+
+.c2:before,
+.c2:after {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 1;
+  display: block;
+  width: 4rem;
+  opacity: 0;
+  -webkit-transition: opacity 0.3s linear;
+  transition: opacity 0.3s linear;
+  content: "";
+  pointer-events: none;
+  background: radial-gradient( ellipse at center, #fff 15%, rgba(255,255,255,0) 80% );
+}
+
+.c2:before {
+  left: -2rem;
+}
+
+.c2:after {
+  right: -2rem;
+}
+
+.c4 {
+  overflow-x: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  margin-top: 0;
+  margin-right: calc(-1 * 1rem);
+  margin-bottom: 4rem;
+  margin-left: calc(-1 * 1rem);
+  padding: 0;
+  list-style-type: none;
+  margin-right: 0;
+  margin-left: 0;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  margin: 1rem;
+  padding: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin-bottom: 0;
+}
+
+.c6:first-of-type {
+  margin-left: 2rem;
+}
+
+.c6:last-of-type:after {
+  display: block;
+  width: 2rem;
+  height: 100%;
+  background-color: transparent;
+  content: "";
+}
+
+.c25 {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+.c15 {
   position: relative;
   margin: 3.2rem 0 2rem 0;
   color: #2f3b6c;
@@ -145,7 +257,7 @@ exports[`<Article /> should render 1`] = `
   line-height: 1.625;
 }
 
-.c9 {
+.c14 {
   display: block;
   margin: 0 0 1rem 0;
   color: #4d73b8;
@@ -156,7 +268,7 @@ exports[`<Article /> should render 1`] = `
   text-transform: uppercase;
 }
 
-.c2 {
+.c7 {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -197,9 +309,9 @@ exports[`<Article /> should render 1`] = `
   appearance: none;
 }
 
-.c2:hover,
-.c2:active,
-.c2:focus {
+.c7:hover,
+.c7:active,
+.c7:focus {
   color: #3e486e;
   box-shadow: 0 1rem 2rem rgba(121,148,212,0.4);
   -webkit-transform: translateY(-2px);
@@ -207,7 +319,7 @@ exports[`<Article /> should render 1`] = `
   transform: translateY(-2px);
 }
 
-.c7 {
+.c12 {
   display: block;
   width: 7.2rem;
   height: 7.2rem;
@@ -217,28 +329,28 @@ exports[`<Article /> should render 1`] = `
   border-radius: 50%;
 }
 
-.c6 {
+.c11 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
 }
 
-.c8 {
+.c13 {
   padding-right: 1rem;
 }
 
-.c11 {
+.c16 {
   margin: 0;
 }
 
-.c12 {
+.c17 {
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
   margin-top: 1rem;
 }
 
-.c13 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -253,387 +365,569 @@ exports[`<Article /> should render 1`] = `
   height: 100%;
 }
 
-.c14 {
+.c19 {
   margin-top: 1rem;
 }
 
-.c0 {
+.c1 {
   position: -webkit-sticky;
   position: sticky;
   top: 12rem;
-  width: 30%;
-  margin: 0;
-  padding: 0 1.6rem 0 4rem;
-  list-style-type: none;
+  width: calc(30% - 4rem);
+  margin-left: 4rem;
 }
 
-.c0 > *:first-child {
-  margin-top: 0;
-}
-
-.c18 {
+.c23 {
   max-width: 28rem;
 }
 
-.c3 {
+.c8 {
   max-width: 28rem;
 }
 
-.c1 {
+.c26 {
   margin: 1.6rem 0;
   padding: 0;
 }
 
 @media (max-width:600px) {
-  .c16 {
-    font-size: 1.4rem;
+  .c24 {
+    padding: 0 1rem;
+  }
+}
+
+@media print {
+  .c24 {
+    max-width: 100%;
+    padding: 0;
   }
 }
 
 @media (max-width:600px) {
-  .c10 {
-    font-size: 1.6rem;
+  .c0 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
+  .c21 {
+    font-size: 1.4rem;
   }
 }
 
 @media (max-width:600px) {
   .c2 {
+    overflow-x: hidden;
+  }
+}
+
+@media (max-width:600px) {
+  .c2:before,
+  .c2:after {
+    display: block;
+  }
+}
+
+@media (max-width:600px) {
+  .c4 {
+    overflow-x: auto;
+  }
+}
+
+@media (max-width:600px) {
+  .c3 {
+    margin-bottom: 1.6rem;
+  }
+}
+
+@media (max-width:600px) {
+  .c5 {
+    -webkit-flex-wrap: nowrap;
+    -ms-flex-wrap: nowrap;
+    flex-wrap: nowrap;
+    margin-right: 0;
+    margin-bottom: 2rem;
+    margin-left: 0;
+  }
+}
+
+@media (max-width:600px) {
+  .c15 {
+    font-size: 1.6rem;
+  }
+}
+
+@media (max-width:600px) {
+  .c7 {
     padding: 2rem 1.6rem;
     font-size: 1.4rem;
   }
 }
 
+@media (min-width:980px) {
+  .c1 {
+    padding-top: 0;
+  }
+}
+
 @media (max-width:1180px) {
-  .c0 {
-    padding-left: 1.6rem;
+  .c1 {
+    width: 30%;
+    margin: 0;
   }
 }
 
 @media (max-width:980px) {
-  .c0 {
-    display: none;
+  .c1 {
+    width: 100%;
   }
 }
 
 <div>
-  <ul
-    class="c0"
+  <div
+    class="c0 c1"
   >
-    <li
-      class="c1"
+    <div
+      class="c2 c3"
     >
-      <a
-        class="c2 c3"
-        href="/modeles-de-courriers/modele.url"
+      <div
+        class="c4"
       >
-        <div
-          class="c4"
+        <ul
+          class="c5"
         >
-          <div
-            class="c5"
+          <li
+            class="c6"
           >
-            <svg
-              fill="none"
-              viewBox="0 0 32 32"
-            >
-              <path
-                clip-rule="evenodd"
-                d="M11.938 16.5a3.548 3.548 0 013.562-3.563 3.548 3.548 0 013.563 3.563 3.548 3.548 0 01-3.563 3.563 3.548 3.548 0 01-3.563-3.563zm2.062 0c0 .84.66 1.5 1.5 1.5s1.5-.66 1.5-1.5-.66-1.5-1.5-1.5-1.5.66-1.5 1.5z"
-                fill="currentColor"
-                fill-rule="evenodd"
-              />
-              <path
-                clip-rule="evenodd"
-                d="M25 14.838v3.404l-1.663.87-.474 1.109.554 1.82-2.375 2.376-1.9-.555-1.109.476-.87 1.662h-3.405l-.87-1.663-1.109-.474-1.82.554-2.376-2.375.554-1.9-.475-1.109L6 18.163v-3.405l1.662-.87.475-1.109-.554-1.82 2.375-2.376 1.9.554 1.109-.475.87-1.662h3.405l.87 1.662 1.109.475 1.82-.554 2.376 2.375-.555 1.9.476 1.109 1.662.87zm-4.1 5.112l.825-2.025L23 17.25v-1.5l-1.2-.6-.825-2.025.375-1.35-1.05-1.05-1.35.375-2.025-.825L16.25 9h-1.5l-.6 1.2-2.025.825-1.35-.375-1.05 1.05.375 1.35-.825 2.025L8 15.75v1.5l1.2.6.825 2.025-.375 1.35 1.05 1.05 1.35-.375 2.025.825L14.75 24h1.5l.6-1.2 2.025-.825 1.35.375 1.05-1.05-.375-1.35z"
-                fill="currentColor"
-                fill-rule="evenodd"
-              />
-            </svg>
-          </div>
-        </div>
-        <div
-          class="c6"
-        >
-          <div
-            class="c7"
-          >
-            <svg
-              fill="none"
-              viewBox="0 0 52 52"
-            >
-              <path
-                clip-rule="evenodd"
-                d="M26.567 3.89L32.544 8H42a1 1 0 011 1v6.188l6.566 4.514a1 1 0 01.434.824V47a1 1 0 01-1 1H3a1 1 0 01-1-1V20.526a1 1 0 01.433-.824L9 15.188V9a1 1 0 011-1h9.455l5.979-4.11a1 1 0 011.133 0zM22.985 8h6.03L26 5.927 22.985 8zM9 17.615l-5 3.437v.323l5 3.438v-7.198zm2 8.573l10.537 7.244 2.873-1.796a3 3 0 013.18 0l2.873 1.796L41 26.188V10H11v16.188zm32-1.375l5-3.438v-.323l-5-3.437v7.198zm5-1.01L32.313 34.586 48 44.392v-20.59zM4 44.391l15.687-9.805L4 23.802v20.59zm21.47-11.06L5.2 46h41.6L26.53 33.332a1 1 0 00-1.06 0z"
-                fill="#4E6896"
-                fill-rule="evenodd"
-              />
-              <path
-                d="M16 17c0-.552.471-1 1.053-1h17.894c.582 0 1.053.448 1.053 1s-.471 1-1.053 1H17.053C16.47 18 16 17.552 16 17zm1.053 5C16.47 22 16 22.448 16 23s.471 1 1.053 1h17.894C35.53 24 36 23.552 36 23s-.471-1-1.053-1H17.053z"
-                fill="#FF7067"
-              />
-            </svg>
-          </div>
-          <div
-            class="c8"
-          >
-            <span
-              class="c9"
-            >
-              Modèles de documents
-            </span>
-            <h3
-              class="c10 c11"
-            >
-              modele de courrier
-            </h3>
-          </div>
-        </div>
-        <div
-          class="c12"
-        >
-          <div
-            class="c13"
-          >
-            <div
-              class="c14"
+            <a
+              class="c7 c8"
+              href="/modeles-de-courriers/modele.url"
             >
               <div
-                class="c15 c16"
+                class="c9"
               >
-                Consulter
-                <svg
-                  class="c17"
-                  fill="none"
-                  viewBox="0 0 28 15"
+                <div
+                  class="c10"
                 >
-                  <path
-                    d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
-                    fill="currentColor"
-                  />
-                </svg>
+                  <svg
+                    fill="none"
+                    viewBox="0 0 32 32"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M11.938 16.5a3.548 3.548 0 013.562-3.563 3.548 3.548 0 013.563 3.563 3.548 3.548 0 01-3.563 3.563 3.548 3.548 0 01-3.563-3.563zm2.062 0c0 .84.66 1.5 1.5 1.5s1.5-.66 1.5-1.5-.66-1.5-1.5-1.5-1.5.66-1.5 1.5z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                    <path
+                      clip-rule="evenodd"
+                      d="M25 14.838v3.404l-1.663.87-.474 1.109.554 1.82-2.375 2.376-1.9-.555-1.109.476-.87 1.662h-3.405l-.87-1.663-1.109-.474-1.82.554-2.376-2.375.554-1.9-.475-1.109L6 18.163v-3.405l1.662-.87.475-1.109-.554-1.82 2.375-2.376 1.9.554 1.109-.475.87-1.662h3.405l.87 1.662 1.109.475 1.82-.554 2.376 2.375-.555 1.9.476 1.109 1.662.87zm-4.1 5.112l.825-2.025L23 17.25v-1.5l-1.2-.6-.825-2.025.375-1.35-1.05-1.05-1.35.375-2.025-.825L16.25 9h-1.5l-.6 1.2-2.025.825-1.35-.375-1.05 1.05.375 1.35-.825 2.025L8 15.75v1.5l1.2.6.825 2.025-.375 1.35 1.05 1.05 1.35-.375 2.025.825L14.75 24h1.5l.6-1.2 2.025-.825 1.35.375 1.05-1.05-.375-1.35z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </div>
               </div>
-            </div>
-          </div>
-        </div>
-      </a>
-    </li>
-    <li
-      class="c1"
-    >
-      <a
-        class="c2 c3"
-        href="/outils/outils.url"
-      >
-        <div
-          class="c4"
-        >
-          <div
-            class="c5"
+              <div
+                class="c11"
+              >
+                <div
+                  class="c12"
+                >
+                  <svg
+                    fill="none"
+                    viewBox="0 0 52 52"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M26.567 3.89L32.544 8H42a1 1 0 011 1v6.188l6.566 4.514a1 1 0 01.434.824V47a1 1 0 01-1 1H3a1 1 0 01-1-1V20.526a1 1 0 01.433-.824L9 15.188V9a1 1 0 011-1h9.455l5.979-4.11a1 1 0 011.133 0zM22.985 8h6.03L26 5.927 22.985 8zM9 17.615l-5 3.437v.323l5 3.438v-7.198zm2 8.573l10.537 7.244 2.873-1.796a3 3 0 013.18 0l2.873 1.796L41 26.188V10H11v16.188zm32-1.375l5-3.438v-.323l-5-3.437v7.198zm5-1.01L32.313 34.586 48 44.392v-20.59zM4 44.391l15.687-9.805L4 23.802v20.59zm21.47-11.06L5.2 46h41.6L26.53 33.332a1 1 0 00-1.06 0z"
+                      fill="#4E6896"
+                      fill-rule="evenodd"
+                    />
+                    <path
+                      d="M16 17c0-.552.471-1 1.053-1h17.894c.582 0 1.053.448 1.053 1s-.471 1-1.053 1H17.053C16.47 18 16 17.552 16 17zm1.053 5C16.47 22 16 22.448 16 23s.471 1 1.053 1h17.894C35.53 24 36 23.552 36 23s-.471-1-1.053-1H17.053z"
+                      fill="#FF7067"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="c13"
+                >
+                  <span
+                    class="c14"
+                  >
+                    Modèles de documents
+                  </span>
+                  <h3
+                    class="c15 c16"
+                  >
+                    modele de courrier
+                  </h3>
+                </div>
+              </div>
+              <div
+                class="c17"
+              >
+                <div
+                  class="c18"
+                >
+                  <div
+                    class="c19"
+                  >
+                    <div
+                      class="c20 c21"
+                    >
+                      Consulter
+                      <svg
+                        class="c22"
+                        fill="none"
+                        viewBox="0 0 28 15"
+                      >
+                        <path
+                          d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </a>
+          </li>
+          <li
+            class="c6"
           >
-            <svg
-              fill="none"
-              viewBox="0 0 32 32"
-            >
-              <path
-                clip-rule="evenodd"
-                d="M11.938 16.5a3.548 3.548 0 013.562-3.563 3.548 3.548 0 013.563 3.563 3.548 3.548 0 01-3.563 3.563 3.548 3.548 0 01-3.563-3.563zm2.062 0c0 .84.66 1.5 1.5 1.5s1.5-.66 1.5-1.5-.66-1.5-1.5-1.5-1.5.66-1.5 1.5z"
-                fill="currentColor"
-                fill-rule="evenodd"
-              />
-              <path
-                clip-rule="evenodd"
-                d="M25 14.838v3.404l-1.663.87-.474 1.109.554 1.82-2.375 2.376-1.9-.555-1.109.476-.87 1.662h-3.405l-.87-1.663-1.109-.474-1.82.554-2.376-2.375.554-1.9-.475-1.109L6 18.163v-3.405l1.662-.87.475-1.109-.554-1.82 2.375-2.376 1.9.554 1.109-.475.87-1.662h3.405l.87 1.662 1.109.475 1.82-.554 2.376 2.375-.555 1.9.476 1.109 1.662.87zm-4.1 5.112l.825-2.025L23 17.25v-1.5l-1.2-.6-.825-2.025.375-1.35-1.05-1.05-1.35.375-2.025-.825L16.25 9h-1.5l-.6 1.2-2.025.825-1.35-.375-1.05 1.05.375 1.35-.825 2.025L8 15.75v1.5l1.2.6.825 2.025-.375 1.35 1.05 1.05 1.35-.375 2.025.825L14.75 24h1.5l.6-1.2 2.025-.825 1.35.375 1.05-1.05-.375-1.35z"
-                fill="currentColor"
-                fill-rule="evenodd"
-              />
-            </svg>
-          </div>
-        </div>
-        <div
-          class="c6"
-        >
-          <div
-            class="c7"
-          >
-            <svg
-              fill="none"
-              viewBox="0 0 52 52"
-            >
-              <path
-                d="M43.566 34.192a.752.752 0 00-.47-.191.615.615 0 00-.454.173.592.592 0 00-.177.444v3.68H29v4.939h13.467v3.682c0 .163.067.32.185.436a.635.635 0 00.445.181.625.625 0 00.45-.183l6.277-6.143a.645.645 0 000-.885l-6.258-6.133z"
-                fill="#FF7067"
-              />
-              <path
-                d="M29.112 4c-.312-.015-.495.131-.698.361-.201.228-.215.563-.214.871L28.195 27 17.8 17a1.176 1.176 0 00-1.205.002c-.182.11-.334.267-.438.456a1.257 1.257 0 00-.157.62V27L4.8 17a1.176 1.176 0 00-1.205.002c-.182.11-.334.267-.438.456a1.258 1.258 0 00-.157.62l.151 30.652c0 .327.127.64.352.871.225.231.53.361.848.361h35.427c.318 0 .623-.13.848-.36a1.25 1.25 0 00.352-.872V46H39v2H5V20l11.157 9.602a1.177 1.177 0 001.204-.003c.183-.109.334-.266.439-.455a1.26 1.26 0 00.156-.62L18 20.5l10.2 9.102a1.177 1.177 0 001.205-.003c.182-.109.334-.266.438-.455a1.25 1.25 0 00.157-.62V6h9v29h1.978V5.232c0-.327-.127-.64-.352-.871a1.185 1.185 0 00-.848-.36H29.112z"
-                fill="#4E6896"
-              />
-              <path
-                d="M35 37v-2.809c0-.327-.127-.64-.352-.871a1.184 1.184 0 00-.848-.36h-8.6a1.173 1.173 0 00-.113 0 1.19 1.19 0 00-.776.398 1.251 1.251 0 00-.311.833v8.624c0 .327.127.64.352.871.224.231.53.361.848.361H27V42h-1v-7h7v2h2z"
-                fill="#4E6896"
-              />
-              <path
-                clip-rule="evenodd"
-                d="M10.287 32.96a1.189 1.189 0 00-.776.398 1.25 1.25 0 00-.311.833v8.624c0 .327.126.64.351.871.226.231.53.361.849.361h8.4c.318 0 .623-.13.848-.36a1.25 1.25 0 00.352-.872v-8.624c0-.327-.127-.64-.352-.871a1.184 1.184 0 00-.848-.36h-8.4a1.173 1.173 0 00-.113 0zM11 35h7v7h-7v-7z"
-                fill="#4E6896"
-                fill-rule="evenodd"
-              />
-            </svg>
-          </div>
-          <div
-            class="c8"
-          >
-            <span
-              class="c9"
-            >
-              Outils
-            </span>
-            <h3
-              class="c10 c11"
-            >
-              Simulateur
-            </h3>
-          </div>
-        </div>
-        <div
-          class="c12"
-        >
-          <div
-            class="c13"
-          >
-            <div
-              class="c14"
+            <a
+              class="c7 c8"
+              href="/outils/outils.url"
             >
               <div
-                class="c15 c16"
+                class="c9"
               >
-                simuler
-                <svg
-                  class="c17"
-                  fill="none"
-                  viewBox="0 0 28 15"
+                <div
+                  class="c10"
                 >
-                  <path
-                    d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
-                    fill="currentColor"
-                  />
-                </svg>
+                  <svg
+                    fill="none"
+                    viewBox="0 0 32 32"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M11.938 16.5a3.548 3.548 0 013.562-3.563 3.548 3.548 0 013.563 3.563 3.548 3.548 0 01-3.563 3.563 3.548 3.548 0 01-3.563-3.563zm2.062 0c0 .84.66 1.5 1.5 1.5s1.5-.66 1.5-1.5-.66-1.5-1.5-1.5-1.5.66-1.5 1.5z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                    <path
+                      clip-rule="evenodd"
+                      d="M25 14.838v3.404l-1.663.87-.474 1.109.554 1.82-2.375 2.376-1.9-.555-1.109.476-.87 1.662h-3.405l-.87-1.663-1.109-.474-1.82.554-2.376-2.375.554-1.9-.475-1.109L6 18.163v-3.405l1.662-.87.475-1.109-.554-1.82 2.375-2.376 1.9.554 1.109-.475.87-1.662h3.405l.87 1.662 1.109.475 1.82-.554 2.376 2.375-.555 1.9.476 1.109 1.662.87zm-4.1 5.112l.825-2.025L23 17.25v-1.5l-1.2-.6-.825-2.025.375-1.35-1.05-1.05-1.35.375-2.025-.825L16.25 9h-1.5l-.6 1.2-2.025.825-1.35-.375-1.05 1.05.375 1.35-.825 2.025L8 15.75v1.5l1.2.6.825 2.025-.375 1.35 1.05 1.05 1.35-.375 2.025.825L14.75 24h1.5l.6-1.2 2.025-.825 1.35.375 1.05-1.05-.375-1.35z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </div>
               </div>
-            </div>
-          </div>
-        </div>
-      </a>
-    </li>
-    <li
-      class="c1"
+              <div
+                class="c11"
+              >
+                <div
+                  class="c12"
+                >
+                  <svg
+                    fill="none"
+                    viewBox="0 0 52 52"
+                  >
+                    <path
+                      d="M43.566 34.192a.752.752 0 00-.47-.191.615.615 0 00-.454.173.592.592 0 00-.177.444v3.68H29v4.939h13.467v3.682c0 .163.067.32.185.436a.635.635 0 00.445.181.625.625 0 00.45-.183l6.277-6.143a.645.645 0 000-.885l-6.258-6.133z"
+                      fill="#FF7067"
+                    />
+                    <path
+                      d="M29.112 4c-.312-.015-.495.131-.698.361-.201.228-.215.563-.214.871L28.195 27 17.8 17a1.176 1.176 0 00-1.205.002c-.182.11-.334.267-.438.456a1.257 1.257 0 00-.157.62V27L4.8 17a1.176 1.176 0 00-1.205.002c-.182.11-.334.267-.438.456a1.258 1.258 0 00-.157.62l.151 30.652c0 .327.127.64.352.871.225.231.53.361.848.361h35.427c.318 0 .623-.13.848-.36a1.25 1.25 0 00.352-.872V46H39v2H5V20l11.157 9.602a1.177 1.177 0 001.204-.003c.183-.109.334-.266.439-.455a1.26 1.26 0 00.156-.62L18 20.5l10.2 9.102a1.177 1.177 0 001.205-.003c.182-.109.334-.266.438-.455a1.25 1.25 0 00.157-.62V6h9v29h1.978V5.232c0-.327-.127-.64-.352-.871a1.185 1.185 0 00-.848-.36H29.112z"
+                      fill="#4E6896"
+                    />
+                    <path
+                      d="M35 37v-2.809c0-.327-.127-.64-.352-.871a1.184 1.184 0 00-.848-.36h-8.6a1.173 1.173 0 00-.113 0 1.19 1.19 0 00-.776.398 1.251 1.251 0 00-.311.833v8.624c0 .327.127.64.352.871.224.231.53.361.848.361H27V42h-1v-7h7v2h2z"
+                      fill="#4E6896"
+                    />
+                    <path
+                      clip-rule="evenodd"
+                      d="M10.287 32.96a1.189 1.189 0 00-.776.398 1.25 1.25 0 00-.311.833v8.624c0 .327.126.64.351.871.226.231.53.361.849.361h8.4c.318 0 .623-.13.848-.36a1.25 1.25 0 00.352-.872v-8.624c0-.327-.127-.64-.352-.871a1.184 1.184 0 00-.848-.36h-8.4a1.173 1.173 0 00-.113 0zM11 35h7v7h-7v-7z"
+                      fill="#4E6896"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="c13"
+                >
+                  <span
+                    class="c14"
+                  >
+                    Outils
+                  </span>
+                  <h3
+                    class="c15 c16"
+                  >
+                    Simulateur
+                  </h3>
+                </div>
+              </div>
+              <div
+                class="c17"
+              >
+                <div
+                  class="c18"
+                >
+                  <div
+                    class="c19"
+                  >
+                    <div
+                      class="c20 c21"
+                    >
+                      simuler
+                      <svg
+                        class="c22"
+                        fill="none"
+                        viewBox="0 0 28 15"
+                      >
+                        <path
+                          d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </a>
+          </li>
+          <li
+            class="c6"
+          >
+            <a
+              class="c7 c8"
+              href="/outils/outil-2.slug"
+            >
+              <div
+                class="c9"
+              >
+                <div
+                  class="c10"
+                >
+                  <svg
+                    fill="none"
+                    viewBox="0 0 32 32"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M11.938 16.5a3.548 3.548 0 013.562-3.563 3.548 3.548 0 013.563 3.563 3.548 3.548 0 01-3.563 3.563 3.548 3.548 0 01-3.563-3.563zm2.062 0c0 .84.66 1.5 1.5 1.5s1.5-.66 1.5-1.5-.66-1.5-1.5-1.5-1.5.66-1.5 1.5z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                    <path
+                      clip-rule="evenodd"
+                      d="M25 14.838v3.404l-1.663.87-.474 1.109.554 1.82-2.375 2.376-1.9-.555-1.109.476-.87 1.662h-3.405l-.87-1.663-1.109-.474-1.82.554-2.376-2.375.554-1.9-.475-1.109L6 18.163v-3.405l1.662-.87.475-1.109-.554-1.82 2.375-2.376 1.9.554 1.109-.475.87-1.662h3.405l.87 1.662 1.109.475 1.82-.554 2.376 2.375-.555 1.9.476 1.109 1.662.87zm-4.1 5.112l.825-2.025L23 17.25v-1.5l-1.2-.6-.825-2.025.375-1.35-1.05-1.05-1.35.375-2.025-.825L16.25 9h-1.5l-.6 1.2-2.025.825-1.35-.375-1.05 1.05.375 1.35-.825 2.025L8 15.75v1.5l1.2.6.825 2.025-.375 1.35 1.05 1.05 1.35-.375 2.025.825L14.75 24h1.5l.6-1.2 2.025-.825 1.35.375 1.05-1.05-.375-1.35z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div
+                class="c11"
+              >
+                <div
+                  class="c12"
+                >
+                  <svg
+                    fill="none"
+                    viewBox="0 0 52 52"
+                  >
+                    <path
+                      d="M41.953 2H9.047A3.05 3.05 0 006 5.047V15c0 .56.455 1 1.016 1 .56 0 1.015-.44 1.015-1V5.047c0-.56.456-1.016 1.016-1.016h32.906c.56 0 1.016.456 1.016 1.016v41.906c0 .56-.456 1.016-1.016 1.016H9.047c-.56 0-1.016-.456-1.016-1.016V23.971a1.016 1.016 0 00-2.031 0v22.982A3.05 3.05 0 009.047 50h32.906A3.05 3.05 0 0045 46.953V5.047A3.05 3.05 0 0041.953 2z"
+                      fill="#4E6896"
+                    />
+                    <path
+                      d="M7.062 18a1.018 1.018 0 011.015 1.015 1.017 1.017 0 01-1.734.719 1.026 1.026 0 01-.297-.72c.001-.268.108-.526.297-.717.19-.19.451-.297.719-.297zm13.063 18.297a1.016 1.016 0 00-1.436 0l-2.7 2.7-1.255-1.255a1.016 1.016 0 00-1.437 1.436l1.974 1.974a1.016 1.016 0 001.436 0l3.418-3.418a1.016 1.016 0 000-1.437zm.06-8a1.016 1.016 0 00-1.436 0l-2.7 2.7-1.256-1.255a1.016 1.016 0 00-1.436 1.436l1.974 1.974a1.016 1.016 0 001.436 0l3.418-3.418a1.016 1.016 0 000-1.437z"
+                      fill="#4E6896"
+                    />
+                    <path
+                      clip-rule="evenodd"
+                      d="M12.016 10h10c.56 0 1.015.455 1.015 1.016v9.968c0 .561-.454 1.016-1.015 1.016h-10A1.016 1.016 0 0111 20.984v-9.968c0-.561.455-1.016 1.016-1.016zM21 19.969h-7.969V12.03H21v7.938z"
+                      fill="#4E6896"
+                      fill-rule="evenodd"
+                    />
+                    <path
+                      d="M29.016 11h9.109a1.016 1.016 0 010 2.031h-9.11a1.016 1.016 0 010-2.031zm0 8h9.109a1.016 1.016 0 010 2.031h-9.11a1.016 1.016 0 010-2.031zm8.96 10H26.024C25.46 29 25 29.448 25 30s.459 1 1.024 1h11.952C38.54 31 39 30.552 39 30s-.459-1-1.024-1zm0 9H26.024C25.46 38 25 38.448 25 39s.459 1 1.024 1h11.952C38.54 40 39 39.552 39 39s-.459-1-1.024-1zm.149-23h-9.11a1.016 1.016 0 000 2.031h9.11a1.016 1.016 0 000-2.031z"
+                      fill="#FF7067"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="c13"
+                >
+                  <span
+                    class="c14"
+                  >
+                    Outils
+                  </span>
+                  <h3
+                    class="c15 c16"
+                  >
+                    fiche sp
+                  </h3>
+                </div>
+              </div>
+              <div
+                class="c17"
+              >
+                <div
+                  class="c18"
+                >
+                  <div
+                    class="c19"
+                  >
+                    <div
+                      class="c20 c21"
+                    >
+                      tester
+                      <svg
+                        class="c22"
+                        fill="none"
+                        viewBox="0 0 28 15"
+                      >
+                        <path
+                          d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </a>
+          </li>
+          <li
+            class="c6"
+          >
+            <a
+              class="c7 c23"
+              href="external.tools"
+              rel="noopener nofollow"
+              target="_blank"
+            >
+              <div
+                class="c11"
+              >
+                <div
+                  class="c12"
+                >
+                  <svg
+                    fill="none"
+                    viewBox="0 0 52 52"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M17 2L6 13v2c0 1 .398 1 1.076 1h9.693C18.554 16 20 14.657 20 13V4h19a1 1 0 011 1v27h2V5a3 3 0 00-3-3H17zm-.23 12H8L18 4v9c0 .552-.636 1-1.23 1z"
+                      fill="#4E6896"
+                      fill-rule="evenodd"
+                    />
+                    <path
+                      d="M27 50v-2H9a1 1 0 01-1-1V24s0-1-1-1-1 1-1 1v23a3 3 0 003 3h18zM7 20a1 1 0 100-2 1 1 0 000 2z"
+                      fill="#4E6896"
+                    />
+                    <path
+                      d="M15.053 20C14.47 20 14 20.448 14 21s.471 1 1.053 1h17.894C33.53 22 34 21.552 34 21s-.471-1-1.053-1H15.053zM14 27c0-.552.471-1 1.053-1h17.894c.582 0 1.053.448 1.053 1s-.471 1-1.053 1H15.053C14.47 28 14 27.552 14 27z"
+                      fill="#FF7067"
+                    />
+                    <path
+                      clip-rule="evenodd"
+                      d="M36.5 37.938a3.548 3.548 0 00-3.563 3.562 3.548 3.548 0 003.563 3.563 3.548 3.548 0 003.563-3.563 3.548 3.548 0 00-3.563-3.563zm0 5.062c-.84 0-1.5-.66-1.5-1.5s.66-1.5 1.5-1.5 1.5.66 1.5 1.5-.66 1.5-1.5 1.5z"
+                      fill="#FF7067"
+                      fill-rule="evenodd"
+                    />
+                    <path
+                      clip-rule="evenodd"
+                      d="M46 43.242v-3.404l-1.663-.871-.475-1.109.555-1.9-2.375-2.375-1.821.555-1.108-.475L38.241 32h-3.404l-.871 1.663-1.109.475-1.9-.555-2.375 2.375.555 1.821-.476 1.108-1.662.871v3.404l1.663.871.474 1.109-.554 1.9 2.375 2.375 1.821-.555 1.108.475.871 1.663h3.404l.871-1.663 1.109-.475 1.9.555 2.375-2.375-.555-1.821.475-1.108L46 43.241zm-3.275-.317L41.9 44.95l.375 1.35-1.05 1.05-1.35-.375-2.025.825-.6 1.2h-1.5l-.675-1.275-2.025-.825-1.35.375-1.05-1.05.375-1.35-.825-2.025-1.2-.6v-1.5l1.275-.675.825-2.025-.375-1.35 1.05-1.05 1.35.375 2.025-.825.6-1.2h1.5l.675 1.275 2.025.825 1.35-.375 1.05 1.05-.375 1.35.825 2.025 1.2.6v1.5l-1.275.675z"
+                      fill="#FF7067"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="c13"
+                >
+                  
+                  <h3
+                    class="c15 c16"
+                  >
+                    externalTool
+                  </h3>
+                </div>
+              </div>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div
+      class="c24"
     >
-      <a
-        class="c2 c18"
-        href="external.tools"
-        rel="noopener nofollow"
-        target="_blank"
+      <div>
+        Les articles pouvant vous intéresser :
+      </div>
+      <ul
+        class="c25"
       >
-        <div
-          class="c6"
+        <li
+          class="c26"
         >
-          <div
-            class="c7"
+          <a
+            class="c27 c28"
+            href="/fiche-service-public/fiche.sp.url"
           >
             <svg
+              class="c29"
               fill="none"
-              viewBox="0 0 52 52"
+              viewBox="0 0 28 15"
             >
               <path
-                clip-rule="evenodd"
-                d="M17 2L6 13v2c0 1 .398 1 1.076 1h9.693C18.554 16 20 14.657 20 13V4h19a1 1 0 011 1v27h2V5a3 3 0 00-3-3H17zm-.23 12H8L18 4v9c0 .552-.636 1-1.23 1z"
-                fill="#4E6896"
-                fill-rule="evenodd"
-              />
-              <path
-                d="M27 50v-2H9a1 1 0 01-1-1V24s0-1-1-1-1 1-1 1v23a3 3 0 003 3h18zM7 20a1 1 0 100-2 1 1 0 000 2z"
-                fill="#4E6896"
-              />
-              <path
-                d="M15.053 20C14.47 20 14 20.448 14 21s.471 1 1.053 1h17.894C33.53 22 34 21.552 34 21s-.471-1-1.053-1H15.053zM14 27c0-.552.471-1 1.053-1h17.894c.582 0 1.053.448 1.053 1s-.471 1-1.053 1H15.053C14.47 28 14 27.552 14 27z"
-                fill="#FF7067"
-              />
-              <path
-                clip-rule="evenodd"
-                d="M36.5 37.938a3.548 3.548 0 00-3.563 3.562 3.548 3.548 0 003.563 3.563 3.548 3.548 0 003.563-3.563 3.548 3.548 0 00-3.563-3.563zm0 5.062c-.84 0-1.5-.66-1.5-1.5s.66-1.5 1.5-1.5 1.5.66 1.5 1.5-.66 1.5-1.5 1.5z"
-                fill="#FF7067"
-                fill-rule="evenodd"
-              />
-              <path
-                clip-rule="evenodd"
-                d="M46 43.242v-3.404l-1.663-.871-.475-1.109.555-1.9-2.375-2.375-1.821.555-1.108-.475L38.241 32h-3.404l-.871 1.663-1.109.475-1.9-.555-2.375 2.375.555 1.821-.476 1.108-1.662.871v3.404l1.663.871.474 1.109-.554 1.9 2.375 2.375 1.821-.555 1.108.475.871 1.663h3.404l.871-1.663 1.109-.475 1.9.555 2.375-2.375-.555-1.821.475-1.108L46 43.241zm-3.275-.317L41.9 44.95l.375 1.35-1.05 1.05-1.35-.375-2.025.825-.6 1.2h-1.5l-.675-1.275-2.025-.825-1.35.375-1.05-1.05.375-1.35-.825-2.025-1.2-.6v-1.5l1.275-.675.825-2.025-.375-1.35 1.05-1.05 1.35.375 2.025-.825.6-1.2h1.5l.675 1.275 2.025.825 1.35-.375 1.05 1.05-.375 1.35.825 2.025 1.2.6v1.5l-1.275.675z"
-                fill="#FF7067"
-                fill-rule="evenodd"
+                d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
+                fill="currentColor"
               />
             </svg>
-          </div>
-          <div
-            class="c8"
-          >
-            
-            <h3
-              class="c10 c11"
+            <span
+              class="c30"
             >
-              externalTool
-            </h3>
-          </div>
-        </div>
-      </a>
-    </li>
-    <span>
-      Les articles pouvant vous intéresser :
-    </span>
-    <li
-      class="c1"
-    >
-      <a
-        class="c19 c20"
-        href="/fiche-service-public/fiche.sp.url"
-      >
-        <svg
-          class="c21"
-          fill="none"
-          viewBox="0 0 28 15"
+              fiche sp
+            </span>
+          </a>
+        </li>
+        <li
+          class="c26"
         >
-          <path
-            d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
-            fill="currentColor"
-          />
-        </svg>
-        <span
-          class="c22"
-        >
-          fiche sp
-        </span>
-      </a>
-    </li>
-    <li
-      class="c1"
-    >
-      <a
-        class="c19 c20"
-        href="/contribution/contrib.url"
-      >
-        <svg
-          class="c21"
-          fill="none"
-          viewBox="0 0 28 15"
-        >
-          <path
-            d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
-            fill="currentColor"
-          />
-        </svg>
-        <span
-          class="c22"
-        >
-          contrib
-        </span>
-      </a>
-    </li>
-  </ul>
+          <a
+            class="c27 c28"
+            href="/contribution/contrib.url"
+          >
+            <svg
+              class="c29"
+              fill="none"
+              viewBox="0 0 28 15"
+            >
+              <path
+                d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
+                fill="currentColor"
+              />
+            </svg>
+            <span
+              class="c30"
+            >
+              contrib
+            </span>
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
 </div>
 `;

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/RelatedItems.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/RelatedItems.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Article /> should render 1`] = `
-.c24 {
+.c2 {
   max-width: 124rem;
   margin: 0 auto;
   padding: 0 2rem;
@@ -13,7 +13,7 @@ exports[`<Article /> should render 1`] = `
   color: #3e486e;
 }
 
-.c28 {
+.c24 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -26,14 +26,14 @@ exports[`<Article /> should render 1`] = `
   text-decoration: none;
 }
 
-.c30 {
+.c26 {
   -webkit-flex: 0 1 auto;
   -ms-flex: 0 1 auto;
   flex: 0 1 auto;
   width: auto;
 }
 
-.c29 {
+.c25 {
   -webkit-flex: 0 0 2.8rem;
   -ms-flex: 0 0 2.8rem;
   flex: 0 0 2.8rem;
@@ -47,13 +47,13 @@ exports[`<Article /> should render 1`] = `
   transition: transform 250ms linear;
 }
 
-.c27:hover .c29 {
+.c23:hover .c25 {
   -webkit-transform: translateX(4px);
   -ms-transform: translateX(4px);
   transform: translateX(4px);
 }
 
-.c9 {
+.c18 {
   position: absolute;
   top: 0;
   right: 0;
@@ -64,7 +64,7 @@ exports[`<Article /> should render 1`] = `
   border-radius: 0 0.6rem 0 0;
 }
 
-.c9:before {
+.c18:before {
   position: absolute;
   display: block;
   width: 0;
@@ -75,7 +75,7 @@ exports[`<Article /> should render 1`] = `
   content: "";
 }
 
-.c10 {
+.c19 {
   position: absolute;
   top: 0;
   right: 0;
@@ -84,7 +84,7 @@ exports[`<Article /> should render 1`] = `
   height: 3rem;
 }
 
-.c21 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -125,14 +125,14 @@ exports[`<Article /> should render 1`] = `
   overflow: visible;
 }
 
-.c21:focus,
-.c21:hover,
-.c21:active {
+.c16:focus,
+.c16:hover,
+.c16:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c22 {
+.c17 {
   width: 2.6rem;
   height: 1.4rem;
   margin: 0 0.4rem 0 1rem;
@@ -141,113 +141,19 @@ exports[`<Article /> should render 1`] = `
   transition: transform 250ms linear;
 }
 
-.c20:hover .c22 {
+.c15:hover .c17 {
   -webkit-transform: translateX(4px);
   -ms-transform: translateX(4px);
   transform: translateX(4px);
 }
 
-.c2 {
-  position: relative;
-  overflow: hidden;
-}
-
-.c2:before,
-.c2:after {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  z-index: 1;
-  display: block;
-  width: 4rem;
-  opacity: 0;
-  -webkit-transition: opacity 0.3s linear;
-  transition: opacity 0.3s linear;
-  content: "";
-  pointer-events: none;
-  background: radial-gradient( ellipse at center, #fff 15%, rgba(255,255,255,0) 80% );
-}
-
-.c2:before {
-  left: -2rem;
-}
-
-.c2:after {
-  right: -2rem;
-}
-
-.c4 {
-  overflow-x: auto;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
-  align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  margin-top: 0;
-  margin-right: calc(-1 * 1rem);
-  margin-bottom: 4rem;
-  margin-left: calc(-1 * 1rem);
-  padding: 0;
-  list-style-type: none;
-  margin-right: 0;
-  margin-left: 0;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
-  flex-grow: 0;
-  margin: 1rem;
-  padding: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  margin-bottom: 0;
-}
-
-.c6:first-of-type {
-  margin-left: 2rem;
-}
-
-.c6:last-of-type:after {
-  display: block;
-  width: 2rem;
-  height: 100%;
-  background-color: transparent;
-  content: "";
-}
-
-.c25 {
+.c21 {
   margin: 0;
   padding: 0;
   list-style-type: none;
 }
 
-.c15 {
+.c10 {
   position: relative;
   margin: 3.2rem 0 2rem 0;
   color: #2f3b6c;
@@ -257,7 +163,7 @@ exports[`<Article /> should render 1`] = `
   line-height: 1.625;
 }
 
-.c14 {
+.c20 {
   display: block;
   margin: 0 0 1rem 0;
   color: #4d73b8;
@@ -268,7 +174,7 @@ exports[`<Article /> should render 1`] = `
   text-transform: uppercase;
 }
 
-.c7 {
+.c6 {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -309,9 +215,9 @@ exports[`<Article /> should render 1`] = `
   appearance: none;
 }
 
-.c7:hover,
-.c7:active,
-.c7:focus {
+.c6:hover,
+.c6:active,
+.c6:focus {
   color: #3e486e;
   box-shadow: 0 1rem 2rem rgba(121,148,212,0.4);
   -webkit-transform: translateY(-2px);
@@ -319,7 +225,7 @@ exports[`<Article /> should render 1`] = `
   transform: translateY(-2px);
 }
 
-.c12 {
+.c8 {
   display: block;
   width: 7.2rem;
   height: 7.2rem;
@@ -329,28 +235,28 @@ exports[`<Article /> should render 1`] = `
   border-radius: 50%;
 }
 
-.c11 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
 }
 
-.c13 {
+.c9 {
   padding-right: 1rem;
 }
 
-.c16 {
+.c11 {
   margin: 0;
 }
 
-.c17 {
+.c12 {
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
   margin-top: 1rem;
 }
 
-.c18 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -365,7 +271,7 @@ exports[`<Article /> should render 1`] = `
   height: 100%;
 }
 
-.c19 {
+.c14 {
   margin-top: 1rem;
 }
 
@@ -377,27 +283,30 @@ exports[`<Article /> should render 1`] = `
   margin-left: 4rem;
 }
 
-.c23 {
-  max-width: 28rem;
+.c3 {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
 }
 
-.c8 {
-  max-width: 28rem;
+.c5 {
+  margin: 0 0 1.6rem 0;
+  padding: 0;
 }
 
-.c26 {
-  margin: 1.6rem 0;
+.c22 {
+  margin: 0 0 1.6rem 0;
   padding: 0;
 }
 
 @media (max-width:600px) {
-  .c24 {
+  .c2 {
     padding: 0 1rem;
   }
 }
 
 @media print {
-  .c24 {
+  .c2 {
     max-width: 100%;
     padding: 0;
   }
@@ -410,55 +319,19 @@ exports[`<Article /> should render 1`] = `
 }
 
 @media (max-width:600px) {
-  .c21 {
+  .c16 {
     font-size: 1.4rem;
   }
 }
 
 @media (max-width:600px) {
-  .c2 {
-    overflow-x: hidden;
-  }
-}
-
-@media (max-width:600px) {
-  .c2:before,
-  .c2:after {
-    display: block;
-  }
-}
-
-@media (max-width:600px) {
-  .c4 {
-    overflow-x: auto;
-  }
-}
-
-@media (max-width:600px) {
-  .c3 {
-    margin-bottom: 1.6rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c5 {
-    -webkit-flex-wrap: nowrap;
-    -ms-flex-wrap: nowrap;
-    flex-wrap: nowrap;
-    margin-right: 0;
-    margin-bottom: 2rem;
-    margin-left: 0;
-  }
-}
-
-@media (max-width:600px) {
-  .c15 {
+  .c10 {
     font-size: 1.6rem;
   }
 }
 
 @media (max-width:600px) {
-  .c7 {
+  .c6 {
     padding: 2rem 1.6rem;
     font-size: 1.4rem;
   }
@@ -483,410 +356,270 @@ exports[`<Article /> should render 1`] = `
   }
 }
 
+@media (max-width:980px) {
+  .c3 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (max-width:600px) {
+  .c3 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media (max-width:980px) {
+  .c5 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex: 1 0 auto;
+    -ms-flex: 1 0 auto;
+    flex: 1 0 auto;
+    -webkit-box-pack: stretch;
+    -webkit-justify-content: stretch;
+    -ms-flex-pack: stretch;
+    justify-content: stretch;
+    width: calc((100% - 1.6rem) / 2);
+  }
+
+  .c5 + .c4 {
+    margin-left: 1.6rem;
+  }
+}
+
+@media (max-width:600px) {
+  .c5 {
+    -webkit-flex: 1 0 auto;
+    -ms-flex: 1 0 auto;
+    flex: 1 0 auto;
+    width: 100%;
+  }
+
+  .c5 + .c4 {
+    margin-left: 0;
+  }
+}
+
 <div>
   <div
     class="c0 c1"
   >
     <div
-      class="c2 c3"
+      class="c2"
     >
-      <div
-        class="c4"
+      <ul
+        class="c3"
       >
-        <ul
-          class="c5"
+        <li
+          class="c4 c5"
         >
-          <li
+          <a
             class="c6"
+            href="external.tools"
+            rel="noopener nofollow"
+            target="_blank"
           >
-            <a
-              class="c7 c8"
-              href="/modeles-de-courriers/modele.url"
+            <div
+              class="c7"
             >
+              <div
+                class="c8"
+              >
+                <svg
+                  fill="none"
+                  viewBox="0 0 52 52"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M17 2L6 13v2c0 1 .398 1 1.076 1h9.693C18.554 16 20 14.657 20 13V4h19a1 1 0 011 1v27h2V5a3 3 0 00-3-3H17zm-.23 12H8L18 4v9c0 .552-.636 1-1.23 1z"
+                    fill="#4E6896"
+                    fill-rule="evenodd"
+                  />
+                  <path
+                    d="M27 50v-2H9a1 1 0 01-1-1V24s0-1-1-1-1 1-1 1v23a3 3 0 003 3h18zM7 20a1 1 0 100-2 1 1 0 000 2z"
+                    fill="#4E6896"
+                  />
+                  <path
+                    d="M15.053 20C14.47 20 14 20.448 14 21s.471 1 1.053 1h17.894C33.53 22 34 21.552 34 21s-.471-1-1.053-1H15.053zM14 27c0-.552.471-1 1.053-1h17.894c.582 0 1.053.448 1.053 1s-.471 1-1.053 1H15.053C14.47 28 14 27.552 14 27z"
+                    fill="#FF7067"
+                  />
+                  <path
+                    clip-rule="evenodd"
+                    d="M36.5 37.938a3.548 3.548 0 00-3.563 3.562 3.548 3.548 0 003.563 3.563 3.548 3.548 0 003.563-3.563 3.548 3.548 0 00-3.563-3.563zm0 5.062c-.84 0-1.5-.66-1.5-1.5s.66-1.5 1.5-1.5 1.5.66 1.5 1.5-.66 1.5-1.5 1.5z"
+                    fill="#FF7067"
+                    fill-rule="evenodd"
+                  />
+                  <path
+                    clip-rule="evenodd"
+                    d="M46 43.242v-3.404l-1.663-.871-.475-1.109.555-1.9-2.375-2.375-1.821.555-1.108-.475L38.241 32h-3.404l-.871 1.663-1.109.475-1.9-.555-2.375 2.375.555 1.821-.476 1.108-1.662.871v3.404l1.663.871.474 1.109-.554 1.9 2.375 2.375 1.821-.555 1.108.475.871 1.663h3.404l.871-1.663 1.109-.475 1.9.555 2.375-2.375-.555-1.821.475-1.108L46 43.241zm-3.275-.317L41.9 44.95l.375 1.35-1.05 1.05-1.35-.375-2.025.825-.6 1.2h-1.5l-.675-1.275-2.025-.825-1.35.375-1.05-1.05.375-1.35-.825-2.025-1.2-.6v-1.5l1.275-.675.825-2.025-.375-1.35 1.05-1.05 1.35.375 2.025-.825.6-1.2h1.5l.675 1.275 2.025.825 1.35-.375 1.05 1.05-.375 1.35.825 2.025 1.2.6v1.5l-1.275.675z"
+                    fill="#FF7067"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </div>
               <div
                 class="c9"
               >
-                <div
-                  class="c10"
+                
+                <h3
+                  class="c10 c11"
                 >
-                  <svg
-                    fill="none"
-                    viewBox="0 0 32 32"
-                  >
-                    <path
-                      clip-rule="evenodd"
-                      d="M11.938 16.5a3.548 3.548 0 013.562-3.563 3.548 3.548 0 013.563 3.563 3.548 3.548 0 01-3.563 3.563 3.548 3.548 0 01-3.563-3.563zm2.062 0c0 .84.66 1.5 1.5 1.5s1.5-.66 1.5-1.5-.66-1.5-1.5-1.5-1.5.66-1.5 1.5z"
-                      fill="currentColor"
-                      fill-rule="evenodd"
-                    />
-                    <path
-                      clip-rule="evenodd"
-                      d="M25 14.838v3.404l-1.663.87-.474 1.109.554 1.82-2.375 2.376-1.9-.555-1.109.476-.87 1.662h-3.405l-.87-1.663-1.109-.474-1.82.554-2.376-2.375.554-1.9-.475-1.109L6 18.163v-3.405l1.662-.87.475-1.109-.554-1.82 2.375-2.376 1.9.554 1.109-.475.87-1.662h3.405l.87 1.662 1.109.475 1.82-.554 2.376 2.375-.555 1.9.476 1.109 1.662.87zm-4.1 5.112l.825-2.025L23 17.25v-1.5l-1.2-.6-.825-2.025.375-1.35-1.05-1.05-1.35.375-2.025-.825L16.25 9h-1.5l-.6 1.2-2.025.825-1.35-.375-1.05 1.05.375 1.35-.825 2.025L8 15.75v1.5l1.2.6.825 2.025-.375 1.35 1.05 1.05 1.35-.375 2.025.825L14.75 24h1.5l.6-1.2 2.025-.825 1.35.375 1.05-1.05-.375-1.35z"
-                      fill="currentColor"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
+                  externalTool
+                </h3>
               </div>
+            </div>
+            <div
+              class="c12"
+            >
               <div
-                class="c11"
+                class="c13"
               >
                 <div
-                  class="c12"
-                >
-                  <svg
-                    fill="none"
-                    viewBox="0 0 52 52"
-                  >
-                    <path
-                      clip-rule="evenodd"
-                      d="M26.567 3.89L32.544 8H42a1 1 0 011 1v6.188l6.566 4.514a1 1 0 01.434.824V47a1 1 0 01-1 1H3a1 1 0 01-1-1V20.526a1 1 0 01.433-.824L9 15.188V9a1 1 0 011-1h9.455l5.979-4.11a1 1 0 011.133 0zM22.985 8h6.03L26 5.927 22.985 8zM9 17.615l-5 3.437v.323l5 3.438v-7.198zm2 8.573l10.537 7.244 2.873-1.796a3 3 0 013.18 0l2.873 1.796L41 26.188V10H11v16.188zm32-1.375l5-3.438v-.323l-5-3.437v7.198zm5-1.01L32.313 34.586 48 44.392v-20.59zM4 44.391l15.687-9.805L4 23.802v20.59zm21.47-11.06L5.2 46h41.6L26.53 33.332a1 1 0 00-1.06 0z"
-                      fill="#4E6896"
-                      fill-rule="evenodd"
-                    />
-                    <path
-                      d="M16 17c0-.552.471-1 1.053-1h17.894c.582 0 1.053.448 1.053 1s-.471 1-1.053 1H17.053C16.47 18 16 17.552 16 17zm1.053 5C16.47 22 16 22.448 16 23s.471 1 1.053 1h17.894C35.53 24 36 23.552 36 23s-.471-1-1.053-1H17.053z"
-                      fill="#FF7067"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="c13"
-                >
-                  <span
-                    class="c14"
-                  >
-                    Modèles de documents
-                  </span>
-                  <h3
-                    class="c15 c16"
-                  >
-                    modele de courrier
-                  </h3>
-                </div>
-              </div>
-              <div
-                class="c17"
-              >
-                <div
-                  class="c18"
+                  class="c14"
                 >
                   <div
-                    class="c19"
+                    class="c15 c16"
                   >
-                    <div
-                      class="c20 c21"
+                    voir
+                    <svg
+                      class="c17"
+                      fill="none"
+                      viewBox="0 0 28 15"
                     >
-                      Consulter
-                      <svg
-                        class="c22"
-                        fill="none"
-                        viewBox="0 0 28 15"
-                      >
-                        <path
-                          d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                    </div>
+                      <path
+                        d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
+                        fill="currentColor"
+                      />
+                    </svg>
                   </div>
                 </div>
               </div>
-            </a>
-          </li>
-          <li
+            </div>
+          </a>
+        </li>
+        <li
+          class="c4 c5"
+        >
+          <a
             class="c6"
+            href="/modeles-de-courriers/modele.url"
           >
-            <a
-              class="c7 c8"
-              href="/outils/outils.url"
+            <div
+              class="c18"
             >
+              <div
+                class="c19"
+              >
+                <svg
+                  fill="none"
+                  viewBox="0 0 32 32"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M11.938 16.5a3.548 3.548 0 013.562-3.563 3.548 3.548 0 013.563 3.563 3.548 3.548 0 01-3.563 3.563 3.548 3.548 0 01-3.563-3.563zm2.062 0c0 .84.66 1.5 1.5 1.5s1.5-.66 1.5-1.5-.66-1.5-1.5-1.5-1.5.66-1.5 1.5z"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                  />
+                  <path
+                    clip-rule="evenodd"
+                    d="M25 14.838v3.404l-1.663.87-.474 1.109.554 1.82-2.375 2.376-1.9-.555-1.109.476-.87 1.662h-3.405l-.87-1.663-1.109-.474-1.82.554-2.376-2.375.554-1.9-.475-1.109L6 18.163v-3.405l1.662-.87.475-1.109-.554-1.82 2.375-2.376 1.9.554 1.109-.475.87-1.662h3.405l.87 1.662 1.109.475 1.82-.554 2.376 2.375-.555 1.9.476 1.109 1.662.87zm-4.1 5.112l.825-2.025L23 17.25v-1.5l-1.2-.6-.825-2.025.375-1.35-1.05-1.05-1.35.375-2.025-.825L16.25 9h-1.5l-.6 1.2-2.025.825-1.35-.375-1.05 1.05.375 1.35-.825 2.025L8 15.75v1.5l1.2.6.825 2.025-.375 1.35 1.05 1.05 1.35-.375 2.025.825L14.75 24h1.5l.6-1.2 2.025-.825 1.35.375 1.05-1.05-.375-1.35z"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="c7"
+            >
+              <div
+                class="c8"
+              >
+                <svg
+                  fill="none"
+                  viewBox="0 0 52 52"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M26.567 3.89L32.544 8H42a1 1 0 011 1v6.188l6.566 4.514a1 1 0 01.434.824V47a1 1 0 01-1 1H3a1 1 0 01-1-1V20.526a1 1 0 01.433-.824L9 15.188V9a1 1 0 011-1h9.455l5.979-4.11a1 1 0 011.133 0zM22.985 8h6.03L26 5.927 22.985 8zM9 17.615l-5 3.437v.323l5 3.438v-7.198zm2 8.573l10.537 7.244 2.873-1.796a3 3 0 013.18 0l2.873 1.796L41 26.188V10H11v16.188zm32-1.375l5-3.438v-.323l-5-3.437v7.198zm5-1.01L32.313 34.586 48 44.392v-20.59zM4 44.391l15.687-9.805L4 23.802v20.59zm21.47-11.06L5.2 46h41.6L26.53 33.332a1 1 0 00-1.06 0z"
+                    fill="#4E6896"
+                    fill-rule="evenodd"
+                  />
+                  <path
+                    d="M16 17c0-.552.471-1 1.053-1h17.894c.582 0 1.053.448 1.053 1s-.471 1-1.053 1H17.053C16.47 18 16 17.552 16 17zm1.053 5C16.47 22 16 22.448 16 23s.471 1 1.053 1h17.894C35.53 24 36 23.552 36 23s-.471-1-1.053-1H17.053z"
+                    fill="#FF7067"
+                  />
+                </svg>
+              </div>
               <div
                 class="c9"
               >
-                <div
-                  class="c10"
+                <span
+                  class="c20"
                 >
-                  <svg
-                    fill="none"
-                    viewBox="0 0 32 32"
-                  >
-                    <path
-                      clip-rule="evenodd"
-                      d="M11.938 16.5a3.548 3.548 0 013.562-3.563 3.548 3.548 0 013.563 3.563 3.548 3.548 0 01-3.563 3.563 3.548 3.548 0 01-3.563-3.563zm2.062 0c0 .84.66 1.5 1.5 1.5s1.5-.66 1.5-1.5-.66-1.5-1.5-1.5-1.5.66-1.5 1.5z"
-                      fill="currentColor"
-                      fill-rule="evenodd"
-                    />
-                    <path
-                      clip-rule="evenodd"
-                      d="M25 14.838v3.404l-1.663.87-.474 1.109.554 1.82-2.375 2.376-1.9-.555-1.109.476-.87 1.662h-3.405l-.87-1.663-1.109-.474-1.82.554-2.376-2.375.554-1.9-.475-1.109L6 18.163v-3.405l1.662-.87.475-1.109-.554-1.82 2.375-2.376 1.9.554 1.109-.475.87-1.662h3.405l.87 1.662 1.109.475 1.82-.554 2.376 2.375-.555 1.9.476 1.109 1.662.87zm-4.1 5.112l.825-2.025L23 17.25v-1.5l-1.2-.6-.825-2.025.375-1.35-1.05-1.05-1.35.375-2.025-.825L16.25 9h-1.5l-.6 1.2-2.025.825-1.35-.375-1.05 1.05.375 1.35-.825 2.025L8 15.75v1.5l1.2.6.825 2.025-.375 1.35 1.05 1.05 1.35-.375 2.025.825L14.75 24h1.5l.6-1.2 2.025-.825 1.35.375 1.05-1.05-.375-1.35z"
-                      fill="currentColor"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
+                  Modèles de documents
+                </span>
+                <h3
+                  class="c10 c11"
+                >
+                  modele de courrier
+                </h3>
               </div>
+            </div>
+            <div
+              class="c12"
+            >
               <div
-                class="c11"
+                class="c13"
               >
                 <div
-                  class="c12"
-                >
-                  <svg
-                    fill="none"
-                    viewBox="0 0 52 52"
-                  >
-                    <path
-                      d="M43.566 34.192a.752.752 0 00-.47-.191.615.615 0 00-.454.173.592.592 0 00-.177.444v3.68H29v4.939h13.467v3.682c0 .163.067.32.185.436a.635.635 0 00.445.181.625.625 0 00.45-.183l6.277-6.143a.645.645 0 000-.885l-6.258-6.133z"
-                      fill="#FF7067"
-                    />
-                    <path
-                      d="M29.112 4c-.312-.015-.495.131-.698.361-.201.228-.215.563-.214.871L28.195 27 17.8 17a1.176 1.176 0 00-1.205.002c-.182.11-.334.267-.438.456a1.257 1.257 0 00-.157.62V27L4.8 17a1.176 1.176 0 00-1.205.002c-.182.11-.334.267-.438.456a1.258 1.258 0 00-.157.62l.151 30.652c0 .327.127.64.352.871.225.231.53.361.848.361h35.427c.318 0 .623-.13.848-.36a1.25 1.25 0 00.352-.872V46H39v2H5V20l11.157 9.602a1.177 1.177 0 001.204-.003c.183-.109.334-.266.439-.455a1.26 1.26 0 00.156-.62L18 20.5l10.2 9.102a1.177 1.177 0 001.205-.003c.182-.109.334-.266.438-.455a1.25 1.25 0 00.157-.62V6h9v29h1.978V5.232c0-.327-.127-.64-.352-.871a1.185 1.185 0 00-.848-.36H29.112z"
-                      fill="#4E6896"
-                    />
-                    <path
-                      d="M35 37v-2.809c0-.327-.127-.64-.352-.871a1.184 1.184 0 00-.848-.36h-8.6a1.173 1.173 0 00-.113 0 1.19 1.19 0 00-.776.398 1.251 1.251 0 00-.311.833v8.624c0 .327.127.64.352.871.224.231.53.361.848.361H27V42h-1v-7h7v2h2z"
-                      fill="#4E6896"
-                    />
-                    <path
-                      clip-rule="evenodd"
-                      d="M10.287 32.96a1.189 1.189 0 00-.776.398 1.25 1.25 0 00-.311.833v8.624c0 .327.126.64.351.871.226.231.53.361.849.361h8.4c.318 0 .623-.13.848-.36a1.25 1.25 0 00.352-.872v-8.624c0-.327-.127-.64-.352-.871a1.184 1.184 0 00-.848-.36h-8.4a1.173 1.173 0 00-.113 0zM11 35h7v7h-7v-7z"
-                      fill="#4E6896"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="c13"
-                >
-                  <span
-                    class="c14"
-                  >
-                    Outils
-                  </span>
-                  <h3
-                    class="c15 c16"
-                  >
-                    Simulateur
-                  </h3>
-                </div>
-              </div>
-              <div
-                class="c17"
-              >
-                <div
-                  class="c18"
+                  class="c14"
                 >
                   <div
-                    class="c19"
+                    class="c15 c16"
                   >
-                    <div
-                      class="c20 c21"
+                    Consulter
+                    <svg
+                      class="c17"
+                      fill="none"
+                      viewBox="0 0 28 15"
                     >
-                      simuler
-                      <svg
-                        class="c22"
-                        fill="none"
-                        viewBox="0 0 28 15"
-                      >
-                        <path
-                          d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                    </div>
+                      <path
+                        d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
+                        fill="currentColor"
+                      />
+                    </svg>
                   </div>
                 </div>
               </div>
-            </a>
-          </li>
-          <li
-            class="c6"
-          >
-            <a
-              class="c7 c8"
-              href="/outils/outil-2.slug"
-            >
-              <div
-                class="c9"
-              >
-                <div
-                  class="c10"
-                >
-                  <svg
-                    fill="none"
-                    viewBox="0 0 32 32"
-                  >
-                    <path
-                      clip-rule="evenodd"
-                      d="M11.938 16.5a3.548 3.548 0 013.562-3.563 3.548 3.548 0 013.563 3.563 3.548 3.548 0 01-3.563 3.563 3.548 3.548 0 01-3.563-3.563zm2.062 0c0 .84.66 1.5 1.5 1.5s1.5-.66 1.5-1.5-.66-1.5-1.5-1.5-1.5.66-1.5 1.5z"
-                      fill="currentColor"
-                      fill-rule="evenodd"
-                    />
-                    <path
-                      clip-rule="evenodd"
-                      d="M25 14.838v3.404l-1.663.87-.474 1.109.554 1.82-2.375 2.376-1.9-.555-1.109.476-.87 1.662h-3.405l-.87-1.663-1.109-.474-1.82.554-2.376-2.375.554-1.9-.475-1.109L6 18.163v-3.405l1.662-.87.475-1.109-.554-1.82 2.375-2.376 1.9.554 1.109-.475.87-1.662h3.405l.87 1.662 1.109.475 1.82-.554 2.376 2.375-.555 1.9.476 1.109 1.662.87zm-4.1 5.112l.825-2.025L23 17.25v-1.5l-1.2-.6-.825-2.025.375-1.35-1.05-1.05-1.35.375-2.025-.825L16.25 9h-1.5l-.6 1.2-2.025.825-1.35-.375-1.05 1.05.375 1.35-.825 2.025L8 15.75v1.5l1.2.6.825 2.025-.375 1.35 1.05 1.05 1.35-.375 2.025.825L14.75 24h1.5l.6-1.2 2.025-.825 1.35.375 1.05-1.05-.375-1.35z"
-                      fill="currentColor"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-              </div>
-              <div
-                class="c11"
-              >
-                <div
-                  class="c12"
-                >
-                  <svg
-                    fill="none"
-                    viewBox="0 0 52 52"
-                  >
-                    <path
-                      d="M41.953 2H9.047A3.05 3.05 0 006 5.047V15c0 .56.455 1 1.016 1 .56 0 1.015-.44 1.015-1V5.047c0-.56.456-1.016 1.016-1.016h32.906c.56 0 1.016.456 1.016 1.016v41.906c0 .56-.456 1.016-1.016 1.016H9.047c-.56 0-1.016-.456-1.016-1.016V23.971a1.016 1.016 0 00-2.031 0v22.982A3.05 3.05 0 009.047 50h32.906A3.05 3.05 0 0045 46.953V5.047A3.05 3.05 0 0041.953 2z"
-                      fill="#4E6896"
-                    />
-                    <path
-                      d="M7.062 18a1.018 1.018 0 011.015 1.015 1.017 1.017 0 01-1.734.719 1.026 1.026 0 01-.297-.72c.001-.268.108-.526.297-.717.19-.19.451-.297.719-.297zm13.063 18.297a1.016 1.016 0 00-1.436 0l-2.7 2.7-1.255-1.255a1.016 1.016 0 00-1.437 1.436l1.974 1.974a1.016 1.016 0 001.436 0l3.418-3.418a1.016 1.016 0 000-1.437zm.06-8a1.016 1.016 0 00-1.436 0l-2.7 2.7-1.256-1.255a1.016 1.016 0 00-1.436 1.436l1.974 1.974a1.016 1.016 0 001.436 0l3.418-3.418a1.016 1.016 0 000-1.437z"
-                      fill="#4E6896"
-                    />
-                    <path
-                      clip-rule="evenodd"
-                      d="M12.016 10h10c.56 0 1.015.455 1.015 1.016v9.968c0 .561-.454 1.016-1.015 1.016h-10A1.016 1.016 0 0111 20.984v-9.968c0-.561.455-1.016 1.016-1.016zM21 19.969h-7.969V12.03H21v7.938z"
-                      fill="#4E6896"
-                      fill-rule="evenodd"
-                    />
-                    <path
-                      d="M29.016 11h9.109a1.016 1.016 0 010 2.031h-9.11a1.016 1.016 0 010-2.031zm0 8h9.109a1.016 1.016 0 010 2.031h-9.11a1.016 1.016 0 010-2.031zm8.96 10H26.024C25.46 29 25 29.448 25 30s.459 1 1.024 1h11.952C38.54 31 39 30.552 39 30s-.459-1-1.024-1zm0 9H26.024C25.46 38 25 38.448 25 39s.459 1 1.024 1h11.952C38.54 40 39 39.552 39 39s-.459-1-1.024-1zm.149-23h-9.11a1.016 1.016 0 000 2.031h9.11a1.016 1.016 0 000-2.031z"
-                      fill="#FF7067"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="c13"
-                >
-                  <span
-                    class="c14"
-                  >
-                    Outils
-                  </span>
-                  <h3
-                    class="c15 c16"
-                  >
-                    fiche sp
-                  </h3>
-                </div>
-              </div>
-              <div
-                class="c17"
-              >
-                <div
-                  class="c18"
-                >
-                  <div
-                    class="c19"
-                  >
-                    <div
-                      class="c20 c21"
-                    >
-                      tester
-                      <svg
-                        class="c22"
-                        fill="none"
-                        viewBox="0 0 28 15"
-                      >
-                        <path
-                          d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </a>
-          </li>
-          <li
-            class="c6"
-          >
-            <a
-              class="c7 c23"
-              href="external.tools"
-              rel="noopener nofollow"
-              target="_blank"
-            >
-              <div
-                class="c11"
-              >
-                <div
-                  class="c12"
-                >
-                  <svg
-                    fill="none"
-                    viewBox="0 0 52 52"
-                  >
-                    <path
-                      clip-rule="evenodd"
-                      d="M17 2L6 13v2c0 1 .398 1 1.076 1h9.693C18.554 16 20 14.657 20 13V4h19a1 1 0 011 1v27h2V5a3 3 0 00-3-3H17zm-.23 12H8L18 4v9c0 .552-.636 1-1.23 1z"
-                      fill="#4E6896"
-                      fill-rule="evenodd"
-                    />
-                    <path
-                      d="M27 50v-2H9a1 1 0 01-1-1V24s0-1-1-1-1 1-1 1v23a3 3 0 003 3h18zM7 20a1 1 0 100-2 1 1 0 000 2z"
-                      fill="#4E6896"
-                    />
-                    <path
-                      d="M15.053 20C14.47 20 14 20.448 14 21s.471 1 1.053 1h17.894C33.53 22 34 21.552 34 21s-.471-1-1.053-1H15.053zM14 27c0-.552.471-1 1.053-1h17.894c.582 0 1.053.448 1.053 1s-.471 1-1.053 1H15.053C14.47 28 14 27.552 14 27z"
-                      fill="#FF7067"
-                    />
-                    <path
-                      clip-rule="evenodd"
-                      d="M36.5 37.938a3.548 3.548 0 00-3.563 3.562 3.548 3.548 0 003.563 3.563 3.548 3.548 0 003.563-3.563 3.548 3.548 0 00-3.563-3.563zm0 5.062c-.84 0-1.5-.66-1.5-1.5s.66-1.5 1.5-1.5 1.5.66 1.5 1.5-.66 1.5-1.5 1.5z"
-                      fill="#FF7067"
-                      fill-rule="evenodd"
-                    />
-                    <path
-                      clip-rule="evenodd"
-                      d="M46 43.242v-3.404l-1.663-.871-.475-1.109.555-1.9-2.375-2.375-1.821.555-1.108-.475L38.241 32h-3.404l-.871 1.663-1.109.475-1.9-.555-2.375 2.375.555 1.821-.476 1.108-1.662.871v3.404l1.663.871.474 1.109-.554 1.9 2.375 2.375 1.821-.555 1.108.475.871 1.663h3.404l.871-1.663 1.109-.475 1.9.555 2.375-2.375-.555-1.821.475-1.108L46 43.241zm-3.275-.317L41.9 44.95l.375 1.35-1.05 1.05-1.35-.375-2.025.825-.6 1.2h-1.5l-.675-1.275-2.025-.825-1.35.375-1.05-1.05.375-1.35-.825-2.025-1.2-.6v-1.5l1.275-.675.825-2.025-.375-1.35 1.05-1.05 1.35.375 2.025-.825.6-1.2h1.5l.675 1.275 2.025.825 1.35-.375 1.05 1.05-.375 1.35.825 2.025 1.2.6v1.5l-1.275.675z"
-                      fill="#FF7067"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="c13"
-                >
-                  
-                  <h3
-                    class="c15 c16"
-                  >
-                    externalTool
-                  </h3>
-                </div>
-              </div>
-            </a>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div
-      class="c24"
-    >
-      <div>
+            </div>
+          </a>
+        </li>
+      </ul>
+      <div
+        class="c10"
+      >
         Les articles pouvant vous intéresser :
       </div>
       <ul
-        class="c25"
+        class="c21"
       >
         <li
-          class="c26"
+          class="c22"
         >
           <a
-            class="c27 c28"
+            class="c23 c24"
             href="/fiche-service-public/fiche.sp.url"
           >
             <svg
-              class="c29"
+              class="c25"
               fill="none"
               viewBox="0 0 28 15"
             >
@@ -896,21 +629,21 @@ exports[`<Article /> should render 1`] = `
               />
             </svg>
             <span
-              class="c30"
+              class="c26"
             >
               fiche sp
             </span>
           </a>
         </li>
         <li
-          class="c26"
+          class="c22"
         >
           <a
-            class="c27 c28"
+            class="c23 c24"
             href="/contribution/contrib.url"
           >
             <svg
-              class="c29"
+              class="c25"
               fill="none"
               viewBox="0 0 28 15"
             >
@@ -920,7 +653,7 @@ exports[`<Article /> should render 1`] = `
               />
             </svg>
             <span
-              class="c30"
+              class="c26"
             >
               contrib
             </span>

--- a/packages/code-du-travail-frontend/src/contributions/__tests__/__snapshots__/Contribution.test.js.snap
+++ b/packages/code-du-travail-frontend/src/contributions/__tests__/__snapshots__/Contribution.test.js.snap
@@ -360,6 +360,12 @@ exports[`<Contribution /> should NOT render invalid preselected convention 1`] =
 }
 
 @media (max-width:600px) {
+  .c10 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c12 {
     padding: 1.6rem 1rem;
   }
@@ -1053,6 +1059,12 @@ exports[`<Contribution /> should render answer references 1`] = `
 .c27 {
   width: 2.8rem;
   margin-left: 1.6rem;
+}
+
+@media (max-width:600px) {
+  .c10 {
+    padding: 2.4rem 0;
+  }
 }
 
 @media (max-width:600px) {
@@ -1781,6 +1793,12 @@ exports[`<Contribution /> should render preselected convention 1`] = `
 }
 
 @media (max-width:600px) {
+  .c10 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c12 {
     padding: 1.6rem 1rem;
   }
@@ -2371,6 +2389,12 @@ exports[`<Contribution /> should render with both answers 1`] = `
 }
 
 @media (max-width:600px) {
+  .c10 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c12 {
     padding: 1.6rem 1rem;
   }
@@ -2852,6 +2876,12 @@ exports[`<Contribution /> should render with conventions answer 1`] = `
 
 .c11 {
   margin-top: 0;
+}
+
+@media (max-width:600px) {
+  .c7 {
+    padding: 2.4rem 0;
+  }
 }
 
 @media (max-width:600px) {

--- a/packages/code-du-travail-frontend/src/conventions/Convention/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/code-du-travail-frontend/src/conventions/Convention/__tests__/__snapshots__/index.test.js.snap
@@ -241,12 +241,12 @@ exports[`<Convention /> renders 1`] = `
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
+  margin: 1rem;
+  padding: 0;
+  width: calc(100% / 3 - 2 * 1rem - 1px);
   -webkit-flex-shrink: 1;
   -ms-flex-negative: 1;
   flex-shrink: 1;
-  width: calc(100% / 3 - 2 * 1rem - 1px);
-  margin: 1rem;
-  padding: 0;
 }
 
 .c5 {

--- a/packages/code-du-travail-frontend/src/conventions/Convention/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/code-du-travail-frontend/src/conventions/Convention/__tests__/__snapshots__/index.test.js.snap
@@ -241,12 +241,12 @@ exports[`<Convention /> renders 1`] = `
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  margin: 1rem;
-  padding: 0;
-  width: calc(100% / 3 - 2 * 1rem - 1px);
   -webkit-flex-shrink: 1;
   -ms-flex-negative: 1;
   flex-shrink: 1;
+  margin: 1rem;
+  padding: 0;
+  width: calc(100% / 3 - 2 * 1rem - 1px);
 }
 
 .c5 {
@@ -557,6 +557,27 @@ exports[`<Convention /> renders 1`] = `
   }
 }
 
+@media (max-width:600px) {
+  .c20 {
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    min-width: 23rem;
+  }
+
+  .c20:first-of-type {
+    margin-left: 2rem;
+  }
+
+  .c20:last-of-type:after {
+    display: block;
+    width: 2rem;
+    height: 100%;
+    background-color: transparent;
+    content: "";
+  }
+}
+
 @media (max-width:1180px) {
   .c20 {
     width: calc( 100% / 2 - 2 * 1rem - 1px );
@@ -571,23 +592,7 @@ exports[`<Convention /> renders 1`] = `
 
 @media (max-width:600px) {
   .c20 {
-    -webkit-flex-shrink: 0;
-    -ms-flex-negative: 0;
-    flex-shrink: 0;
     width: 80%;
-    min-width: 23rem;
-  }
-
-  .c20:first-of-type {
-    margin-left: 2rem;
-  }
-
-  .c20:last-of-type:after {
-    display: block;
-    width: 2rem;
-    height: 100%;
-    background-color: transparent;
-    content: "";
   }
 }
 

--- a/packages/code-du-travail-frontend/src/layout/__tests__/__snapshots__/Footer.test.js.snap
+++ b/packages/code-du-travail-frontend/src/layout/__tests__/__snapshots__/Footer.test.js.snap
@@ -254,6 +254,12 @@ exports[`<Footer /> should render 1`] = `
 }
 
 @media (max-width:600px) {
+  .c2 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c9 {
     font-size: 1.4rem;
   }

--- a/packages/code-du-travail-frontend/src/layout/__tests__/__snapshots__/Layout.test.js.snap
+++ b/packages/code-du-travail-frontend/src/layout/__tests__/__snapshots__/Layout.test.js.snap
@@ -561,6 +561,12 @@ exports[`<Layout /> should render 1`] = `
 }
 
 @media (max-width:600px) {
+  .c21 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c16 {
     font-size: 1.4rem;
   }

--- a/packages/code-du-travail-frontend/src/search/SearchResults/Results.js
+++ b/packages/code-du-travail-frontend/src/search/SearchResults/Results.js
@@ -45,12 +45,14 @@ export const ListLink = ({
 
   if (source === SOURCES.EXTERNALS) {
     return (
-      <Tile
+      <CallToActionTile
+        action={action || "Consulter"}
         href={url}
         target="_blank"
         rel="noreferer noopener"
         className="no-after"
         {...tileCommonProps}
+        custom={false}
       />
     );
   }

--- a/packages/code-du-travail-frontend/src/search/__tests__/__snapshots__/SearchHero.test.js.snap
+++ b/packages/code-du-travail-frontend/src/search/__tests__/__snapshots__/SearchHero.test.js.snap
@@ -246,6 +246,12 @@ exports[`<SearchHero /> should render 1`] = `
 }
 
 @media (max-width:600px) {
+  .c0 {
+    padding: 2.4rem 0;
+  }
+}
+
+@media (max-width:600px) {
   .c15 {
     font-size: 1.4rem;
   }

--- a/packages/code-du-travail-frontend/src/search/__tests__/__snapshots__/SearchResults.test.js.snap
+++ b/packages/code-du-travail-frontend/src/search/__tests__/__snapshots__/SearchResults.test.js.snap
@@ -205,12 +205,12 @@ exports[`<SearchResults/> should render results 1`] = `
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  margin: 1rem;
-  padding: 0;
-  width: calc(100% / 3 - 2 * 1rem - 1px);
   -webkit-flex-shrink: 1;
   -ms-flex-negative: 1;
   flex-shrink: 1;
+  margin: 1rem;
+  padding: 0;
+  width: calc(100% / 3 - 2 * 1rem - 1px);
 }
 
 .c29 {
@@ -222,12 +222,12 @@ exports[`<SearchResults/> should render results 1`] = `
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  margin: 1rem;
-  padding: 0;
-  width: calc(100% / 4 - 2 * 1rem - 1px);
   -webkit-flex-shrink: 1;
   -ms-flex-negative: 1;
   flex-shrink: 1;
+  margin: 1rem;
+  padding: 0;
+  width: calc(100% / 4 - 2 * 1rem - 1px);
 }
 
 .c4 {
@@ -522,6 +522,27 @@ exports[`<SearchResults/> should render results 1`] = `
   }
 }
 
+@media (max-width:600px) {
+  .c28 {
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    min-width: 23rem;
+  }
+
+  .c28:first-of-type {
+    margin-left: 2rem;
+  }
+
+  .c28:last-of-type:after {
+    display: block;
+    width: 2rem;
+    height: 100%;
+    background-color: transparent;
+    content: "";
+  }
+}
+
 @media (max-width:1180px) {
   .c28 {
     width: calc( 100% / 2 - 2 * 1rem - 1px );
@@ -536,18 +557,23 @@ exports[`<SearchResults/> should render results 1`] = `
 
 @media (max-width:600px) {
   .c28 {
+    width: 80%;
+  }
+}
+
+@media (max-width:600px) {
+  .c29 {
     -webkit-flex-shrink: 0;
     -ms-flex-negative: 0;
     flex-shrink: 0;
-    width: 80%;
     min-width: 23rem;
   }
 
-  .c28:first-of-type {
+  .c29:first-of-type {
     margin-left: 2rem;
   }
 
-  .c28:last-of-type:after {
+  .c29:last-of-type:after {
     display: block;
     width: 2rem;
     height: 100%;
@@ -570,23 +596,7 @@ exports[`<SearchResults/> should render results 1`] = `
 
 @media (max-width:600px) {
   .c29 {
-    -webkit-flex-shrink: 0;
-    -ms-flex-negative: 0;
-    flex-shrink: 0;
     width: 60%;
-    min-width: 23rem;
-  }
-
-  .c29:first-of-type {
-    margin-left: 2rem;
-  }
-
-  .c29:last-of-type:after {
-    display: block;
-    width: 2rem;
-    height: 100%;
-    background-color: transparent;
-    content: "";
   }
 }
 
@@ -784,7 +794,30 @@ exports[`<SearchResults/> should render results 1`] = `
           <div
             class="c11"
           >
-            description
+            <div
+              class="c15"
+            >
+              description
+              <div
+                class="c16"
+              >
+                <div
+                  class="c17 c18"
+                >
+                  Consulter
+                  <svg
+                    class="c19"
+                    fill="none"
+                    viewBox="0 0 28 15"
+                  >
+                    <path
+                      d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </div>
           </div>
         </a>
       </li>

--- a/packages/code-du-travail-frontend/src/search/__tests__/__snapshots__/SearchResults.test.js.snap
+++ b/packages/code-du-travail-frontend/src/search/__tests__/__snapshots__/SearchResults.test.js.snap
@@ -205,12 +205,12 @@ exports[`<SearchResults/> should render results 1`] = `
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
+  margin: 1rem;
+  padding: 0;
+  width: calc(100% / 3 - 2 * 1rem - 1px);
   -webkit-flex-shrink: 1;
   -ms-flex-negative: 1;
   flex-shrink: 1;
-  width: calc(100% / 3 - 2 * 1rem - 1px);
-  margin: 1rem;
-  padding: 0;
 }
 
 .c29 {
@@ -222,12 +222,12 @@ exports[`<SearchResults/> should render results 1`] = `
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
+  margin: 1rem;
+  padding: 0;
+  width: calc(100% / 4 - 2 * 1rem - 1px);
   -webkit-flex-shrink: 1;
   -ms-flex-negative: 1;
   flex-shrink: 1;
-  width: calc(100% / 4 - 2 * 1rem - 1px);
-  margin: 1rem;
-  padding: 0;
 }
 
 .c4 {

--- a/packages/react-fiche-service-public/__tests__/__snapshots__/FicheServicePublic.test.js.snap
+++ b/packages/react-fiche-service-public/__tests__/__snapshots__/FicheServicePublic.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<FicheServicePublic /> should render 1`] = `
-.c6:not(:focus):not(:active) {
+.c9:not(:focus):not(:active) {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -13,7 +13,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
   clip: rect(0,0,0,0);
 }
 
-.c14 {
+.c17 {
   position: relative;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -27,31 +27,31 @@ exports[`<FicheServicePublic /> should render 1`] = `
   transition: transform 250ms linear;
 }
 
-[aria-expanded="true"] .c14,
-[aria-selected="true"] .c14 {
+[aria-expanded="true"] .c17,
+[aria-selected="true"] .c17 {
   -webkit-transform: rotate(90deg);
   -ms-transform: rotate(90deg);
   transform: rotate(90deg);
 }
 
-.c12 {
+.c15 {
   position: relative;
   z-index: 1;
 }
 
-.c19 {
+.c22 {
   position: relative;
   z-index: 1;
   border-top: 1px solid #bbcadf;
 }
 
-.c16 {
+.c19 {
   padding: 1.6rem;
   -webkit-animation: dpvxPj 250ms ease-in;
   animation: dpvxPj 250ms ease-in;
 }
 
-.c13 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -68,14 +68,14 @@ exports[`<FicheServicePublic /> should render 1`] = `
   cursor: pointer;
 }
 
-.c13:hover,
-.c13:focus,
-.c13:focus-within,
-.c13[aria-expanded="true"] {
+.c16:hover,
+.c16:focus,
+.c16:focus-within,
+.c16[aria-expanded="true"] {
   color: #3e486e;
 }
 
-.c15 {
+.c18 {
   margin: 2rem 0 2rem 1rem;
   color: #2f3b6c;
   font-weight: 600;
@@ -84,78 +84,48 @@ exports[`<FicheServicePublic /> should render 1`] = `
   line-height: 1.25;
 }
 
-.c18 > *:first-child {
+.c21 > *:first-child {
   margin-top: 0;
 }
 
-.c18 > *:last-child {
+.c21 > *:last-child {
   margin-bottom: 0;
 }
 
-.c23 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: content-box;
-  font-weight: 500;
-  font-size: 1.6rem;
-  line-height: 1.125em;
-  text-align: center;
-  vertical-align: middle;
-  border: 1px solid;
-  border-radius: 0.6rem;
-  cursor: pointer;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,-webkit-transform 100ms linear;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  height: 5.2rem;
-  padding: 0 4.4rem;
-  color: #fff;
-  background: #7994d4;
-  border-color: #7994d4;
-  box-shadow: 0px 10px 20px rgba(121,148,212,0.26),0px 5px 7px rgba(121,148,212,0.35);
-  opacity: 1;
+.c3 {
+  position: relative;
+  overflow: hidden;
 }
 
-.c23:link,
-.c23:visited {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #fff;
+.c3:before,
+.c3:after {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 1;
+  display: block;
+  width: 4rem;
+  opacity: 0;
+  -webkit-transition: opacity 0.3s linear;
+  transition: opacity 0.3s linear;
+  content: "";
+  pointer-events: none;
+  background: radial-gradient( ellipse at center, #fff 15%, rgba(255,255,255,0) 80% );
 }
 
-.c23:not([disabled]):hover,
-.c23:not([disabled]):active,
-.c23:not([disabled]):focus {
-  opacity: 1;
-  -webkit-transform: translateY(-2px);
-  -ms-transform: translateY(-2px);
-  transform: translateY(-2px);
-  background: #a0b3e0;
-  border-color: #a0b3e0;
+.c3:before {
+  left: -2rem;
 }
 
-.c23[disabled] {
-  background-color: #e4e8ef;
-  border-color: #e4e8ef;
-  color: #9298af;
-  box-shadow: none;
-  cursor: not-allowed;
+.c3:after {
+  right: -2rem;
 }
 
-.c9 {
+.c5 {
+  overflow-x: auto;
+}
+
+.c12 {
   position: absolute;
   background-color: #7994d4;
   border-radius: 0.6rem;
@@ -172,9 +142,11 @@ exports[`<FicheServicePublic /> should render 1`] = `
   margin-bottom: 3.2rem;
 }
 
-.c3 {
-  position: relative;
-  top: 1px;
+.c4 {
+  margin-right: 0.4rem;
+}
+
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -184,12 +156,16 @@ exports[`<FicheServicePublic /> should render 1`] = `
   flex-wrap: nowrap;
   max-width: 100%;
   margin: 0;
-  padding: 0 0.4rem 0 0;
+  padding: 0 0 0 0;
   overflow: visible;
   list-style-type: none;
 }
 
-.c4 {
+.c7 {
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  max-height: 11rem;
   margin-left: 0.4rem;
   padding: 1rem 1.6rem;
   color: #4d73b8;
@@ -197,7 +173,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
   font-size: 1.8rem;
   background-color: #fff;
   border: 1px solid #bbcadf;
-  border-bottom: 1px solid #bbcadf;
+  border-bottom: 1px solid transparent;
   border-radius: 0.6rem 0.6rem 0 0;
   cursor: pointer;
   opacity: 1;
@@ -205,35 +181,35 @@ exports[`<FicheServicePublic /> should render 1`] = `
   transition: opacity 250ms linear;
 }
 
-.c4[aria-selected="false"]:hover {
+.c7[aria-selected="false"]:hover {
   opacity: 0.7;
 }
 
-.c4[aria-selected="true"] {
+.c7[aria-selected="true"] {
   color: #fff;
   background-color: #7994d4;
 }
 
-.c5 {
+.c8 {
   color: #3e486e;
   background-color: #fff;
 }
 
-.c5.react-tabs__tab-panel--selected {
+.c8.react-tabs__tab-panel--selected {
   padding: 2.4rem;
   border: 1px solid #bbcadf;
   border-radius: 0.6rem;
 }
 
-.c10 > *:first-child {
+.c13 > *:first-child {
   margin-top: 0;
 }
 
-.c10 > *:last-child {
+.c13 > *:last-child {
   margin-bottom: 0;
 }
 
-.c17 {
+.c20 {
   position: relative;
   margin: 3.2rem 0 2rem 0;
   color: #2f3b6c;
@@ -243,14 +219,97 @@ exports[`<FicheServicePublic /> should render 1`] = `
   line-height: 1.625;
 }
 
-.c7 {
+.c28 {
+  display: block;
+  margin: 0 0 1rem 0;
+  color: #4d73b8;
+  font-weight: 600;
+  font-size: 1.2rem;
+  font-family: "Open Sans",sans-serif;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+
+.c24 {
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  width: 100%;
+  margin: 0;
+  padding: 2rem 2rem;
+  color: #3e486e;
+  font-weight: normal;
+  font-size: 1.6rem;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: #fff;
+  border: none;
+  border-radius: 0.6rem;
+  box-shadow: 0 1rem 2rem rgba(121,148,212,0.2);
+  cursor: pointer;
+  -webkit-transition: box-shadow 250ms linear, -webkit-transform 100ms linear;
+  -webkit-transition: box-shadow 250ms linear, transform 100ms linear;
+  transition: box-shadow 250ms linear, transform 100ms linear;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c24:hover,
+.c24:active,
+.c24:focus {
+  color: #3e486e;
+  box-shadow: 0 1rem 2rem rgba(121,148,212,0.4);
+  -webkit-transform: translateY(-2px);
+  -ms-transform: translateY(-2px);
+  transform: translateY(-2px);
+}
+
+.c26 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c27 {
+  padding-right: 1rem;
+}
+
+.c29 {
+  margin: 0;
+}
+
+.c30 {
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 1rem;
+}
+
+.c10 {
   margin-top: 3.2rem;
   margin-bottom: 2rem;
   margin-left: auto;
   text-align: left;
 }
 
-.c8 {
+.c11 {
   position: relative;
   margin: 0;
   color: #2f3b6c;
@@ -262,48 +321,19 @@ exports[`<FicheServicePublic /> should render 1`] = `
   text-align: left;
 }
 
-.c11 {
+.c14 {
   margin-bottom: 3.2rem;
 }
 
-.c20 {
+.c23 {
   margin-bottom: 0.4rem;
-}
-
-.c21 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: column;
-  -ms-flex-flow: column;
-  flex-flow: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-bottom: 1.6rem;
-  padding: 3.2rem;
-  background-color: #e4e8ef;
-  border-radius: 0.6rem;
-}
-
-.c22 {
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: start;
-  align-self: flex-start;
-  margin-bottom: 0.4rem;
-  color: #3e486e;
-  font-weight: bold;
-  font-size: 1.8rem;
-}
-
-.c24 {
-  display: inline-block;
-  margin-top: 0.4rem;
 }
 
 .c25 {
+  margin-bottom: 1.6rem;
+}
+
+.c31 {
   padding: 2rem 2.4rem;
   color: #3e486e;
   border-radius: 0.6rem;
@@ -312,11 +342,11 @@ exports[`<FicheServicePublic /> should render 1`] = `
   margin-bottom: 1.6rem;
 }
 
-.c25 > *:first-child {
+.c31 > *:first-child {
   margin-top: 0;
 }
 
-.c25 > *:last-child {
+.c31 > *:last-child {
   margin-bottom: 0;
 }
 
@@ -333,26 +363,33 @@ exports[`<FicheServicePublic /> should render 1`] = `
 }
 
 @media (max-width:600px) {
-  .c16 {
+  .c19 {
     padding: 1rem 0;
   }
 }
 
 @media (max-width:600px) {
-  .c15 {
+  .c18 {
     font-size: 1.6rem;
   }
 }
 
 @media (max-width:600px) {
-  .c23 {
-    font-size: 1.4rem;
+  .c3 {
+    overflow-x: hidden;
   }
 }
 
 @media (max-width:600px) {
-  .c23 {
-    padding: 0 3rem;
+  .c3:before,
+  .c3:after {
+    display: block;
+  }
+}
+
+@media (max-width:600px) {
+  .c5 {
+    overflow-x: auto;
   }
 }
 
@@ -363,19 +400,13 @@ exports[`<FicheServicePublic /> should render 1`] = `
 }
 
 @media (max-width:980px) {
-  .c3 {
-    -webkit-flex-wrap: wrap;
-    -ms-flex-wrap: wrap;
-    flex-wrap: wrap;
+  .c6 {
     padding: 0;
   }
 }
 
 @media (max-width:980px) {
-  .c4 {
-    -webkit-flex: 1 1 auto;
-    -ms-flex: 1 1 auto;
-    flex: 1 1 auto;
+  .c7 {
     margin: 0.4rem;
     border-bottom: 1px solid #bbcadf;
     border-radius: 0.6rem;
@@ -383,68 +414,63 @@ exports[`<FicheServicePublic /> should render 1`] = `
 }
 
 @media (max-width:600px) {
-  .c4 {
+  .c7 {
     font-size: 1.6rem;
   }
 }
 
 @media (max-width:980px) {
-  .c5.react-tabs__tab-panel--selected {
+  .c8.react-tabs__tab-panel--selected {
     margin-top: 0.4rem;
   }
 }
 
 @media (max-width:600px) {
-  .c5.react-tabs__tab-panel--selected {
+  .c8.react-tabs__tab-panel--selected {
     padding: 1rem;
   }
 }
 
 @media (max-width:600px) {
-  .c17 {
+  .c20 {
     font-size: 1.6rem;
   }
 }
 
 @media (max-width:600px) {
-  .c7 {
+  .c24 {
+    padding: 1.6rem 1.6rem;
+    font-size: 1.4rem;
+  }
+}
+
+@media (max-width:600px) {
+  .c10 {
     margin-bottom: 1rem;
     margin-left: auto;
   }
 }
 
 @media (max-width:600px) {
-  .c8 {
+  .c11 {
     padding-left: 1.6rem;
   }
 }
 
 @media (max-width:600px) {
-  .c8 {
+  .c11 {
     font-size: 2.2rem;
   }
 }
 
 @media (max-width:600px) {
-  .c21 {
-    padding: 1rem 2rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c22 {
-    font-size: 1.6rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c25 {
+  .c31 {
     padding: 1.6rem 1rem;
   }
 }
 
 @media print {
-  .c25 {
+  .c31 {
     padding: 0 5pt;
     border: none;
   }
@@ -473,74 +499,82 @@ exports[`<FicheServicePublic /> should render 1`] = `
       class="c2"
       data-tabs="true"
     >
-      <ul
-        class="c3"
-        role="tablist"
+      <div
+        class="c3 c4"
       >
-        <li
-          aria-controls="react-tabs-1"
-          aria-disabled="false"
-          aria-selected="true"
-          class="c4 react-tabs__tab--selected"
-          id="react-tabs-0"
-          role="tab"
-          tabindex="0"
+        <div
+          class="c5"
         >
-          CDI
-        </li>
-        <li
-          aria-controls="react-tabs-3"
-          aria-disabled="false"
-          aria-selected="false"
-          class="c4"
-          id="react-tabs-2"
-          role="tab"
-        >
-          CDD
-        </li>
-        <li
-          aria-controls="react-tabs-5"
-          aria-disabled="false"
-          aria-selected="false"
-          class="c4"
-          id="react-tabs-4"
-          role="tab"
-        >
-          Contrat de travail temporaire (intérim)
-        </li>
-      </ul>
+          <ul
+            class="c6"
+            role="tablist"
+          >
+            <li
+              aria-controls="react-tabs-1"
+              aria-disabled="false"
+              aria-selected="true"
+              class="c7 react-tabs__tab--selected"
+              id="react-tabs-0"
+              role="tab"
+              tabindex="0"
+            >
+              CDI
+            </li>
+            <li
+              aria-controls="react-tabs-3"
+              aria-disabled="false"
+              aria-selected="false"
+              class="c7"
+              id="react-tabs-2"
+              role="tab"
+            >
+              CDD
+            </li>
+            <li
+              aria-controls="react-tabs-5"
+              aria-disabled="false"
+              aria-selected="false"
+              class="c7"
+              id="react-tabs-4"
+              role="tab"
+            >
+              Contrat de travail temporaire (intérim)
+            </li>
+          </ul>
+        </div>
+      </div>
       <div
         aria-labelledby="react-tabs-0"
-        class="c5 react-tabs__tab-panel--selected"
+        class="c8 react-tabs__tab-panel--selected"
         id="react-tabs-1"
         role="tabpanel"
       >
         <div
-          class="c6"
+          class="c9"
         >
           <header
-            class="c7"
+            class="c10"
           >
             <h2
-              class="c8"
+              class="c11"
             >
               <div
-                class="c9"
+                class="c12"
               />
               CDI
             </h2>
           </header>
         </div>
         <div
-          class="c10"
+          class="c13"
         >
           <div
-            class="c11"
+            class="c14"
             data-accordion-component="Accordion"
           >
             <div>
               <div
-                class="c12"
+                class="c15"
                 data-accordion-component="AccordionItem"
                 index="0"
               >
@@ -554,14 +588,14 @@ exports[`<FicheServicePublic /> should render 1`] = `
                     aria-controls="accordion__panel-0"
                     aria-disabled="false"
                     aria-expanded="false"
-                    class="c13"
+                    class="c16"
                     data-accordion-component="AccordionItemButton"
                     id="accordion__heading-0"
                     role="button"
                     tabindex="0"
                   >
                     <svg
-                      class="c14"
+                      class="c17"
                       fill="none"
                       height="24"
                       stroke="currentColor"
@@ -577,7 +611,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
                       />
                     </svg>
                     <div
-                      class="c15"
+                      class="c18"
                     >
                       De quoi s'agit-il ?
                     </div>
@@ -586,22 +620,22 @@ exports[`<FicheServicePublic /> should render 1`] = `
                 <div
                   aria-hidden="true"
                   aria-labelledby="accordion__heading-0"
-                  class="c16"
+                  class="c19"
                   data-accordion-component="AccordionItemPanel"
                   hidden=""
                   id="accordion__panel-0"
                 >
                   <div
-                    class="c6"
+                    class="c9"
                   >
                     <h3
-                      class="c17"
+                      class="c20"
                     >
                       De quoi s'agit-il ?
                     </h3>
                   </div>
                   <div
-                    class="c18"
+                    class="c21"
                   >
                     <p>
                       La démission est un mode de rupture du contrat de travail qui  vous permet de quitter votre entreprise sans avoir à justifier cette décision.
@@ -621,7 +655,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
             </div>
             <div>
               <div
-                class="c19"
+                class="c22"
                 data-accordion-component="AccordionItem"
                 index="1"
               >
@@ -635,14 +669,14 @@ exports[`<FicheServicePublic /> should render 1`] = `
                     aria-controls="accordion__panel-1"
                     aria-disabled="false"
                     aria-expanded="false"
-                    class="c13"
+                    class="c16"
                     data-accordion-component="AccordionItemButton"
                     id="accordion__heading-1"
                     role="button"
                     tabindex="0"
                   >
                     <svg
-                      class="c14"
+                      class="c17"
                       fill="none"
                       height="24"
                       stroke="currentColor"
@@ -658,7 +692,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
                       />
                     </svg>
                     <div
-                      class="c15"
+                      class="c18"
                     >
                       Conditions
                     </div>
@@ -667,36 +701,36 @@ exports[`<FicheServicePublic /> should render 1`] = `
                 <div
                   aria-hidden="true"
                   aria-labelledby="accordion__heading-1"
-                  class="c16"
+                  class="c19"
                   data-accordion-component="AccordionItemPanel"
                   hidden=""
                   id="accordion__panel-1"
                 >
                   <div
-                    class="c6"
+                    class="c9"
                   >
                     <h3
-                      class="c17"
+                      class="c20"
                     >
                       Conditions
                     </h3>
                   </div>
                   <div
-                    class="c18"
+                    class="c21"
                   >
                     <p>
                       Le salarié peut mettre fin à son contrat de travail dans les cas suivants :
                     </p>
                     <ul>
                       <li
-                        class="c20"
+                        class="c23"
                       >
                         <p>
                           Dans le cadre d'une rupture volontaire du contrat de travail par le salarié
                         </p>
                       </li>
                       <li
-                        class="c20"
+                        class="c23"
                       >
                         <p>
                           
@@ -709,7 +743,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
                         </p>
                       </li>
                       <li
-                        class="c20"
+                        class="c23"
                       >
                         <p>
                           
@@ -719,7 +753,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
                         </p>
                       </li>
                       <li
-                        class="c20"
+                        class="c23"
                       >
                         <p>
                           
@@ -729,7 +763,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
                         </p>
                       </li>
                       <li
-                        class="c20"
+                        class="c23"
                       >
                         <p>
                           
@@ -745,7 +779,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
             </div>
             <div>
               <div
-                class="c19"
+                class="c22"
                 data-accordion-component="AccordionItem"
                 index="2"
               >
@@ -759,14 +793,14 @@ exports[`<FicheServicePublic /> should render 1`] = `
                     aria-controls="accordion__panel-2"
                     aria-disabled="false"
                     aria-expanded="false"
-                    class="c13"
+                    class="c16"
                     data-accordion-component="AccordionItemButton"
                     id="accordion__heading-2"
                     role="button"
                     tabindex="0"
                   >
                     <svg
-                      class="c14"
+                      class="c17"
                       fill="none"
                       height="24"
                       stroke="currentColor"
@@ -782,7 +816,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
                       />
                     </svg>
                     <div
-                      class="c15"
+                      class="c18"
                     >
                       Volonté de démissionner
                     </div>
@@ -791,22 +825,22 @@ exports[`<FicheServicePublic /> should render 1`] = `
                 <div
                   aria-hidden="true"
                   aria-labelledby="accordion__heading-2"
-                  class="c16"
+                  class="c19"
                   data-accordion-component="AccordionItemPanel"
                   hidden=""
                   id="accordion__panel-2"
                 >
                   <div
-                    class="c6"
+                    class="c9"
                   >
                     <h3
-                      class="c17"
+                      class="c20"
                     >
                       Volonté de démissionner
                     </h3>
                   </div>
                   <div
-                    class="c18"
+                    class="c21"
                   >
                     <p>
                       Pour qu'une démission soit valable, vous devez manifester de façon claire et non équivoque votre volonté de mettre fin au contrat de travail.
@@ -853,7 +887,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
             </div>
             <div>
               <div
-                class="c19"
+                class="c22"
                 data-accordion-component="AccordionItem"
                 index="3"
               >
@@ -867,14 +901,14 @@ exports[`<FicheServicePublic /> should render 1`] = `
                     aria-controls="accordion__panel-3"
                     aria-disabled="false"
                     aria-expanded="false"
-                    class="c13"
+                    class="c16"
                     data-accordion-component="AccordionItemButton"
                     id="accordion__heading-3"
                     role="button"
                     tabindex="0"
                   >
                     <svg
-                      class="c14"
+                      class="c17"
                       fill="none"
                       height="24"
                       stroke="currentColor"
@@ -890,7 +924,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
                       />
                     </svg>
                     <div
-                      class="c15"
+                      class="c18"
                     >
                       Procédure
                     </div>
@@ -899,22 +933,22 @@ exports[`<FicheServicePublic /> should render 1`] = `
                 <div
                   aria-hidden="true"
                   aria-labelledby="accordion__heading-3"
-                  class="c16"
+                  class="c19"
                   data-accordion-component="AccordionItemPanel"
                   hidden=""
                   id="accordion__panel-3"
                 >
                   <div
-                    class="c6"
+                    class="c9"
                   >
                     <h3
-                      class="c17"
+                      class="c20"
                     >
                       Procédure
                     </h3>
                   </div>
                   <div
-                    class="c18"
+                    class="c21"
                   >
                     <p>
                       Pour manifester votre volonté claire et non équivoque de démissionner, vous devez nécessairement prévenir votre employeur.
@@ -922,28 +956,37 @@ exports[`<FicheServicePublic /> should render 1`] = `
                     <p>
                       Il n'y a pas de procédure légale imposée pour signifier une démission. Vous pouvez prévenir votre employeur par oral ou par écrit, en lui adressant une lettre de démission.
                     </p>
-                    <div
-                      class="c21"
+                    <a
+                      class="c24 c25 no-after"
+                      href="https://www.service-public.fr/simulateur/calcul/Demission"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
                       <div
-                        class="c22"
+                        class="c26"
                       >
-                        Modèle de document
+                        <div
+                          class="c27"
+                        >
+                          <span
+                            class="c28"
+                          >
+                            Modèle de document
+                          </span>
+                          <h3
+                            class="c20 c29"
+                          >
+                            Lettre de démission du salarié
+                          </h3>
+                        </div>
                       </div>
-                      <a
-                        class="c23 no-after"
-                        href="https://www.service-public.fr/simulateur/calcul/Demission"
-                        rel="noopener noreferrer"
-                        target="_blank"
+                      <div
+                        class="c30"
                       >
-                        Lettre de démission du salarié
-                      </a>
-                      <small
-                        class="c24"
-                      >
+                        Source: 
                         Direction de l'information légale et administrative (Premier ministre)
-                      </small>
-                    </div>
+                      </div>
+                    </a>
                     <p>
                       
                   Des
@@ -963,7 +1006,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
             </div>
             <div>
               <div
-                class="c19"
+                class="c22"
                 data-accordion-component="AccordionItem"
                 index="4"
               >
@@ -977,14 +1020,14 @@ exports[`<FicheServicePublic /> should render 1`] = `
                     aria-controls="accordion__panel-4"
                     aria-disabled="false"
                     aria-expanded="false"
-                    class="c13"
+                    class="c16"
                     data-accordion-component="AccordionItemButton"
                     id="accordion__heading-4"
                     role="button"
                     tabindex="0"
                   >
                     <svg
-                      class="c14"
+                      class="c17"
                       fill="none"
                       height="24"
                       stroke="currentColor"
@@ -1000,7 +1043,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
                       />
                     </svg>
                     <div
-                      class="c15"
+                      class="c18"
                     >
                       Préavis
                     </div>
@@ -1009,28 +1052,28 @@ exports[`<FicheServicePublic /> should render 1`] = `
                 <div
                   aria-hidden="true"
                   aria-labelledby="accordion__heading-4"
-                  class="c16"
+                  class="c19"
                   data-accordion-component="AccordionItemPanel"
                   hidden=""
                   id="accordion__panel-4"
                 >
                   <div
-                    class="c6"
+                    class="c9"
                   >
                     <h3
-                      class="c17"
+                      class="c20"
                     >
                       Préavis
                     </h3>
                   </div>
                   <div
-                    class="c18"
+                    class="c21"
                   >
                     <p>
                       Vous ne pouvez pas quitter votre travail dès que vous avez signifié votre démission à votre employeur. Vous continuez de travailler jusqu'à la fin de votre contrat de travail, dans le respect du délai de préavis prévu (sauf en cas de dispense du préavis).
                     </p>
                     <h4
-                      class="c17"
+                      class="c20"
                     >
                       Durée
                     </h4>
@@ -1038,73 +1081,81 @@ exports[`<FicheServicePublic /> should render 1`] = `
                       class="c2"
                       data-tabs="true"
                     >
-                      <ul
-                        class="c3"
-                        role="tablist"
+                      <div
+                        class="c3 c4"
                       >
-                        <li
-                          aria-controls="react-tabs-7"
-                          aria-disabled="false"
-                          aria-selected="true"
-                          class="c4 react-tabs__tab--selected"
-                          id="react-tabs-6"
-                          role="tab"
-                          tabindex="0"
+                        <div
+                          class="c5"
                         >
-                          Cas général
-                        </li>
-                        <li
-                          aria-controls="react-tabs-9"
-                          aria-disabled="false"
-                          aria-selected="false"
-                          class="c4"
-                          id="react-tabs-8"
-                          role="tab"
-                        >
-                          Journaliste
-                        </li>
-                        <li
-                          aria-controls="react-tabs-11"
-                          aria-disabled="false"
-                          aria-selected="false"
-                          class="c4"
-                          id="react-tabs-10"
-                          role="tab"
-                        >
-                          VRP
-                        </li>
-                      </ul>
+                          <ul
+                            class="c6"
+                            role="tablist"
+                          >
+                            <li
+                              aria-controls="react-tabs-7"
+                              aria-disabled="false"
+                              aria-selected="true"
+                              class="c7 react-tabs__tab--selected"
+                              id="react-tabs-6"
+                              role="tab"
+                              tabindex="0"
+                            >
+                              Cas général
+                            </li>
+                            <li
+                              aria-controls="react-tabs-9"
+                              aria-disabled="false"
+                              aria-selected="false"
+                              class="c7"
+                              id="react-tabs-8"
+                              role="tab"
+                            >
+                              Journaliste
+                            </li>
+                            <li
+                              aria-controls="react-tabs-11"
+                              aria-disabled="false"
+                              aria-selected="false"
+                              class="c7"
+                              id="react-tabs-10"
+                              role="tab"
+                            >
+                              VRP
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
                       <div
                         aria-labelledby="react-tabs-6"
-                        class="c5 react-tabs__tab-panel--selected"
+                        class="c8 react-tabs__tab-panel--selected"
                         id="react-tabs-7"
                         role="tabpanel"
                       >
                         <div
-                          class="c6"
+                          class="c9"
                         >
                           <h5
-                            class="c17"
+                            class="c20"
                           >
                             Cas général
                           </h5>
                         </div>
                         <div
-                          class="c10"
+                          class="c13"
                         >
                           <p>
                             La durée du préavis de démission est fixée :
                           </p>
                           <ul>
                             <li
-                              class="c20"
+                              class="c23"
                             >
                               <p>
                                 Soit par convention collective ou accord collectif
                               </p>
                             </li>
                             <li
-                              class="c20"
+                              class="c23"
                             >
                               <p>
                                 
@@ -1117,7 +1168,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
                               </p>
                             </li>
                             <li
-                              class="c20"
+                              class="c23"
                             >
                               <p>
                                 Soit par le droit local (en Alsace-Moselle)
@@ -1131,10 +1182,14 @@ exports[`<FicheServicePublic /> should render 1`] = `
                             Si vous travaillez à temps partiel, la durée calendaire du préavis de démission est la même que celle d'un salarié à temps plein.
                           </p>
                           <div
+<<<<<<< HEAD
                             class="sc-AykKH c25"
+=======
+                            class="c31"
+>>>>>>> test(front): update snaps
                           >
                             <h6
-                              class="c17"
+                              class="c20"
                             >
                               À savoir
                             </h6>
@@ -1146,19 +1201,19 @@ exports[`<FicheServicePublic /> should render 1`] = `
                       </div>
                       <div
                         aria-labelledby="react-tabs-8"
-                        class="c5"
+                        class="c8"
                         id="react-tabs-9"
                         role="tabpanel"
                       />
                       <div
                         aria-labelledby="react-tabs-10"
-                        class="c5"
+                        class="c8"
                         id="react-tabs-11"
                         role="tabpanel"
                       />
                     </div>
                     <h4
-                      class="c17"
+                      class="c20"
                     >
                       Dispense de préavis
                     </h4>
@@ -1167,7 +1222,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
                     </p>
                     <ul>
                       <li
-                        class="c20"
+                        class="c23"
                       >
                         <p>
                           
@@ -1177,7 +1232,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
                         </p>
                       </li>
                       <li
-                        class="c20"
+                        class="c23"
                       >
                         <p>
                           
@@ -1194,60 +1249,68 @@ exports[`<FicheServicePublic /> should render 1`] = `
                       class="c2"
                       data-tabs="true"
                     >
-                      <ul
-                        class="c3"
-                        role="tablist"
+                      <div
+                        class="c3 c4"
                       >
-                        <li
-                          aria-controls="react-tabs-13"
-                          aria-disabled="false"
-                          aria-selected="true"
-                          class="c4 react-tabs__tab--selected"
-                          id="react-tabs-12"
-                          role="tab"
-                          tabindex="0"
+                        <div
+                          class="c5"
                         >
-                          Vous demandez une dispense de préavis
-                        </li>
-                        <li
-                          aria-controls="react-tabs-15"
-                          aria-disabled="false"
-                          aria-selected="false"
-                          class="c4"
-                          id="react-tabs-14"
-                          role="tab"
-                        >
-                          Votre employeur vous dispense de préavis
-                        </li>
-                      </ul>
+                          <ul
+                            class="c6"
+                            role="tablist"
+                          >
+                            <li
+                              aria-controls="react-tabs-13"
+                              aria-disabled="false"
+                              aria-selected="true"
+                              class="c7 react-tabs__tab--selected"
+                              id="react-tabs-12"
+                              role="tab"
+                              tabindex="0"
+                            >
+                              Vous demandez une dispense de préavis
+                            </li>
+                            <li
+                              aria-controls="react-tabs-15"
+                              aria-disabled="false"
+                              aria-selected="false"
+                              class="c7"
+                              id="react-tabs-14"
+                              role="tab"
+                            >
+                              Votre employeur vous dispense de préavis
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
                       <div
                         aria-labelledby="react-tabs-12"
-                        class="c5 react-tabs__tab-panel--selected"
+                        class="c8 react-tabs__tab-panel--selected"
                         id="react-tabs-13"
                         role="tabpanel"
                       >
                         <div
-                          class="c6"
+                          class="c9"
                         >
                           <h5
-                            class="c17"
+                            class="c20"
                           >
                             Vous demandez une dispense de préavis
                           </h5>
                         </div>
                         <div
-                          class="c10"
+                          class="c13"
                         >
                           <p>
                             Vous pouvez demander à votre employeur de vous dispenser d'effectuer votre préavis (par écrit ou par oral) :
                           </p>
                           <div
-                            class="c11"
+                            class="c14"
                             data-accordion-component="Accordion"
                           >
                             <div>
                               <div
-                                class="c12"
+                                class="c15"
                                 data-accordion-component="AccordionItem"
                                 index="0"
                               >
@@ -1261,14 +1324,14 @@ exports[`<FicheServicePublic /> should render 1`] = `
                                     aria-controls="accordion__panel-5"
                                     aria-disabled="false"
                                     aria-expanded="false"
-                                    class="c13"
+                                    class="c16"
                                     data-accordion-component="AccordionItemButton"
                                     id="accordion__heading-5"
                                     role="button"
                                     tabindex="0"
                                   >
                                     <svg
-                                      class="c14"
+                                      class="c17"
                                       fill="none"
                                       height="24"
                                       stroke="currentColor"
@@ -1284,7 +1347,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
                                       />
                                     </svg>
                                     <div
-                                      class="c15"
+                                      class="c18"
                                     >
                                       Accord de l'employeur
                                     </div>
@@ -1293,22 +1356,22 @@ exports[`<FicheServicePublic /> should render 1`] = `
                                 <div
                                   aria-hidden="true"
                                   aria-labelledby="accordion__heading-5"
-                                  class="c16"
+                                  class="c19"
                                   data-accordion-component="AccordionItemPanel"
                                   hidden=""
                                   id="accordion__panel-5"
                                 >
                                   <div
-                                    class="c6"
+                                    class="c9"
                                   >
                                     <h6
-                                      class="c17"
+                                      class="c20"
                                     >
                                       Accord de l'employeur
                                     </h6>
                                   </div>
                                   <div
-                                    class="c18"
+                                    class="c21"
                                   >
                                     <p>
                                       
@@ -1325,7 +1388,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
                             </div>
                             <div>
                               <div
-                                class="c19"
+                                class="c22"
                                 data-accordion-component="AccordionItem"
                                 index="1"
                               >
@@ -1339,14 +1402,14 @@ exports[`<FicheServicePublic /> should render 1`] = `
                                     aria-controls="accordion__panel-6"
                                     aria-disabled="false"
                                     aria-expanded="false"
-                                    class="c13"
+                                    class="c16"
                                     data-accordion-component="AccordionItemButton"
                                     id="accordion__heading-6"
                                     role="button"
                                     tabindex="0"
                                   >
                                     <svg
-                                      class="c14"
+                                      class="c17"
                                       fill="none"
                                       height="24"
                                       stroke="currentColor"
@@ -1362,7 +1425,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
                                       />
                                     </svg>
                                     <div
-                                      class="c15"
+                                      class="c18"
                                     >
                                       Refus de l'employeur
                                     </div>
@@ -1371,22 +1434,22 @@ exports[`<FicheServicePublic /> should render 1`] = `
                                 <div
                                   aria-hidden="true"
                                   aria-labelledby="accordion__heading-6"
-                                  class="c16"
+                                  class="c19"
                                   data-accordion-component="AccordionItemPanel"
                                   hidden=""
                                   id="accordion__panel-6"
                                 >
                                   <div
-                                    class="c6"
+                                    class="c9"
                                   >
                                     <h6
-                                      class="c17"
+                                      class="c20"
                                     >
                                       Refus de l'employeur
                                     </h6>
                                   </div>
                                   <div
-                                    class="c18"
+                                    class="c21"
                                   >
                                     <p>
                                       Si votre employeur refuse, vous devez effectuer votre préavis, sous peine de devoir lui verser une indemnité d'un montant égal à la rémunération brute que vous auriez perçue si vous aviez travaillé.
@@ -1400,13 +1463,13 @@ exports[`<FicheServicePublic /> should render 1`] = `
                       </div>
                       <div
                         aria-labelledby="react-tabs-14"
-                        class="c5"
+                        class="c8"
                         id="react-tabs-15"
                         role="tabpanel"
                       />
                     </div>
                     <h4
-                      class="c17"
+                      class="c20"
                     >
                       Report ou suspension du préavis
                     </h4>
@@ -1415,14 +1478,14 @@ exports[`<FicheServicePublic /> should render 1`] = `
                     </p>
                     <ul>
                       <li
-                        class="c20"
+                        class="c23"
                       >
                         <p>
                           Accord entre le salarié et l'employeur
                         </p>
                       </li>
                       <li
-                        class="c20"
+                        class="c23"
                       >
                         <p>
                           
@@ -1435,7 +1498,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
                         </p>
                       </li>
                       <li
-                        class="c20"
+                        class="c23"
                       >
                         <p>
                           Arrêt de travail
@@ -1445,7 +1508,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
                         </p>
                       </li>
                       <li
-                        class="c20"
+                        class="c23"
                       >
                         <p>
                           Dispositions conventionnelles
@@ -1456,7 +1519,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
                       </li>
                     </ul>
                     <h4
-                      class="c17"
+                      class="c20"
                     >
                       Absence pour recherche d'emploi
                     </h4>
@@ -1478,7 +1541,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
             </div>
             <div>
               <div
-                class="c19"
+                class="c22"
                 data-accordion-component="AccordionItem"
                 index="5"
               >
@@ -1492,14 +1555,14 @@ exports[`<FicheServicePublic /> should render 1`] = `
                     aria-controls="accordion__panel-7"
                     aria-disabled="false"
                     aria-expanded="false"
-                    class="c13"
+                    class="c16"
                     data-accordion-component="AccordionItemButton"
                     id="accordion__heading-7"
                     role="button"
                     tabindex="0"
                   >
                     <svg
-                      class="c14"
+                      class="c17"
                       fill="none"
                       height="24"
                       stroke="currentColor"
@@ -1515,7 +1578,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
                       />
                     </svg>
                     <div
-                      class="c15"
+                      class="c18"
                     >
                       Indemnisation
                     </div>
@@ -1524,22 +1587,22 @@ exports[`<FicheServicePublic /> should render 1`] = `
                 <div
                   aria-hidden="true"
                   aria-labelledby="accordion__heading-7"
-                  class="c16"
+                  class="c19"
                   data-accordion-component="AccordionItemPanel"
                   hidden=""
                   id="accordion__panel-7"
                 >
                   <div
-                    class="c6"
+                    class="c9"
                   >
                     <h3
-                      class="c17"
+                      class="c20"
                     >
                       Indemnisation
                     </h3>
                   </div>
                   <div
-                    class="c18"
+                    class="c21"
                   >
                     <p>
                       <strong>
@@ -1607,7 +1670,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
             </div>
             <div>
               <div
-                class="c19"
+                class="c22"
                 data-accordion-component="AccordionItem"
                 index="6"
               >
@@ -1621,14 +1684,14 @@ exports[`<FicheServicePublic /> should render 1`] = `
                     aria-controls="accordion__panel-8"
                     aria-disabled="false"
                     aria-expanded="false"
-                    class="c13"
+                    class="c16"
                     data-accordion-component="AccordionItemButton"
                     id="accordion__heading-8"
                     role="button"
                     tabindex="0"
                   >
                     <svg
-                      class="c14"
+                      class="c17"
                       fill="none"
                       height="24"
                       stroke="currentColor"
@@ -1644,7 +1707,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
                       />
                     </svg>
                     <div
-                      class="c15"
+                      class="c18"
                     >
                       Documents remis au salarié
                     </div>
@@ -1653,50 +1716,50 @@ exports[`<FicheServicePublic /> should render 1`] = `
                 <div
                   aria-hidden="true"
                   aria-labelledby="accordion__heading-8"
-                  class="c16"
+                  class="c19"
                   data-accordion-component="AccordionItemPanel"
                   hidden=""
                   id="accordion__panel-8"
                 >
                   <div
-                    class="c6"
+                    class="c9"
                   >
                     <h3
-                      class="c17"
+                      class="c20"
                     >
                       Documents remis au salarié
                     </h3>
                   </div>
                   <div
-                    class="c18"
+                    class="c21"
                   >
                     <p>
                       L'employeur doit remettre au salarié les documents suivants :
                     </p>
                     <ul>
                       <li
-                        class="c20"
+                        class="c23"
                       >
                         <p>
                           Certificat de travail
                         </p>
                       </li>
                       <li
-                        class="c20"
+                        class="c23"
                       >
                         <p>
                           Attestation Pôle emploi
                         </p>
                       </li>
                       <li
-                        class="c20"
+                        class="c23"
                       >
                         <p>
                           Solde de tout compte
                         </p>
                       </li>
                       <li
-                        class="c20"
+                        class="c23"
                       >
                         <p>
                           En cas de dispositifs de participation, d'intéressement et des plans d'épargne salariale au sein de l'entreprise, état récapitulatif de l'ensemble des sommes et valeurs mobilières épargnées
@@ -1712,39 +1775,48 @@ exports[`<FicheServicePublic /> should render 1`] = `
       </div>
       <div
         aria-labelledby="react-tabs-2"
-        class="c5"
+        class="c8"
         id="react-tabs-3"
         role="tabpanel"
       />
       <div
         aria-labelledby="react-tabs-4"
-        class="c5"
+        class="c8"
         id="react-tabs-5"
         role="tabpanel"
       />
     </div>
-    <div
-      class="c21"
+    <a
+      class="c24 c25 no-after"
+      href="https://www.service-public.fr/simulateur/calcul/Demission"
+      rel="noopener noreferrer"
+      target="_blank"
     >
       <div
-        class="c22"
+        class="c26"
       >
-        Modèle de document
+        <div
+          class="c27"
+        >
+          <span
+            class="c28"
+          >
+            Modèle de document
+          </span>
+          <h3
+            class="c20 c29"
+          >
+            Lettre de démission du salarié
+          </h3>
+        </div>
       </div>
-      <a
-        class="c23 no-after"
-        href="https://www.service-public.fr/simulateur/calcul/Demission"
-        rel="noopener noreferrer"
-        target="_blank"
+      <div
+        class="c30"
       >
-        Lettre de démission du salarié
-      </a>
-      <small
-        class="c24"
-      >
+        Source: 
         Direction de l'information légale et administrative (Premier ministre)
-      </small>
-    </div>
+      </div>
+    </a>
   </div>
 </div>
 `;

--- a/packages/react-fiche-service-public/__tests__/__snapshots__/FicheServicePublic.test.js.snap
+++ b/packages/react-fiche-service-public/__tests__/__snapshots__/FicheServicePublic.test.js.snap
@@ -1182,11 +1182,7 @@ exports[`<FicheServicePublic /> should render 1`] = `
                             Si vous travaillez à temps partiel, la durée calendaire du préavis de démission est la même que celle d'un salarié à temps plein.
                           </p>
                           <div
-<<<<<<< HEAD
-                            class="sc-AykKH c25"
-=======
-                            class="c31"
->>>>>>> test(front): update snaps
+                            class="sc-AykKH c31"
                           >
                             <h6
                               class="c20"

--- a/packages/react-fiche-service-public/src/components/ServiceEnLigne.js
+++ b/packages/react-fiche-service-public/src/components/ServiceEnLigne.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { Button, theme } from "@socialgouv/react-ui";
+import { theme, Tile } from "@socialgouv/react-ui";
 
 import { getText } from "../utils";
 
@@ -16,52 +16,25 @@ class ServiceEnLigne extends React.PureComponent {
     const title = getText(data.children[0]);
     const source = getText(data.children[1]);
     return (
-      <Wrapper>
-        <Type>{type}</Type>
-        <Button
-          as="a"
-          href={url}
-          rel="noopener noreferrer"
-          target="_blank"
-          className="no-after"
-        >
-          {title}
-        </Button>
-        <Source>{source}</Source>
-      </Wrapper>
+      <StyledTile
+        wide
+        href={url}
+        rel="noopener noreferrer"
+        target="_blank"
+        className="no-after"
+        subtitle={type}
+        title={title}
+      >
+        Source: {source}
+      </StyledTile>
     );
   }
 }
 
 export default ServiceEnLigne;
 
-const { breakpoints, colors, fonts, spacings, box } = theme;
+const { spacings } = theme;
 
-const Wrapper = styled.div`
-  display: flex;
-  flex-flow: column;
-  align-items: center;
+const StyledTile = styled(Tile)`
   margin-bottom: ${spacings.base};
-  padding: ${spacings.large};
-  background-color: ${colors.bgTertiary};
-  border-radius: ${box.borderRadius};
-  @media (max-width: ${breakpoints.mobile}) {
-    padding: ${spacings.small} ${spacings.medium};
-  }
-`;
-
-const Type = styled.div`
-  align-self: flex-start;
-  margin-bottom: ${spacings.tiny};
-  color: ${colors.paragraph};
-  font-weight: bold;
-  font-size: ${fonts.sizes.headings.small};
-  @media (max-width: ${breakpoints.mobile}) {
-    font-size: ${fonts.sizes.default};
-  }
-`;
-
-const Source = styled.small`
-  display: inline-block;
-  margin-top: ${spacings.tiny};
 `;

--- a/packages/react-fiche-service-public/src/components/__tests__/__snapshots__/ServiceEnLigne.test.js.snap
+++ b/packages/react-fiche-service-public/src/components/__tests__/__snapshots__/ServiceEnLigne.test.js.snap
@@ -1,148 +1,147 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ServiceEnLigne /> should render 1`] = `
-.c2 {
+.c5 {
+  position: relative;
+  margin: 3.2rem 0 2rem 0;
+  color: #2f3b6c;
+  font-weight: 600;
+  font-size: 1.8rem;
+  font-family: "Open Sans",sans-serif;
+  line-height: 1.25;
+}
+
+.c4 {
+  display: block;
+  margin: 0 0 1rem 0;
+  color: #4d73b8;
+  font-weight: 600;
+  font-size: 1.2rem;
+  font-family: "Open Sans",sans-serif;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+
+.c0 {
+  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: content-box;
-  font-weight: 500;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  width: 100%;
+  margin: 0;
+  padding: 2rem 2rem;
+  color: #3e486e;
+  font-weight: normal;
   font-size: 1.6rem;
-  line-height: 1.125em;
-  text-align: center;
-  vertical-align: middle;
-  border: 1px solid;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: #fff;
+  border: none;
   border-radius: 0.6rem;
+  box-shadow: 0 1rem 2rem rgba(121,148,212,0.2);
   cursor: pointer;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,-webkit-transform 100ms linear;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
+  -webkit-transition: box-shadow 250ms linear, -webkit-transform 100ms linear;
+  -webkit-transition: box-shadow 250ms linear, transform 100ms linear;
+  transition: box-shadow 250ms linear, transform 100ms linear;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  height: 5.2rem;
-  padding: 0 4.4rem;
-  color: #fff;
-  background: #7994d4;
-  border-color: #7994d4;
-  box-shadow: 0px 10px 20px rgba(121,148,212,0.26),0px 5px 7px rgba(121,148,212,0.35);
-  opacity: 1;
 }
 
-.c2:link,
-.c2:visited {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #fff;
-}
-
-.c2:not([disabled]):hover,
-.c2:not([disabled]):active,
-.c2:not([disabled]):focus {
-  opacity: 1;
+.c0:hover,
+.c0:active,
+.c0:focus {
+  color: #3e486e;
+  box-shadow: 0 1rem 2rem rgba(121,148,212,0.4);
   -webkit-transform: translateY(-2px);
   -ms-transform: translateY(-2px);
   transform: translateY(-2px);
-  background: #a0b3e0;
-  border-color: #a0b3e0;
 }
 
-.c2[disabled] {
-  background-color: #e4e8ef;
-  border-color: #e4e8ef;
-  color: #9298af;
-  box-shadow: none;
-  cursor: not-allowed;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: column;
-  -ms-flex-flow: column;
-  flex-flow: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-bottom: 1.6rem;
-  padding: 3.2rem;
-  background-color: #e4e8ef;
-  border-radius: 0.6rem;
-}
-
-.c1 {
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: start;
-  align-self: flex-start;
-  margin-bottom: 0.4rem;
-  color: #3e486e;
-  font-weight: bold;
-  font-size: 1.8rem;
+.c2 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c3 {
-  display: inline-block;
-  margin-top: 0.4rem;
+  padding-right: 1rem;
+}
+
+.c6 {
+  margin: 0;
+}
+
+.c7 {
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 1rem;
+}
+
+.c1 {
+  margin-bottom: 1.6rem;
 }
 
 @media (max-width:600px) {
-  .c2 {
-    font-size: 1.4rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c2 {
-    padding: 0 3rem;
+  .c5 {
+    font-size: 1.6rem;
   }
 }
 
 @media (max-width:600px) {
   .c0 {
-    padding: 1rem 2rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c1 {
-    font-size: 1.6rem;
+    padding: 1.6rem 1.6rem;
+    font-size: 1.4rem;
   }
 }
 
 <div>
-  <div
-    class="c0"
+  <a
+    class="c0 c1 no-after"
+    href="url à retoruver dans le lien"
+    rel="noopener noreferrer"
+    target="_blank"
   >
     <div
-      class="c1"
+      class="c2"
     >
-      Se retrouve dans en entête
+      <div
+        class="c3"
+      >
+        <span
+          class="c4"
+        >
+          Se retrouve dans en entête
+        </span>
+        <h3
+          class="c5 c6"
+        >
+          Texte qui se retrouve dans le lien
+        </h3>
+      </div>
     </div>
-    <a
-      class="c2 no-after"
-      href="url à retoruver dans le lien"
-      rel="noopener noreferrer"
-      target="_blank"
+    <div
+      class="c7"
     >
-      Texte qui se retrouve dans le lien
-    </a>
-    <small
-      class="c3"
-    >
+      Source: 
       Source qui se retrouve sous le lien
-    </small>
-  </div>
+    </div>
+  </a>
 </div>
 `;

--- a/packages/react-fiche-service-public/src/components/__tests__/__snapshots__/ServiceEnLigne.test.js.snap
+++ b/packages/react-fiche-service-public/src/components/__tests__/__snapshots__/ServiceEnLigne.test.js.snap
@@ -8,7 +8,7 @@ exports[`<ServiceEnLigne /> should render 1`] = `
   font-weight: 600;
   font-size: 1.8rem;
   font-family: "Open Sans",sans-serif;
-  line-height: 1.25;
+  line-height: 1.625;
 }
 
 .c4 {

--- a/packages/react-fiche-service-public/src/components/__tests__/__snapshots__/Tabulator.test.js.snap
+++ b/packages/react-fiche-service-public/src/components/__tests__/__snapshots__/Tabulator.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Tabulator /> should have two different levels of headings 1`] = `
-.c4:not(:focus):not(:active) {
+.c7:not(:focus):not(:active) {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -13,7 +13,40 @@ exports[`<Tabulator /> should have two different levels of headings 1`] = `
   clip: rect(0,0,0,0);
 }
 
-.c7 {
+.c1 {
+  position: relative;
+  overflow: hidden;
+}
+
+.c1:before,
+.c1:after {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 1;
+  display: block;
+  width: 4rem;
+  opacity: 0;
+  -webkit-transition: opacity 0.3s linear;
+  transition: opacity 0.3s linear;
+  content: "";
+  pointer-events: none;
+  background: radial-gradient( ellipse at center, #fff 15%, rgba(255,255,255,0) 80% );
+}
+
+.c1:before {
+  left: -2rem;
+}
+
+.c1:after {
+  right: -2rem;
+}
+
+.c3 {
+  overflow-x: auto;
+}
+
+.c10 {
   position: absolute;
   background-color: #7994d4;
   border-radius: 0.6rem;
@@ -30,9 +63,11 @@ exports[`<Tabulator /> should have two different levels of headings 1`] = `
   margin-bottom: 3.2rem;
 }
 
-.c1 {
-  position: relative;
-  top: 1px;
+.c2 {
+  margin-right: 0.4rem;
+}
+
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -42,12 +77,16 @@ exports[`<Tabulator /> should have two different levels of headings 1`] = `
   flex-wrap: nowrap;
   max-width: 100%;
   margin: 0;
-  padding: 0 0.4rem 0 0;
+  padding: 0 0 0 0;
   overflow: visible;
   list-style-type: none;
 }
 
-.c2 {
+.c5 {
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  max-height: 11rem;
   margin-left: 0.4rem;
   padding: 1rem 1.6rem;
   color: #4d73b8;
@@ -55,7 +94,7 @@ exports[`<Tabulator /> should have two different levels of headings 1`] = `
   font-size: 1.8rem;
   background-color: #fff;
   border: 1px solid #bbcadf;
-  border-bottom: 1px solid #bbcadf;
+  border-bottom: 1px solid transparent;
   border-radius: 0.6rem 0.6rem 0 0;
   cursor: pointer;
   opacity: 1;
@@ -63,35 +102,35 @@ exports[`<Tabulator /> should have two different levels of headings 1`] = `
   transition: opacity 250ms linear;
 }
 
-.c2[aria-selected="false"]:hover {
+.c5[aria-selected="false"]:hover {
   opacity: 0.7;
 }
 
-.c2[aria-selected="true"] {
+.c5[aria-selected="true"] {
   color: #fff;
   background-color: #7994d4;
 }
 
-.c3 {
+.c6 {
   color: #3e486e;
   background-color: #fff;
 }
 
-.c3.react-tabs__tab-panel--selected {
+.c6.react-tabs__tab-panel--selected {
   padding: 2.4rem;
   border: 1px solid #bbcadf;
   border-radius: 0.6rem;
 }
 
-.c8 > *:first-child {
+.c11 > *:first-child {
   margin-top: 0;
 }
 
-.c8 > *:last-child {
+.c11 > *:last-child {
   margin-bottom: 0;
 }
 
-.c9 {
+.c12 {
   position: relative;
   margin: 3.2rem 0 2rem 0;
   color: #2f3b6c;
@@ -101,14 +140,14 @@ exports[`<Tabulator /> should have two different levels of headings 1`] = `
   line-height: 1.625;
 }
 
-.c5 {
+.c8 {
   margin-top: 3.2rem;
   margin-bottom: 2rem;
   margin-left: auto;
   text-align: left;
 }
 
-.c6 {
+.c9 {
   position: relative;
   margin: 0;
   color: #2f3b6c;
@@ -121,25 +160,38 @@ exports[`<Tabulator /> should have two different levels of headings 1`] = `
 }
 
 @media (max-width:600px) {
+  .c1 {
+    overflow-x: hidden;
+  }
+}
+
+@media (max-width:600px) {
+  .c1:before,
+  .c1:after {
+    display: block;
+  }
+}
+
+@media (max-width:600px) {
+  .c3 {
+    overflow-x: auto;
+  }
+}
+
+@media (max-width:600px) {
   .c0 {
     margin-bottom: 2rem;
   }
 }
 
 @media (max-width:980px) {
-  .c1 {
-    -webkit-flex-wrap: wrap;
-    -ms-flex-wrap: wrap;
-    flex-wrap: wrap;
+  .c4 {
     padding: 0;
   }
 }
 
 @media (max-width:980px) {
-  .c2 {
-    -webkit-flex: 1 1 auto;
-    -ms-flex: 1 1 auto;
-    flex: 1 1 auto;
+  .c5 {
     margin: 0.4rem;
     border-bottom: 1px solid #bbcadf;
     border-radius: 0.6rem;
@@ -147,44 +199,44 @@ exports[`<Tabulator /> should have two different levels of headings 1`] = `
 }
 
 @media (max-width:600px) {
-  .c2 {
+  .c5 {
     font-size: 1.6rem;
   }
 }
 
 @media (max-width:980px) {
-  .c3.react-tabs__tab-panel--selected {
+  .c6.react-tabs__tab-panel--selected {
     margin-top: 0.4rem;
   }
 }
 
 @media (max-width:600px) {
-  .c3.react-tabs__tab-panel--selected {
+  .c6.react-tabs__tab-panel--selected {
     padding: 1rem;
   }
 }
 
 @media (max-width:600px) {
-  .c9 {
+  .c12 {
     font-size: 1.6rem;
   }
 }
 
 @media (max-width:600px) {
-  .c5 {
+  .c8 {
     margin-bottom: 1rem;
     margin-left: auto;
   }
 }
 
 @media (max-width:600px) {
-  .c6 {
+  .c9 {
     padding-left: 1.6rem;
   }
 }
 
 @media (max-width:600px) {
-  .c6 {
+  .c9 {
     font-size: 2.2rem;
   }
 }
@@ -194,59 +246,67 @@ exports[`<Tabulator /> should have two different levels of headings 1`] = `
     class="c0"
     data-tabs="true"
   >
-    <ul
-      class="c1"
-      role="tablist"
+    <div
+      class="c1 c2"
     >
-      <li
-        aria-controls="react-tabs-1"
-        aria-disabled="false"
-        aria-selected="true"
-        class="c2 react-tabs__tab--selected"
-        id="react-tabs-0"
-        role="tab"
-        tabindex="0"
+      <div
+        class="c3"
       >
-        CDI
-      </li>
-      <li
-        aria-controls="react-tabs-3"
-        aria-disabled="false"
-        aria-selected="false"
-        class="c2"
-        id="react-tabs-2"
-        role="tab"
-      >
-        CDD
-      </li>
-    </ul>
+        <ul
+          class="c4"
+          role="tablist"
+        >
+          <li
+            aria-controls="react-tabs-1"
+            aria-disabled="false"
+            aria-selected="true"
+            class="c5 react-tabs__tab--selected"
+            id="react-tabs-0"
+            role="tab"
+            tabindex="0"
+          >
+            CDI
+          </li>
+          <li
+            aria-controls="react-tabs-3"
+            aria-disabled="false"
+            aria-selected="false"
+            class="c5"
+            id="react-tabs-2"
+            role="tab"
+          >
+            CDD
+          </li>
+        </ul>
+      </div>
+    </div>
     <div
       aria-labelledby="react-tabs-0"
-      class="c3 react-tabs__tab-panel--selected"
+      class="c6 react-tabs__tab-panel--selected"
       id="react-tabs-1"
       role="tabpanel"
     >
       <div
-        class="c4"
+        class="c7"
       >
         <header
-          class="c5"
+          class="c8"
         >
           <h2
-            class="c6"
+            class="c9"
           >
             <div
-              class="c7"
+              class="c10"
             />
             CDI
           </h2>
         </header>
       </div>
       <div
-        class="c8"
+        class="c11"
       >
         <h3
-          class="c9"
+          class="c12"
         >
           titre 1
         </h3>
@@ -257,7 +317,7 @@ exports[`<Tabulator /> should have two different levels of headings 1`] = `
     </div>
     <div
       aria-labelledby="react-tabs-2"
-      class="c3"
+      class="c6"
       id="react-tabs-3"
       role="tabpanel"
     />
@@ -266,7 +326,7 @@ exports[`<Tabulator /> should have two different levels of headings 1`] = `
 `;
 
 exports[`<Tabulator /> should incease heading levels if not 0 1`] = `
-.c4:not(:focus):not(:active) {
+.c7:not(:focus):not(:active) {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -278,13 +338,48 @@ exports[`<Tabulator /> should incease heading levels if not 0 1`] = `
   clip: rect(0,0,0,0);
 }
 
+.c1 {
+  position: relative;
+  overflow: hidden;
+}
+
+.c1:before,
+.c1:after {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 1;
+  display: block;
+  width: 4rem;
+  opacity: 0;
+  -webkit-transition: opacity 0.3s linear;
+  transition: opacity 0.3s linear;
+  content: "";
+  pointer-events: none;
+  background: radial-gradient( ellipse at center, #fff 15%, rgba(255,255,255,0) 80% );
+}
+
+.c1:before {
+  left: -2rem;
+}
+
+.c1:after {
+  right: -2rem;
+}
+
+.c3 {
+  overflow-x: auto;
+}
+
 .c0 {
   margin-bottom: 3.2rem;
 }
 
-.c1 {
-  position: relative;
-  top: 1px;
+.c2 {
+  margin-right: 0.4rem;
+}
+
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -294,12 +389,16 @@ exports[`<Tabulator /> should incease heading levels if not 0 1`] = `
   flex-wrap: nowrap;
   max-width: 100%;
   margin: 0;
-  padding: 0 0.4rem 0 0;
+  padding: 0 0 0 0;
   overflow: visible;
   list-style-type: none;
 }
 
-.c2 {
+.c5 {
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  max-height: 11rem;
   margin-left: 0.4rem;
   padding: 1rem 1.6rem;
   color: #4d73b8;
@@ -307,7 +406,7 @@ exports[`<Tabulator /> should incease heading levels if not 0 1`] = `
   font-size: 1.8rem;
   background-color: #fff;
   border: 1px solid #bbcadf;
-  border-bottom: 1px solid #bbcadf;
+  border-bottom: 1px solid transparent;
   border-radius: 0.6rem 0.6rem 0 0;
   cursor: pointer;
   opacity: 1;
@@ -315,35 +414,35 @@ exports[`<Tabulator /> should incease heading levels if not 0 1`] = `
   transition: opacity 250ms linear;
 }
 
-.c2[aria-selected="false"]:hover {
+.c5[aria-selected="false"]:hover {
   opacity: 0.7;
 }
 
-.c2[aria-selected="true"] {
+.c5[aria-selected="true"] {
   color: #fff;
   background-color: #7994d4;
 }
 
-.c3 {
+.c6 {
   color: #3e486e;
   background-color: #fff;
 }
 
-.c3.react-tabs__tab-panel--selected {
+.c6.react-tabs__tab-panel--selected {
   padding: 2.4rem;
   border: 1px solid #bbcadf;
   border-radius: 0.6rem;
 }
 
-.c6 > *:first-child {
+.c9 > *:first-child {
   margin-top: 0;
 }
 
-.c6 > *:last-child {
+.c9 > *:last-child {
   margin-bottom: 0;
 }
 
-.c5 {
+.c8 {
   position: relative;
   margin: 3.2rem 0 2rem 0;
   color: #2f3b6c;
@@ -354,46 +453,41 @@ exports[`<Tabulator /> should incease heading levels if not 0 1`] = `
 }
 
 @media (max-width:600px) {
+  .c1 {
+    overflow-x: hidden;
+  }
+}
+
+@media (max-width:600px) {
+  .c1:before,
+  .c1:after {
+    display: block;
+  }
+}
+
+@media (max-width:600px) {
+  .c3 {
+    overflow-x: auto;
+  }
+}
+
+@media (max-width:600px) {
   .c0 {
     margin-bottom: 2rem;
   }
 }
 
 @media (max-width:980px) {
-  .c1 {
-    -webkit-flex-wrap: wrap;
-    -ms-flex-wrap: wrap;
-    flex-wrap: wrap;
+  .c4 {
     padding: 0;
   }
 }
 
 @media (max-width:980px) {
-  .c2 {
-    -webkit-flex: 1 1 auto;
-    -ms-flex: 1 1 auto;
-    flex: 1 1 auto;
+  .c5 {
     margin: 0.4rem;
     border-bottom: 1px solid #bbcadf;
     border-radius: 0.6rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c2 {
-    font-size: 1.6rem;
-  }
-}
-
-@media (max-width:980px) {
-  .c3.react-tabs__tab-panel--selected {
-    margin-top: 0.4rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c3.react-tabs__tab-panel--selected {
-    padding: 1rem;
   }
 }
 
@@ -403,57 +497,83 @@ exports[`<Tabulator /> should incease heading levels if not 0 1`] = `
   }
 }
 
+@media (max-width:980px) {
+  .c6.react-tabs__tab-panel--selected {
+    margin-top: 0.4rem;
+  }
+}
+
+@media (max-width:600px) {
+  .c6.react-tabs__tab-panel--selected {
+    padding: 1rem;
+  }
+}
+
+@media (max-width:600px) {
+  .c8 {
+    font-size: 1.6rem;
+  }
+}
+
 <div>
   <div
     class="c0"
     data-tabs="true"
   >
-    <ul
-      class="c1"
-      role="tablist"
+    <div
+      class="c1 c2"
     >
-      <li
-        aria-controls="react-tabs-5"
-        aria-disabled="false"
-        aria-selected="true"
-        class="c2 react-tabs__tab--selected"
-        id="react-tabs-4"
-        role="tab"
-        tabindex="0"
+      <div
+        class="c3"
       >
-        CDI
-      </li>
-      <li
-        aria-controls="react-tabs-7"
-        aria-disabled="false"
-        aria-selected="false"
-        class="c2"
-        id="react-tabs-6"
-        role="tab"
-      >
-        CDD
-      </li>
-    </ul>
+        <ul
+          class="c4"
+          role="tablist"
+        >
+          <li
+            aria-controls="react-tabs-5"
+            aria-disabled="false"
+            aria-selected="true"
+            class="c5 react-tabs__tab--selected"
+            id="react-tabs-4"
+            role="tab"
+            tabindex="0"
+          >
+            CDI
+          </li>
+          <li
+            aria-controls="react-tabs-7"
+            aria-disabled="false"
+            aria-selected="false"
+            class="c5"
+            id="react-tabs-6"
+            role="tab"
+          >
+            CDD
+          </li>
+        </ul>
+      </div>
+    </div>
     <div
       aria-labelledby="react-tabs-4"
-      class="c3 react-tabs__tab-panel--selected"
+      class="c6 react-tabs__tab-panel--selected"
       id="react-tabs-5"
       role="tabpanel"
     >
       <div
-        class="c4"
+        class="c7"
       >
         <h4
-          class="c5"
+          class="c8"
         >
           CDI
         </h4>
       </div>
       <div
-        class="c6"
+        class="c9"
       >
         <h5
-          class="c5"
+          class="c8"
         >
           titre 1
         </h5>
@@ -464,7 +584,7 @@ exports[`<Tabulator /> should incease heading levels if not 0 1`] = `
     </div>
     <div
       aria-labelledby="react-tabs-6"
-      class="c3"
+      class="c6"
       id="react-tabs-7"
       role="tabpanel"
     />
@@ -473,7 +593,7 @@ exports[`<Tabulator /> should incease heading levels if not 0 1`] = `
 `;
 
 exports[`<Tabulator /> should render 1`] = `
-.c4:not(:focus):not(:active) {
+.c7:not(:focus):not(:active) {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -485,13 +605,48 @@ exports[`<Tabulator /> should render 1`] = `
   clip: rect(0,0,0,0);
 }
 
+.c1 {
+  position: relative;
+  overflow: hidden;
+}
+
+.c1:before,
+.c1:after {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 1;
+  display: block;
+  width: 4rem;
+  opacity: 0;
+  -webkit-transition: opacity 0.3s linear;
+  transition: opacity 0.3s linear;
+  content: "";
+  pointer-events: none;
+  background: radial-gradient( ellipse at center, #fff 15%, rgba(255,255,255,0) 80% );
+}
+
+.c1:before {
+  left: -2rem;
+}
+
+.c1:after {
+  right: -2rem;
+}
+
+.c3 {
+  overflow-x: auto;
+}
+
 .c0 {
   margin-bottom: 3.2rem;
 }
 
-.c1 {
-  position: relative;
-  top: 1px;
+.c2 {
+  margin-right: 0.4rem;
+}
+
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -501,12 +656,16 @@ exports[`<Tabulator /> should render 1`] = `
   flex-wrap: nowrap;
   max-width: 100%;
   margin: 0;
-  padding: 0 0.4rem 0 0;
+  padding: 0 0 0 0;
   overflow: visible;
   list-style-type: none;
 }
 
-.c2 {
+.c5 {
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  max-height: 11rem;
   margin-left: 0.4rem;
   padding: 1rem 1.6rem;
   color: #4d73b8;
@@ -514,7 +673,7 @@ exports[`<Tabulator /> should render 1`] = `
   font-size: 1.8rem;
   background-color: #fff;
   border: 1px solid #bbcadf;
-  border-bottom: 1px solid #bbcadf;
+  border-bottom: 1px solid transparent;
   border-radius: 0.6rem 0.6rem 0 0;
   cursor: pointer;
   opacity: 1;
@@ -522,35 +681,35 @@ exports[`<Tabulator /> should render 1`] = `
   transition: opacity 250ms linear;
 }
 
-.c2[aria-selected="false"]:hover {
+.c5[aria-selected="false"]:hover {
   opacity: 0.7;
 }
 
-.c2[aria-selected="true"] {
+.c5[aria-selected="true"] {
   color: #fff;
   background-color: #7994d4;
 }
 
-.c3 {
+.c6 {
   color: #3e486e;
   background-color: #fff;
 }
 
-.c3.react-tabs__tab-panel--selected {
+.c6.react-tabs__tab-panel--selected {
   padding: 2.4rem;
   border: 1px solid #bbcadf;
   border-radius: 0.6rem;
 }
 
-.c6 > *:first-child {
+.c9 > *:first-child {
   margin-top: 0;
 }
 
-.c6 > *:last-child {
+.c9 > *:last-child {
   margin-bottom: 0;
 }
 
-.c5 {
+.c8 {
   position: relative;
   margin: 3.2rem 0 2rem 0;
   color: #2f3b6c;
@@ -561,46 +720,41 @@ exports[`<Tabulator /> should render 1`] = `
 }
 
 @media (max-width:600px) {
+  .c1 {
+    overflow-x: hidden;
+  }
+}
+
+@media (max-width:600px) {
+  .c1:before,
+  .c1:after {
+    display: block;
+  }
+}
+
+@media (max-width:600px) {
+  .c3 {
+    overflow-x: auto;
+  }
+}
+
+@media (max-width:600px) {
   .c0 {
     margin-bottom: 2rem;
   }
 }
 
 @media (max-width:980px) {
-  .c1 {
-    -webkit-flex-wrap: wrap;
-    -ms-flex-wrap: wrap;
-    flex-wrap: wrap;
+  .c4 {
     padding: 0;
   }
 }
 
 @media (max-width:980px) {
-  .c2 {
-    -webkit-flex: 1 1 auto;
-    -ms-flex: 1 1 auto;
-    flex: 1 1 auto;
+  .c5 {
     margin: 0.4rem;
     border-bottom: 1px solid #bbcadf;
     border-radius: 0.6rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c2 {
-    font-size: 1.6rem;
-  }
-}
-
-@media (max-width:980px) {
-  .c3.react-tabs__tab-panel--selected {
-    margin-top: 0.4rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c3.react-tabs__tab-panel--selected {
-    padding: 1rem;
   }
 }
 
@@ -610,57 +764,83 @@ exports[`<Tabulator /> should render 1`] = `
   }
 }
 
+@media (max-width:980px) {
+  .c6.react-tabs__tab-panel--selected {
+    margin-top: 0.4rem;
+  }
+}
+
+@media (max-width:600px) {
+  .c6.react-tabs__tab-panel--selected {
+    padding: 1rem;
+  }
+}
+
+@media (max-width:600px) {
+  .c8 {
+    font-size: 1.6rem;
+  }
+}
+
 <div>
   <div
     class="c0"
     data-tabs="true"
   >
-    <ul
-      class="c1"
-      role="tablist"
+    <div
+      class="c1 c2"
     >
-      <li
-        aria-controls="react-tabs-9"
-        aria-disabled="false"
-        aria-selected="true"
-        class="c2 react-tabs__tab--selected"
-        id="react-tabs-8"
-        role="tab"
-        tabindex="0"
+      <div
+        class="c3"
       >
-        CDI
-      </li>
-      <li
-        aria-controls="react-tabs-11"
-        aria-disabled="false"
-        aria-selected="false"
-        class="c2"
-        id="react-tabs-10"
-        role="tab"
-      >
-        CDD
-      </li>
-    </ul>
+        <ul
+          class="c4"
+          role="tablist"
+        >
+          <li
+            aria-controls="react-tabs-9"
+            aria-disabled="false"
+            aria-selected="true"
+            class="c5 react-tabs__tab--selected"
+            id="react-tabs-8"
+            role="tab"
+            tabindex="0"
+          >
+            CDI
+          </li>
+          <li
+            aria-controls="react-tabs-11"
+            aria-disabled="false"
+            aria-selected="false"
+            class="c5"
+            id="react-tabs-10"
+            role="tab"
+          >
+            CDD
+          </li>
+        </ul>
+      </div>
+    </div>
     <div
       aria-labelledby="react-tabs-8"
-      class="c3 react-tabs__tab-panel--selected"
+      class="c6 react-tabs__tab-panel--selected"
       id="react-tabs-9"
       role="tabpanel"
     >
       <div
-        class="c4"
+        class="c7"
       >
         <h5
-          class="c5"
+          class="c8"
         >
           CDI
         </h5>
       </div>
       <div
-        class="c6"
+        class="c9"
       >
         <h6
-          class="c5"
+          class="c8"
         >
           titre 1
         </h6>
@@ -671,7 +851,7 @@ exports[`<Tabulator /> should render 1`] = `
     </div>
     <div
       aria-labelledby="react-tabs-10"
-      class="c3"
+      class="c6"
       id="react-tabs-11"
       role="tabpanel"
     />

--- a/packages/react-ui/src/Grid/Grid.js
+++ b/packages/react-ui/src/Grid/Grid.js
@@ -1,27 +1,25 @@
 import React from "react";
 import PropTypes from "prop-types";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 import { OverflowWrapper } from "../OverflowWrapper";
 import { breakpoints, spacings } from "../theme";
 
 export const GridContext = React.createContext({ columns: 4 });
 
-export const Grid = ({ columns, singleLined, ...props }) => {
+export const Grid = ({ columns, ...props }) => {
   return (
-    <StyledOverflowWrapper mobileOnly={!singleLined}>
+    <StyledOverflowWrapper mobileOnly>
       <GridContext.Provider value={columns}>
-        <List singleLined={singleLined} {...props} />
+        <List {...props} />
       </GridContext.Provider>
     </StyledOverflowWrapper>
   );
 };
 Grid.propTypes = {
-  columns: PropTypes.number,
-  singleLined: PropTypes.bool
+  columns: PropTypes.number
 };
 Grid.defaultProps = {
-  columns: 4,
-  singleLined: false
+  columns: 4
 };
 
 export const StyledOverflowWrapper = styled(OverflowWrapper)`
@@ -50,11 +48,4 @@ export const List = styled.ul`
     margin-bottom: ${spacings.medium};
     margin-left: 0;
   }
-  ${({ singleLined }) =>
-    singleLined &&
-    css`
-      margin-right: 0;
-      margin-left: 0;
-      flex-wrap: nowrap;
-    `}
 `;

--- a/packages/react-ui/src/Grid/Grid.js
+++ b/packages/react-ui/src/Grid/Grid.js
@@ -1,25 +1,27 @@
 import React from "react";
 import PropTypes from "prop-types";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { OverflowWrapper } from "../OverflowWrapper";
 import { breakpoints, spacings } from "../theme";
 
 export const GridContext = React.createContext({ columns: 4 });
 
-export const Grid = ({ columns, ...props }) => {
+export const Grid = ({ columns, singleLined, ...props }) => {
   return (
-    <StyledOverflowWrapper mobileOnly>
+    <StyledOverflowWrapper mobileOnly={!singleLined}>
       <GridContext.Provider value={columns}>
-        <List {...props} />
+        <List singleLined={singleLined} {...props} />
       </GridContext.Provider>
     </StyledOverflowWrapper>
   );
 };
 Grid.propTypes = {
-  columns: PropTypes.number
+  columns: PropTypes.number,
+  singleLined: PropTypes.bool
 };
 Grid.defaultProps = {
-  columns: 4
+  columns: 4,
+  singleLined: false
 };
 
 export const StyledOverflowWrapper = styled(OverflowWrapper)`
@@ -48,4 +50,11 @@ export const List = styled.ul`
     margin-bottom: ${spacings.medium};
     margin-left: 0;
   }
+  ${({ singleLined }) =>
+    singleLined &&
+    css`
+      margin-right: 0;
+      margin-left: 0;
+      flex-wrap: nowrap;
+    `}
 `;

--- a/packages/react-ui/src/Grid/GridCell.js
+++ b/packages/react-ui/src/Grid/GridCell.js
@@ -1,5 +1,5 @@
 import React, { useContext } from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { breakpoints, spacings } from "../theme";
 
 import { GridContext } from "./Grid";
@@ -14,35 +14,51 @@ export const GridCell = props => {
 export const ListItem = styled.li`
   display: flex;
   flex-grow: 0;
-  flex-shrink: 1;
-  width: calc(100% / ${props => props.columns} - 2 * ${spacings.small} - 1px);
   margin: ${spacings.small};
   padding: 0;
-  @media (max-width: ${breakpoints.desktop}) {
-    width: calc(
-      100% / ${props => Math.max(props.columns - 1, 0)} - 2 * ${spacings.small} -
-        1px
-    );
-  }
-  @media (max-width: ${breakpoints.tablet}) {
-    width: calc(
-      100% / ${props => Math.max(props.columns - 2, 0)} - 2 * ${spacings.small} -
-        1px
-    );
-  }
-  @media (max-width: ${breakpoints.mobile}) {
-    flex-shrink: 0;
-    width: ${({ columns }) => (Math.max(columns - 2, 0) < 2 ? "80%" : "60%")};
-    min-width: 23rem;
-    &:first-of-type {
-      margin-left: ${spacings.medium};
-    }
-    &:last-of-type:after {
-      display: block;
-      width: ${spacings.medium};
-      height: 100%;
-      background-color: transparent;
-      content: "";
-    }
-  }
+  ${({ columns, singleLined }) =>
+    singleLined
+      ? css`
+          flex-shrink: 0;
+          margin-bottom: 0;
+          &:first-of-type {
+            margin-left: ${spacings.medium};
+          }
+          &:last-of-type:after {
+            display: block;
+            width: ${spacings.medium};
+            height: 100%;
+            background-color: transparent;
+            content: "";
+          }
+        `
+      : css`
+          width: calc(100% / ${columns} - 2 * ${spacings.small} - 1px);
+          flex-shrink: 1;
+          @media (max-width: ${breakpoints.desktop}) {
+            width: calc(
+              100% / ${Math.max(columns - 1, 0)} - 2 * ${spacings.small} - 1px
+            );
+          }
+          @media (max-width: ${breakpoints.tablet}) {
+            width: calc(
+              100% / ${Math.max(columns - 2, 0)} - 2 * ${spacings.small} - 1px
+            );
+          }
+          @media (max-width: ${breakpoints.mobile}) {
+            flex-shrink: 0;
+            width: ${Math.max(columns - 2, 0) < 2 ? "80%" : "60%"};
+            min-width: 23rem;
+            &:first-of-type {
+              margin-left: ${spacings.medium};
+            }
+            &:last-of-type:after {
+              display: block;
+              width: ${spacings.medium};
+              height: 100%;
+              background-color: transparent;
+              content: "";
+            }
+          }
+        `}
 `;

--- a/packages/react-ui/src/Grid/GridCell.js
+++ b/packages/react-ui/src/Grid/GridCell.js
@@ -14,51 +14,37 @@ export const GridCell = props => {
 export const ListItem = styled.li`
   display: flex;
   flex-grow: 0;
+  flex-shrink: 1;
   margin: ${spacings.small};
   padding: 0;
-  ${({ columns, singleLined }) =>
-    singleLined
-      ? css`
-          flex-shrink: 0;
-          margin-bottom: 0;
-          &:first-of-type {
-            margin-left: ${spacings.medium};
-          }
-          &:last-of-type:after {
-            display: block;
-            width: ${spacings.medium};
-            height: 100%;
-            background-color: transparent;
-            content: "";
-          }
-        `
-      : css`
-          width: calc(100% / ${columns} - 2 * ${spacings.small} - 1px);
-          flex-shrink: 1;
-          @media (max-width: ${breakpoints.desktop}) {
-            width: calc(
-              100% / ${Math.max(columns - 1, 0)} - 2 * ${spacings.small} - 1px
-            );
-          }
-          @media (max-width: ${breakpoints.tablet}) {
-            width: calc(
-              100% / ${Math.max(columns - 2, 0)} - 2 * ${spacings.small} - 1px
-            );
-          }
-          @media (max-width: ${breakpoints.mobile}) {
-            flex-shrink: 0;
-            width: ${Math.max(columns - 2, 0) < 2 ? "80%" : "60%"};
-            min-width: 23rem;
-            &:first-of-type {
-              margin-left: ${spacings.medium};
-            }
-            &:last-of-type:after {
-              display: block;
-              width: ${spacings.medium};
-              height: 100%;
-              background-color: transparent;
-              content: "";
-            }
-          }
-        `}
+  @media (max-width: ${breakpoints.mobile}) {
+    flex-shrink: 0;
+    min-width: 23rem;
+    &:first-of-type {
+      margin-left: ${spacings.medium};
+    }
+    &:last-of-type:after {
+      display: block;
+      width: ${spacings.medium};
+      height: 100%;
+      background-color: transparent;
+      content: "";
+    }
+  }
+  ${({ columns }) => css`
+    width: calc(100% / ${columns} - 2 * ${spacings.small} - 1px);
+    @media (max-width: ${breakpoints.desktop}) {
+      width: calc(
+        100% / ${Math.max(columns - 1, 0)} - 2 * ${spacings.small} - 1px
+      );
+    }
+    @media (max-width: ${breakpoints.tablet}) {
+      width: calc(
+        100% / ${Math.max(columns - 2, 0)} - 2 * ${spacings.small} - 1px
+      );
+    }
+    @media (max-width: ${breakpoints.mobile}) {
+      width: ${Math.max(columns - 2, 0) < 2 ? "80%" : "60%"};
+    }
+  `}
 `;

--- a/packages/react-ui/src/Grid/__snapshots__/test.js.snap
+++ b/packages/react-ui/src/Grid/__snapshots__/test.js.snap
@@ -70,12 +70,12 @@ exports[`<Grid /> should render 1`] = `
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
+  margin: 1rem;
+  padding: 0;
+  width: calc(100% / 4 - 2 * 1rem - 1px);
   -webkit-flex-shrink: 1;
   -ms-flex-negative: 1;
   flex-shrink: 1;
-  width: calc(100% / 4 - 2 * 1rem - 1px);
-  margin: 1rem;
-  padding: 0;
 }
 
 @media (max-width:600px) {
@@ -258,12 +258,12 @@ exports[`<Grid /> should render 5columns 1`] = `
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
+  margin: 1rem;
+  padding: 0;
+  width: calc(100% / 5 - 2 * 1rem - 1px);
   -webkit-flex-shrink: 1;
   -ms-flex-negative: 1;
   flex-shrink: 1;
-  width: calc(100% / 5 - 2 * 1rem - 1px);
-  margin: 1rem;
-  padding: 0;
 }
 
 @media (max-width:600px) {

--- a/packages/react-ui/src/Grid/__snapshots__/test.js.snap
+++ b/packages/react-ui/src/Grid/__snapshots__/test.js.snap
@@ -70,12 +70,12 @@ exports[`<Grid /> should render 1`] = `
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  margin: 1rem;
-  padding: 0;
-  width: calc(100% / 4 - 2 * 1rem - 1px);
   -webkit-flex-shrink: 1;
   -ms-flex-negative: 1;
   flex-shrink: 1;
+  margin: 1rem;
+  padding: 0;
+  width: calc(100% / 4 - 2 * 1rem - 1px);
 }
 
 @media (max-width:600px) {
@@ -114,6 +114,27 @@ exports[`<Grid /> should render 1`] = `
   }
 }
 
+@media (max-width:600px) {
+  .c4 {
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    min-width: 23rem;
+  }
+
+  .c4:first-of-type {
+    margin-left: 2rem;
+  }
+
+  .c4:last-of-type:after {
+    display: block;
+    width: 2rem;
+    height: 100%;
+    background-color: transparent;
+    content: "";
+  }
+}
+
 @media (max-width:1180px) {
   .c4 {
     width: calc( 100% / 3 - 2 * 1rem - 1px );
@@ -128,23 +149,7 @@ exports[`<Grid /> should render 1`] = `
 
 @media (max-width:600px) {
   .c4 {
-    -webkit-flex-shrink: 0;
-    -ms-flex-negative: 0;
-    flex-shrink: 0;
     width: 60%;
-    min-width: 23rem;
-  }
-
-  .c4:first-of-type {
-    margin-left: 2rem;
-  }
-
-  .c4:last-of-type:after {
-    display: block;
-    width: 2rem;
-    height: 100%;
-    background-color: transparent;
-    content: "";
   }
 }
 
@@ -258,12 +263,12 @@ exports[`<Grid /> should render 5columns 1`] = `
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  margin: 1rem;
-  padding: 0;
-  width: calc(100% / 5 - 2 * 1rem - 1px);
   -webkit-flex-shrink: 1;
   -ms-flex-negative: 1;
   flex-shrink: 1;
+  margin: 1rem;
+  padding: 0;
+  width: calc(100% / 5 - 2 * 1rem - 1px);
 }
 
 @media (max-width:600px) {
@@ -302,6 +307,27 @@ exports[`<Grid /> should render 5columns 1`] = `
   }
 }
 
+@media (max-width:600px) {
+  .c4 {
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    min-width: 23rem;
+  }
+
+  .c4:first-of-type {
+    margin-left: 2rem;
+  }
+
+  .c4:last-of-type:after {
+    display: block;
+    width: 2rem;
+    height: 100%;
+    background-color: transparent;
+    content: "";
+  }
+}
+
 @media (max-width:1180px) {
   .c4 {
     width: calc( 100% / 4 - 2 * 1rem - 1px );
@@ -316,23 +342,7 @@ exports[`<Grid /> should render 5columns 1`] = `
 
 @media (max-width:600px) {
   .c4 {
-    -webkit-flex-shrink: 0;
-    -ms-flex-negative: 0;
-    flex-shrink: 0;
     width: 60%;
-    min-width: 23rem;
-  }
-
-  .c4:first-of-type {
-    margin-left: 2rem;
-  }
-
-  .c4:last-of-type:after {
-    display: block;
-    width: 2rem;
-    height: 100%;
-    background-color: transparent;
-    content: "";
   }
 }
 

--- a/packages/react-ui/src/Grid/index.js
+++ b/packages/react-ui/src/Grid/index.js
@@ -5,13 +5,11 @@ import { Grid as RootGrid } from "./Grid";
 import { GridCell } from "./GridCell";
 
 export { RootGrid, GridCell };
-export const Grid = ({ children, singleLined, ...props }) => (
-  <RootGrid singleLined={singleLined} {...props}>
+export const Grid = ({ children, ...props }) => (
+  <RootGrid {...props}>
     {Array.isArray(children) ? (
       React.Children.map(children, element => (
-        <GridCell singleLined={singleLined} key={element.key}>
-          {element}
-        </GridCell>
+        <GridCell key={element.key}>{element}</GridCell>
       ))
     ) : (
       <GridCell>{children}</GridCell>
@@ -21,11 +19,9 @@ export const Grid = ({ children, singleLined, ...props }) => (
 
 Grid.propTypes = {
   children: PropTypes.node.isRequired,
-  columns: PropTypes.number,
-  singleLined: PropTypes.bool
+  columns: PropTypes.number
 };
 
 Grid.defaultProps = {
-  columns: 4,
-  singleLined: false
+  columns: 4
 };

--- a/packages/react-ui/src/Grid/index.js
+++ b/packages/react-ui/src/Grid/index.js
@@ -5,11 +5,13 @@ import { Grid as RootGrid } from "./Grid";
 import { GridCell } from "./GridCell";
 
 export { RootGrid, GridCell };
-export const Grid = ({ children, ...props }) => (
-  <RootGrid {...props}>
+export const Grid = ({ children, singleLined, ...props }) => (
+  <RootGrid singleLined={singleLined} {...props}>
     {Array.isArray(children) ? (
       React.Children.map(children, element => (
-        <GridCell key={element.key}>{element}</GridCell>
+        <GridCell singleLined={singleLined} key={element.key}>
+          {element}
+        </GridCell>
       ))
     ) : (
       <GridCell>{children}</GridCell>
@@ -19,9 +21,11 @@ export const Grid = ({ children, ...props }) => (
 
 Grid.propTypes = {
   children: PropTypes.node.isRequired,
-  columns: PropTypes.number
+  columns: PropTypes.number,
+  singleLined: PropTypes.bool
 };
 
 Grid.defaultProps = {
-  columns: 4
+  columns: 4,
+  singleLined: false
 };

--- a/packages/react-ui/src/Tabs/__snapshots__/test.js.snap
+++ b/packages/react-ui/src/Tabs/__snapshots__/test.js.snap
@@ -1,7 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Tabs /> renders 1`] = `
-.c4:not(:focus):not(:active) {
+.c1 {
+  position: relative;
+  overflow: hidden;
+}
+
+.c1:before,
+.c1:after {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 1;
+  display: block;
+  width: 4rem;
+  opacity: 0;
+  -webkit-transition: opacity 0.3s linear;
+  transition: opacity 0.3s linear;
+  content: "";
+  pointer-events: none;
+  background: radial-gradient( ellipse at center, #fff 15%, rgba(255,255,255,0) 80% );
+}
+
+.c1:before {
+  left: -2rem;
+}
+
+.c1:after {
+  right: -2rem;
+}
+
+.c3 {
+  overflow-x: auto;
+}
+
+.c7:not(:focus):not(:active) {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -17,9 +50,11 @@ exports[`<Tabs /> renders 1`] = `
   margin-bottom: 3.2rem;
 }
 
-.c1 {
-  position: relative;
-  top: 1px;
+.c2 {
+  margin-right: 0.4rem;
+}
+
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -29,12 +64,16 @@ exports[`<Tabs /> renders 1`] = `
   flex-wrap: nowrap;
   max-width: 100%;
   margin: 0;
-  padding: 0 0.4rem 0 0;
+  padding: 0 0 0 0;
   overflow: visible;
   list-style-type: none;
 }
 
-.c2 {
+.c5 {
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  max-height: 11rem;
   margin-left: 0.4rem;
   padding: 1rem 1.6rem;
   color: #4d73b8;
@@ -42,7 +81,7 @@ exports[`<Tabs /> renders 1`] = `
   font-size: 1.8rem;
   background-color: #fff;
   border: 1px solid #bbcadf;
-  border-bottom: 1px solid #bbcadf;
+  border-bottom: 1px solid transparent;
   border-radius: 0.6rem 0.6rem 0 0;
   cursor: pointer;
   opacity: 1;
@@ -50,32 +89,51 @@ exports[`<Tabs /> renders 1`] = `
   transition: opacity 250ms linear;
 }
 
-.c2[aria-selected="false"]:hover {
+.c5[aria-selected="false"]:hover {
   opacity: 0.7;
 }
 
-.c2[aria-selected="true"] {
+.c5[aria-selected="true"] {
   color: #fff;
   background-color: #7994d4;
 }
 
-.c3 {
+.c6 {
   color: #3e486e;
   background-color: #fff;
 }
 
-.c3.react-tabs__tab-panel--selected {
+.c6.react-tabs__tab-panel--selected {
   padding: 2.4rem;
   border: 1px solid #bbcadf;
   border-radius: 0.6rem;
 }
 
-.c5 > *:first-child {
+.c8 > *:first-child {
   margin-top: 0;
 }
 
-.c5 > *:last-child {
+.c8 > *:last-child {
   margin-bottom: 0;
+}
+
+@media (max-width:600px) {
+  .c1 {
+    overflow-x: hidden;
+  }
+}
+
+@media (max-width:600px) {
+  .c1:before,
+  .c1:after {
+    display: block;
+  }
+}
+
+@media (max-width:600px) {
+  .c3 {
+    overflow-x: auto;
+  }
 }
 
 @media (max-width:600px) {
@@ -85,19 +143,13 @@ exports[`<Tabs /> renders 1`] = `
 }
 
 @media (max-width:980px) {
-  .c1 {
-    -webkit-flex-wrap: wrap;
-    -ms-flex-wrap: wrap;
-    flex-wrap: wrap;
+  .c4 {
     padding: 0;
   }
 }
 
 @media (max-width:980px) {
-  .c2 {
-    -webkit-flex: 1 1 auto;
-    -ms-flex: 1 1 auto;
-    flex: 1 1 auto;
+  .c5 {
     margin: 0.4rem;
     border-bottom: 1px solid #bbcadf;
     border-radius: 0.6rem;
@@ -105,19 +157,19 @@ exports[`<Tabs /> renders 1`] = `
 }
 
 @media (max-width:600px) {
-  .c2 {
+  .c5 {
     font-size: 1.6rem;
   }
 }
 
 @media (max-width:980px) {
-  .c3.react-tabs__tab-panel--selected {
+  .c6.react-tabs__tab-panel--selected {
     margin-top: 0.4rem;
   }
 }
 
 @media (max-width:600px) {
-  .c3.react-tabs__tab-panel--selected {
+  .c6.react-tabs__tab-panel--selected {
     padding: 1rem;
   }
 }
@@ -127,52 +179,60 @@ exports[`<Tabs /> renders 1`] = `
     class="c0"
     data-tabs="true"
   >
-    <ul
-      class="c1"
-      role="tablist"
+    <div
+      class="c1 c2"
     >
-      <li
-        aria-controls="react-tabs-1"
-        aria-disabled="false"
-        aria-selected="true"
-        class="c2 react-tabs__tab--selected"
-        id="react-tabs-0"
-        role="tab"
-        tabindex="0"
+      <div
+        class="c3"
       >
-        Tab 1
-      </li>
-      <li
-        aria-controls="react-tabs-3"
-        aria-disabled="false"
-        aria-selected="false"
-        class="c2"
-        id="react-tabs-2"
-        role="tab"
-      >
-        Tab 2
-      </li>
-    </ul>
+        <ul
+          class="c4"
+          role="tablist"
+        >
+          <li
+            aria-controls="react-tabs-1"
+            aria-disabled="false"
+            aria-selected="true"
+            class="c5 react-tabs__tab--selected"
+            id="react-tabs-0"
+            role="tab"
+            tabindex="0"
+          >
+            Tab 1
+          </li>
+          <li
+            aria-controls="react-tabs-3"
+            aria-disabled="false"
+            aria-selected="false"
+            class="c5"
+            id="react-tabs-2"
+            role="tab"
+          >
+            Tab 2
+          </li>
+        </ul>
+      </div>
+    </div>
     <div
       aria-labelledby="react-tabs-0"
-      class="c3 react-tabs__tab-panel--selected"
+      class="c6 react-tabs__tab-panel--selected"
       id="react-tabs-1"
       role="tabpanel"
     >
       <div
-        class="c4"
+        class="c7"
       >
         Tab 1
       </div>
       <div
-        class="c5"
+        class="c8"
       >
         This panel can contain nodes
       </div>
     </div>
     <div
       aria-labelledby="react-tabs-2"
-      class="c3"
+      class="c6"
       id="react-tabs-3"
       role="tabpanel"
     />

--- a/packages/react-ui/src/Tabs/index.js
+++ b/packages/react-ui/src/Tabs/index.js
@@ -5,6 +5,7 @@ import { Tab, Tabs as RootTabs, TabList, TabPanel } from "react-tabs";
 
 import { animations, box, breakpoints, fonts, spacings } from "../theme";
 import { getTextFromComponent } from "../utils/getTextFromComponent";
+import { OverflowWrapper } from "../OverflowWrapper";
 import { ScreenReaderOnly } from "../ScreenReaderOnly";
 
 export const Tabs = props => {
@@ -21,11 +22,13 @@ export const Tabs = props => {
   return (
     <>
       <StyledTabs {...refinedProps}>
-        <StyledTabList>
-          {data.map(({ tab }, index) => (
-            <StyledTab key={index}>{getTextFromComponent(tab)}</StyledTab>
-          ))}
-        </StyledTabList>
+        <StyledOverflowWrapper>
+          <StyledTabList>
+            {data.map(({ tab }, index) => (
+              <StyledTab key={index}>{getTextFromComponent(tab)}</StyledTab>
+            ))}
+          </StyledTabList>
+        </StyledOverflowWrapper>
         {data.map(({ tab, panel }, index) => (
           <StyledTabPanel key={index}>
             <ScreenReaderOnly>{tab}</ScreenReaderOnly>
@@ -61,23 +64,26 @@ const StyledTabs = styled(RootTabs)`
   }
 `;
 
+const StyledOverflowWrapper = styled(OverflowWrapper)`
+  margin-right: ${spacings.tiny};
+`;
+
 const StyledTabList = styled(TabList)`
-  position: relative;
-  top: 1px;
   display: flex;
   flex-wrap: nowrap;
   max-width: 100%;
   margin: 0;
-  padding: 0 ${spacings.tiny} 0 0;
+  padding: 0 0 0 0;
   overflow: visible;
   list-style-type: none;
   @media (max-width: ${breakpoints.tablet}) {
-    flex-wrap: wrap;
     padding: 0;
   }
 `;
 
 const StyledTab = styled(Tab)`
+  flex: 1 0 auto;
+  max-height: 11rem;
   margin-left: ${spacings.tiny};
   padding: ${spacings.small} ${spacings.base};
   color: ${({ theme }) => theme.altText};
@@ -85,7 +91,7 @@ const StyledTab = styled(Tab)`
   font-size: ${fonts.sizes.headings.small};
   background-color: ${({ theme }) => theme.white};
   border: ${({ theme }) => box.border(theme.border)};
-  border-bottom: 1px solid ${({ theme }) => theme.border};
+  border-bottom: 1px solid transparent;
   border-radius: ${box.borderRadius} ${box.borderRadius} 0 0;
   cursor: pointer;
   opacity: 1;
@@ -98,7 +104,6 @@ const StyledTab = styled(Tab)`
     background-color: ${({ theme }) => theme.secondary};
   }
   @media (max-width: ${breakpoints.tablet}) {
-    flex: 1 1 auto;
     margin: ${spacings.tiny};
     border-bottom: ${({ theme }) => box.border(theme.border)};
     border-radius: ${box.borderRadius};

--- a/packages/react-ui/src/layout/Section/__snapshots__/test.js.snap
+++ b/packages/react-ui/src/layout/Section/__snapshots__/test.js.snap
@@ -7,6 +7,12 @@ exports[`<Section /> it renders a dark Section 1`] = `
   color: #3e486e;
 }
 
+@media (max-width:600px) {
+  .c0 {
+    padding: 2.4rem 0;
+  }
+}
+
 <div>
   <div
     class="c0"
@@ -23,6 +29,12 @@ exports[`<Section /> it renders a default Section 1`] = `
   padding: 3.2rem 0;
   background-color: transparent;
   color: #3e486e;
+}
+
+@media (max-width:600px) {
+  .c0 {
+    padding: 2.4rem 0;
+  }
 }
 
 <div>
@@ -43,6 +55,12 @@ exports[`<Section /> it renders a light Section 1`] = `
   color: #3e486e;
 }
 
+@media (max-width:600px) {
+  .c0 {
+    padding: 2.4rem 0;
+  }
+}
+
 <div>
   <div
     class="c0"
@@ -59,6 +77,12 @@ exports[`<Section /> it renders a white Section 1`] = `
   padding: 3.2rem 0;
   background-color: #fff;
   color: #3e486e;
+}
+
+@media (max-width:600px) {
+  .c0 {
+    padding: 2.4rem 0;
+  }
 }
 
 <div>

--- a/packages/react-ui/src/layout/Section/index.js
+++ b/packages/react-ui/src/layout/Section/index.js
@@ -53,6 +53,9 @@ const StyledSection = styled.div`
       return css`
         padding: ${spacings.large} 0;
         ${assignBackgroundColor};
+        @media (max-width: ${breakpoints.mobile}) {
+          padding: ${spacings.xmedium} 0;
+        }
       `;
     }
     if (decorated) {


### PR DESCRIPTION
- [x] onglets en carrousel
- [x] articles connexes en dessous du contenu en mobile (aujourd'hui ils sont cachés en mobile)
- [x] blocs documents et liens dans les fiches SP (cf figma 4 Page contenu - encart document)

Les blocs document des related items sont désormais scrollables quand il y en a plusieurs

closes #1995
closes #2259