### PR TITLE
feat(search): add tracking for ccn search

### DIFF
--- a/packages/code-du-travail-frontend/src/conventions/Search/SearchCC.js
+++ b/packages/code-du-travail-frontend/src/conventions/Search/SearchCC.js
@@ -2,9 +2,9 @@ import { useState, useEffect } from "react";
 
 import { loadResults } from "./api";
 
-// a render prop that return idcc search results
+// a hook that return [status, searchResults]
 // todo: package as a module
-const SearchCC = ({ query, render }) => {
+const useSearchCC = query => {
   const [results, setResults] = useState();
   const [status, setStatus] = useState("idle");
   // load results when query change
@@ -17,11 +17,13 @@ const SearchCC = ({ query, render }) => {
         try {
           const results = await loadResults(query);
           if (shouldUpdate) {
-            setResults(results);
-            if (results && results.length) {
-              setStatus("success");
-            } else {
-              setStatus("error");
+            if (results) {
+              if (results.length) {
+                setStatus("success");
+              } else {
+                setStatus("empty");
+              }
+              setResults(results);
             }
           }
         } catch (e) {
@@ -38,7 +40,7 @@ const SearchCC = ({ query, render }) => {
     };
   }, [query]);
 
-  return render({ status, results });
+  return [status, results];
 };
 
-export default SearchCC;
+export default useSearchCC;

--- a/packages/code-du-travail-frontend/src/conventions/Search/__tests__/__snapshots__/Search.test.js.snap
+++ b/packages/code-du-travail-frontend/src/conventions/Search/__tests__/__snapshots__/Search.test.js.snap
@@ -756,7 +756,7 @@ exports[`<Search /> should show no results when no result 1`] = `
     class="c4"
   >
     <div>
-      La convention collective n‘a pas été trouvée.
+      Aucun résultat n’a été trouvé.
     </div>
   </div>
 </div>

--- a/packages/code-du-travail-frontend/src/conventions/Search/api.js
+++ b/packages/code-du-travail-frontend/src/conventions/Search/api.js
@@ -66,6 +66,8 @@ export const loadResults = async query => {
         id: match.num,
         conventions: [match]
       }));
+    } else {
+      return [];
     }
   }
   return null;


### PR DESCRIPTION
refactor searchCC renderProp based component into a hook in order to use a useEffect() to  track search results
 
fix #2319