### PR TITLE
ci(deploy): remove create namespace on prod jobs

### DIFF
--- a/.gitlab-ci/stages/deploy.yml
+++ b/.gitlab-ci/stages/deploy.yml
@@ -20,6 +20,7 @@ Create namespace:
     variables:
       # Don't run when running e2e tests
       - $E2E_TEST
+      - $PRODUCTION
   before_script:
     - source ./.gitlab-ci/env.sh
   after_script:


### PR DESCRIPTION
remove create namespace when deploying on production

fix #2355