### PR TITLE
Search tweaking

### DIFF
--- a/packages/code-du-travail-api/src/server/routes/__tests__/__snapshots__/search.test.js.snap
+++ b/packages/code-du-travail-api/src/server/routes/__tests__/__snapshots__/search.test.js.snap
@@ -40,135 +40,6 @@ Object {
       "source": "outils",
       "title": "Préavis de démission",
     },
-    Object {
-      "_score": 1.1074626,
-      "action": "Estimer",
-      "algo": "semantic",
-      "description": "Estimez simplement le montant de l’indemnité de licenciement",
-      "slug": "indemnite-licenciement",
-      "source": "outils",
-      "title": "Indemnité de licenciement",
-    },
-    Object {
-      "_score": 1.0799015,
-      "action": "Consulter",
-      "algo": "semantic",
-      "description": "Consultez en ligne vos droits à la formation, cherchez et réservez une formation",
-      "slug": "mon-compte-formation",
-      "source": "external",
-      "title": "Mon compte formation",
-      "url": "https://www.moncompteformation.gouv.fr",
-    },
-    Object {
-      "_score": 1.0769699,
-      "algo": "semantic",
-      "breadcrumbs": Array [
-        Object {
-          "label": "Départ de l'entreprise",
-          "slug": "/themes/8-depart-de-lentreprise",
-        },
-        Object {
-          "label": "Démission",
-          "slug": "/themes/81-demission",
-        },
-      ],
-      "description": "Le Code du travail ne prévoit aucune forme particulière pour présenter sa démission : elle peut être verbale, écrite ou résulter d’un comportement sans ambiguïté du salarié (ce qui n’est pas le cas, par exemple, de la seule absence du salarié à son poste de travail ou de l’absence de reprise du travail à l’issue des congés payés).",
-      "slug": "la-demission#Comment-presenter-une-demission",
-      "source": "fiches_ministere_travail",
-      "title": "La démission : comment présenter une démission ?",
-    },
-    Object {
-      "_score": 1.0560172,
-      "algo": "semantic",
-      "breadcrumbs": Array [
-        Object {
-          "label": "Embauche et contrat de travail",
-          "slug": "/themes/1-embauche-et-contrat-de-travail",
-        },
-        Object {
-          "label": "Embauche",
-          "slug": "/themes/11-embauche",
-        },
-        Object {
-          "label": "Période d'essai",
-          "slug": "/themes/113-periode-dessai",
-        },
-      ],
-      "description": "Pendant la période d’essai, le contrat de travail peut être rompu librement par l'employeur. L'employeur doit dans ce cas informer le salarié et respecter un délai de prévenance.",
-      "slug": "rupture-de-periode-dessai-a-linitiative-de-lemployeur",
-      "source": "modeles_de_courriers",
-      "title": "Rupture de période d’essai à l'initiative de l'employeur",
-    },
-    Object {
-      "_score": 1.0499763,
-      "algo": "semantic",
-      "breadcrumbs": Array [
-        Object {
-          "label": "Départ de l'entreprise",
-          "slug": "/themes/8-depart-de-lentreprise",
-        },
-        Object {
-          "label": "Rupture conventionnelle",
-          "slug": "/themes/83-rupture-conventionnelle",
-        },
-        Object {
-          "label": "Rupture conventionnelle individuelle",
-          "slug": "/themes/831-rupture-conventionnelle-individuelle",
-        },
-      ],
-      "description": "La rupture conventionnelle individuelle est une modalité de rupture spécifique du CDI. Elle nécessite le consentement de l’employeur et du salarié, et son homologation par l’administration. La rupture ouvre droit à une indemnité de rupture conventionnelle. Ce modèle permet d’initier la procédure de rupture par l’invitation à un premier entretien.",
-      "slug": "demande-de-rendez-vous-en-vue-dune-rupture-conventionnelle",
-      "source": "modeles_de_courriers",
-      "title": "Demande de rendez-vous en vue d’une rupture conventionnelle",
-    },
-    Object {
-      "_score": 1.0449069,
-      "algo": "semantic",
-      "breadcrumbs": Array [
-        Object {
-          "label": "Départ de l'entreprise",
-          "slug": "/themes/8-depart-de-lentreprise",
-        },
-        Object {
-          "label": "Démission",
-          "slug": "/themes/81-demission",
-        },
-      ],
-      "description": "L'assistante maternelle (ou assistant maternel) agréée qui souhaite rompre son contrat de travail doit informer le particulier employeur par écrit et respecter un préavis. À la fin de celui-ci, l'employeur remet les documents de fin de contrat.",
-      "slug": "demission-dune-assistante-maternelle",
-      "source": "fiches_service_public",
-      "title": "Démission d'une assistante maternelle",
-      "url": "https://www.service-public.fr/particuliers/vosdroits/F33164",
-    },
-    Object {
-      "_score": 1.0382855,
-      "action": "Calculer",
-      "algo": "semantic",
-      "description": "L’outil de calcul de votre index égalité professionnelle femmes-hommes",
-      "slug": "index-egapro",
-      "source": "external",
-      "title": "Index Egapro",
-      "url": "https://index-egapro.travail.gouv.fr",
-    },
-    Object {
-      "_score": 1.0301336,
-      "algo": "semantic",
-      "breadcrumbs": Array [
-        Object {
-          "label": "Départ de l'entreprise",
-          "slug": "/themes/8-depart-de-lentreprise",
-        },
-        Object {
-          "label": "Démission",
-          "slug": "/themes/81-demission",
-        },
-      ],
-      "description": "La démission permet au salarié, à son initiative, de rompre son contrat de travail, sous conditions.",
-      "slug": "demission-dun-salarie",
-      "source": "fiches_service_public",
-      "title": "Démission d'un salarié",
-      "url": "https://www.service-public.fr/particuliers/vosdroits/F2883",
-    },
   ],
   "themes": Array [
     Object {
@@ -309,6 +180,25 @@ Object {
   ],
   "documents": Array [
     Object {
+      "_score": 8.825487,
+      "algo": "fulltext",
+      "breadcrumbs": Array [
+        Object {
+          "label": "Départ de l'entreprise",
+          "slug": "/themes/8-depart-de-lentreprise",
+        },
+        Object {
+          "label": "Démission",
+          "slug": "/themes/81-demission",
+        },
+      ],
+      "description": "La démission permet au salarié, à son initiative, de rompre son contrat de travail, sous conditions.",
+      "slug": "demission-dun-salarie",
+      "source": "fiches_service_public",
+      "title": "Démission d'un salarié",
+      "url": "https://www.service-public.fr/particuliers/vosdroits/F2883",
+    },
+    Object {
       "_score": 1.131861,
       "algo": "both",
       "breadcrumbs": Array [
@@ -327,26 +217,7 @@ Object {
       "title": "La démission : l’absence prolongée du salarié est-elle une démission ?",
     },
     Object {
-      "_score": 8.825487,
-      "algo": "both",
-      "breadcrumbs": Array [
-        Object {
-          "label": "Départ de l'entreprise",
-          "slug": "/themes/8-depart-de-lentreprise",
-        },
-        Object {
-          "label": "Démission",
-          "slug": "/themes/81-demission",
-        },
-      ],
-      "description": "La démission permet au salarié, à son initiative, de rompre son contrat de travail, sous conditions.",
-      "slug": "demission-dun-salarie",
-      "source": "fiches_service_public",
-      "title": "Démission d'un salarié",
-      "url": "https://www.service-public.fr/particuliers/vosdroits/F2883",
-    },
-    Object {
-      "_score": 1.1191392,
+      "_score": 8.572784,
       "action": "Calculer",
       "algo": "both",
       "description": "Calculez la durée de préavis à respecter en cas de démission",
@@ -355,17 +226,8 @@ Object {
       "title": "Préavis de démission",
     },
     Object {
-      "_score": 1.1074626,
-      "action": "Estimer",
-      "algo": "semantic",
-      "description": "Estimez simplement le montant de l’indemnité de licenciement",
-      "slug": "indemnite-licenciement",
-      "source": "outils",
-      "title": "Indemnité de licenciement",
-    },
-    Object {
       "_score": 8.245559,
-      "algo": "both",
+      "algo": "fulltext",
       "breadcrumbs": Array [
         Object {
           "label": "Départ de l'entreprise",
@@ -382,18 +244,8 @@ Object {
       "title": "La démission : comment présenter une démission ?",
     },
     Object {
-      "_score": 1.0799015,
-      "action": "Consulter",
-      "algo": "semantic",
-      "description": "Consultez en ligne vos droits à la formation, cherchez et réservez une formation",
-      "slug": "mon-compte-formation",
-      "source": "external",
-      "title": "Mon compte formation",
-      "url": "https://www.moncompteformation.gouv.fr",
-    },
-    Object {
       "_score": 7.8831825,
-      "algo": "both",
+      "algo": "fulltext",
       "breadcrumbs": Array [
         Object {
           "label": "Départ de l'entreprise",
@@ -409,60 +261,6 @@ Object {
       "source": "fiches_service_public",
       "title": "Démission d'une assistante maternelle",
       "url": "https://www.service-public.fr/particuliers/vosdroits/F33164",
-    },
-    Object {
-      "_score": 1.0560172,
-      "algo": "semantic",
-      "breadcrumbs": Array [
-        Object {
-          "label": "Embauche et contrat de travail",
-          "slug": "/themes/1-embauche-et-contrat-de-travail",
-        },
-        Object {
-          "label": "Embauche",
-          "slug": "/themes/11-embauche",
-        },
-        Object {
-          "label": "Période d'essai",
-          "slug": "/themes/113-periode-dessai",
-        },
-      ],
-      "description": "Pendant la période d’essai, le contrat de travail peut être rompu librement par l'employeur. L'employeur doit dans ce cas informer le salarié et respecter un délai de prévenance.",
-      "slug": "rupture-de-periode-dessai-a-linitiative-de-lemployeur",
-      "source": "modeles_de_courriers",
-      "title": "Rupture de période d’essai à l'initiative de l'employeur",
-    },
-    Object {
-      "_score": 1.0499763,
-      "algo": "semantic",
-      "breadcrumbs": Array [
-        Object {
-          "label": "Départ de l'entreprise",
-          "slug": "/themes/8-depart-de-lentreprise",
-        },
-        Object {
-          "label": "Rupture conventionnelle",
-          "slug": "/themes/83-rupture-conventionnelle",
-        },
-        Object {
-          "label": "Rupture conventionnelle individuelle",
-          "slug": "/themes/831-rupture-conventionnelle-individuelle",
-        },
-      ],
-      "description": "La rupture conventionnelle individuelle est une modalité de rupture spécifique du CDI. Elle nécessite le consentement de l’employeur et du salarié, et son homologation par l’administration. La rupture ouvre droit à une indemnité de rupture conventionnelle. Ce modèle permet d’initier la procédure de rupture par l’invitation à un premier entretien.",
-      "slug": "demande-de-rendez-vous-en-vue-dune-rupture-conventionnelle",
-      "source": "modeles_de_courriers",
-      "title": "Demande de rendez-vous en vue d’une rupture conventionnelle",
-    },
-    Object {
-      "_score": 1.0382855,
-      "action": "Calculer",
-      "algo": "semantic",
-      "description": "L’outil de calcul de votre index égalité professionnelle femmes-hommes",
-      "slug": "index-egapro",
-      "source": "external",
-      "title": "Index Egapro",
-      "url": "https://index-egapro.travail.gouv.fr",
     },
   ],
   "themes": Array [

--- a/packages/code-du-travail-api/src/server/routes/__tests__/__snapshots__/search.test.js.snap
+++ b/packages/code-du-travail-api/src/server/routes/__tests__/__snapshots__/search.test.js.snap
@@ -141,8 +141,8 @@ Object {
   ],
   "themes": Array [
     Object {
-      "_score": 1.123209,
-      "algo": "semantic",
+      "_score": 0.8025915,
+      "algo": "fulltext",
       "slug": "81-demission",
       "source": "themes",
       "title": "Démission",
@@ -265,8 +265,8 @@ Object {
   ],
   "themes": Array [
     Object {
-      "_score": 1.123209,
-      "algo": "semantic",
+      "_score": 0.8025915,
+      "algo": "fulltext",
       "slug": "81-demission",
       "source": "themes",
       "title": "Démission",

--- a/packages/code-du-travail-api/src/server/routes/items/getRelatedItems.js
+++ b/packages/code-du-travail-api/src/server/routes/items/getRelatedItems.js
@@ -57,7 +57,7 @@ async function getRelatedItems({ title, settings, slug }) {
   const [rootSlug] = slug.split("#");
 
   return utils
-    .mergePipe(semanticHits, fullTextHits, MAX_RESULTS)
+    .mergePipe(fullTextHits, semanticHits, MAX_RESULTS)
     .filter(({ _source }) => !_source.slug.startsWith(rootSlug))
     .map(({ _source }) => _source);
 }

--- a/packages/code-du-travail-api/src/server/routes/search/index.js
+++ b/packages/code-du-travail-api/src/server/routes/search/index.js
@@ -164,7 +164,7 @@ router.get("/search", async ctx => {
     semanticHits.forEach(item => (item._source.algo = "semantic"));
     themes = removeDuplicate(
       themes
-        .concat(merge(semanticHits, fulltextHits, THEMES_RESULTS_NUMBER * 2))
+        .concat(merge(fulltextHits, semanticHits, THEMES_RESULTS_NUMBER * 2))
         .slice(0, THEMES_RESULTS_NUMBER)
     );
   }

--- a/packages/code-du-travail-frontend/src/search/SearchResults/index.js
+++ b/packages/code-du-travail-frontend/src/search/SearchResults/index.js
@@ -6,7 +6,6 @@ import { Results } from "./Results";
 import { Law } from "./Law";
 import { Themes } from "./Themes";
 import { matopush } from "../../piwik";
-import { formatUrlMatomo } from "../utils";
 
 const SearchResults = ({
   items: { documents, themes, articles },
@@ -14,21 +13,9 @@ const SearchResults = ({
   query
 }) => {
   useEffect(() => {
-    const toLogCandidate = ({ url, source, slug, algo }) => {
-      const trackedUrl = formatUrlMatomo(source, slug, url);
-      return {
-        slug: trackedUrl,
-        algo
-      };
-    };
-    const results = JSON.stringify({
-      documents: documents.map(toLogCandidate),
-      themes: themes.map(toLogCandidate),
-      articles: articles.map(toLogCandidate)
-    });
     // distinction between actual search and theme search when logging
     const eventType = isSearch ? "candidateResults" : "themeResults";
-    matopush(["trackEvent", eventType, query, results]);
+    matopush(["trackEvent", eventType, query]);
   });
 
   return (

--- a/packages/code-du-travail-frontend/src/search/__tests__/__snapshots__/SearchResults.test.js.snap
+++ b/packages/code-du-travail-frontend/src/search/__tests__/__snapshots__/SearchResults.test.js.snap
@@ -1055,7 +1055,6 @@ exports[`<SearchResults/> should track event candidateResults 1`] = `
 Array [
   "trackEvent",
   "candidateResults",
-  "search test",
-  "{\\"documents\\":[{\\"slug\\":\\"/fiche-service-public/mer-il-est-fou\\"},{\\"slug\\":\\"/outils/simulateur-precarite\\"},{\\"slug\\":\\"https://www.telerc.travail.gouv.fr/RuptureConventionnellePortailPublic/jsp/site/Portal.jsp?page_id=14\\"},{\\"slug\\":\\"/outils/mer-il-est-fou2\\"},{\\"slug\\":\\"/undefined/mer-il-est-fou4\\"}],\\"themes\\":[{\\"slug\\":\\"/themes/1-contrat\\"}],\\"articles\\":[{\\"slug\\":\\"/code-du-travail/L1243-1\\"}]}",
+  "search test"
 ]
 `;

--- a/packages/code-du-travail-frontend/src/search/__tests__/__snapshots__/SearchResults.test.js.snap
+++ b/packages/code-du-travail-frontend/src/search/__tests__/__snapshots__/SearchResults.test.js.snap
@@ -1055,6 +1055,6 @@ exports[`<SearchResults/> should track event candidateResults 1`] = `
 Array [
   "trackEvent",
   "candidateResults",
-  "search test"
+  "search test",
 ]
 `;


### PR DESCRIPTION
Different tweaks to improve search relevance :
- Add semantic threshold based on log analysis : 1.11 
- Change minimum prefix size to 3 for prequalified match
- Lower case query before semantic search
- Disable fuzzy matching for specific tokens during pre qualification variant match
- Stop sending all query results to Matomo
- Start with a fulltext result when merging