### PR TITLE
Remove tarteaucitron banner on print

### DIFF
--- a/packages/code-du-travail-frontend/public/static/tarteaucitron/css/tarteaucitron.css
+++ b/packages/code-du-travail-frontend/public/static/tarteaucitron/css/tarteaucitron.css
@@ -668,6 +668,13 @@ a.tarteaucitronSelfLink {
   width: calc(100% - 2rem);
   margin: 1rem;
   border: 2px solid #7994d4;
+
+}
+
+@media print {
+  #tarteaucitronRoot {
+    display:none;
+  }
 }
 
 #tarteaucitronAlertBig #tarteaucitronPrivacyUrl,


### PR DESCRIPTION
Remove tarteaucitron banner on all printed pages