### PR TITLE
fix(frontend): query is not a regexp

### DIFF
--- a/packages/code-du-travail-frontend/src/search/SearchBar/DocumentSuggester.js
+++ b/packages/code-du-travail-frontend/src/search/SearchBar/DocumentSuggester.js
@@ -117,8 +117,7 @@ const SuggestionContainer = styled.div`
 `;
 
 const renderSuggestion = (suggestion, query) => {
-  const regexp = new RegExp(query);
-  const title = suggestion.replace(regexp, "<b>$&</b>");
+  const title = suggestion.replace(query, `<b>${query}</b>`);
   return (
     <SuggestionContainer>
       <Html inline>{title}</Html>

--- a/packages/code-du-travail-frontend/src/search/SearchBar/index.js
+++ b/packages/code-du-travail-frontend/src/search/SearchBar/index.js
@@ -34,7 +34,7 @@ const SearchBar = ({
       router.push({
         pathname: "/recherche",
         query: {
-          q: query
+          q: query.trim()
         }
       });
     }


### PR DESCRIPTION
Fix bug when typing a `\` in search
Also, trim query because why not ?