### PR TITLE
fix(contributions): use experts titles in contribs refs

### DIFF
--- a/packages/code-du-travail-frontend/src/contributions/Contribution.js
+++ b/packages/code-du-travail-frontend/src/contributions/Contribution.js
@@ -46,16 +46,16 @@ const References = ({ references = [] }) => {
         <>
           <Subtitle>Convention collective</Subtitle>
           <ul>
-            {agreementRefs.map(({ agreement, index }) => (
+            {agreementRefs.map(({ agreement, title, index }) => (
               <li key={`${index}-${agreement.id}`}>
                 {agreement.url ? (
                   <RefLink
                     key={agreement.id}
-                    title={agreement.title}
+                    title={title}
                     url={agreement.url}
                   />
                 ) : (
-                  <div key={agreement.id}>{agreement.title}</div>
+                  <div key={agreement.id}>{title}</div>
                 )}
               </li>
             ))}

--- a/packages/code-du-travail-frontend/src/contributions/__tests__/__snapshots__/Contribution.test.js.snap
+++ b/packages/code-du-travail-frontend/src/contributions/__tests__/__snapshots__/Contribution.test.js.snap
@@ -1370,7 +1370,9 @@ exports[`<Contribution /> should render answer references 1`] = `
             href="http://path/to/agreement"
             rel="noopener noreferrer"
             target="_blank"
-          />
+          >
+            reference CC 1
+          </a>
         </li>
       </ul>
       <span


### PR DESCRIPTION
fix #2273

<img width="624" alt="Capture d’écran 2020-02-03 à 14 52 30" src="https://user-images.githubusercontent.com/124937/73659469-9a8a1200-4696-11ea-9517-67b3f4e81944.png">
