### PR TITLE
feat(frontend): remove ambassador link

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint": "lerna run lint --parallel",
     "postinstall": "node scripts/setup-env.js",
     "start": "lerna run start --parallel",
-    "test": "lerna run test"
+    "test": "lerna run test",
+    "jest:ui": "yarn workspace @cdt/frontend jest -u && yarn workspace @socialgouv/react-fiche-service-public jest -u && yarn workspace @socialgouv/react-ui jest -u"
   },
   "repository": {
     "type": "git",

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/a-propos.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/a-propos.test.js.snap
@@ -1660,18 +1660,6 @@ exports[`<About /> should render 1`] = `
                 >
                   <a
                     class="c48"
-                    href="https://calendly.com/code-du-travail-numerique/ambassadeur-du-code-du-travail-numerique"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Devenir ambassadeur
-                  </a>
-                </li>
-                <li
-                  class="c47"
-                >
-                  <a
-                    class="c48"
                     href="https://github.com/SocialGouv/code-du-travail-numerique/tree/vX.Y.Z"
                     rel="noopener noreferrer"
                     target="_blank"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/code-du-travail.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/code-du-travail.test.js.snap
@@ -1683,18 +1683,6 @@ exports[`<CodeDuTravail /> should render 1`] = `
                 >
                   <a
                     class="c51"
-                    href="https://calendly.com/code-du-travail-numerique/ambassadeur-du-code-du-travail-numerique"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Devenir ambassadeur
-                  </a>
-                </li>
-                <li
-                  class="c50"
-                >
-                  <a
-                    class="c51"
                     href="https://github.com/SocialGouv/code-du-travail-numerique/tree/vX.Y.Z"
                     rel="noopener noreferrer"
                     target="_blank"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/contribution.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/contribution.test.js.snap
@@ -2623,18 +2623,6 @@ exports[`<FicheContribution /> should render with external content 1`] = `
                   >
                     <a
                       class="c84"
-                      href="https://calendly.com/code-du-travail-numerique/ambassadeur-du-code-du-travail-numerique"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      Devenir ambassadeur
-                    </a>
-                  </li>
-                  <li
-                    class="c83"
-                  >
-                    <a
-                      class="c84"
                       href="https://github.com/SocialGouv/code-du-travail-numerique/tree/vX.Y.Z"
                       rel="noopener noreferrer"
                       target="_blank"
@@ -5414,18 +5402,6 @@ exports[`<FicheContribution /> should render without external content 1`] = `
                 <ul
                   class="sc-fznMnq c82"
                 >
-                  <li
-                    class="c83"
-                  >
-                    <a
-                      class="c84"
-                      href="https://calendly.com/code-du-travail-numerique/ambassadeur-du-code-du-travail-numerique"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      Devenir ambassadeur
-                    </a>
-                  </li>
                   <li
                     class="c83"
                   >

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/droit-du-travail.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/droit-du-travail.test.js.snap
@@ -5108,18 +5108,6 @@ exports[`<DroitDuTravail /> should render 1`] = `
                 >
                   <a
                     class="c103"
-                    href="https://calendly.com/code-du-travail-numerique/ambassadeur-du-code-du-travail-numerique"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Devenir ambassadeur
-                  </a>
-                </li>
-                <li
-                  class="c102"
-                >
-                  <a
-                    class="c103"
                     href="https://github.com/SocialGouv/code-du-travail-numerique/tree/vX.Y.Z"
                     rel="noopener noreferrer"
                     target="_blank"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/fiche-ministere-travail.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/fiche-ministere-travail.test.js.snap
@@ -2327,18 +2327,6 @@ exports[`<FicheMT /> should render 1`] = `
                 >
                   <a
                     class="c77"
-                    href="https://calendly.com/code-du-travail-numerique/ambassadeur-du-code-du-travail-numerique"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Devenir ambassadeur
-                  </a>
-                </li>
-                <li
-                  class="c76"
-                >
-                  <a
-                    class="c77"
                     href="https://github.com/SocialGouv/code-du-travail-numerique/tree/vX.Y.Z"
                     rel="noopener noreferrer"
                     target="_blank"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/fiche-service-public.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/fiche-service-public.test.js.snap
@@ -1690,18 +1690,6 @@ exports[`<FicheSP /> should render 1`] = `
                 >
                   <a
                     class="c51"
-                    href="https://calendly.com/code-du-travail-numerique/ambassadeur-du-code-du-travail-numerique"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Devenir ambassadeur
-                  </a>
-                </li>
-                <li
-                  class="c50"
-                >
-                  <a
-                    class="c51"
                     href="https://github.com/SocialGouv/code-du-travail-numerique/tree/vX.Y.Z"
                     rel="noopener noreferrer"
                     target="_blank"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire-[slug].test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire-[slug].test.js.snap
@@ -1551,18 +1551,6 @@ exports[`<Term /> should render 1`] = `
                 >
                   <a
                     class="c46"
-                    href="https://calendly.com/code-du-travail-numerique/ambassadeur-du-code-du-travail-numerique"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Devenir ambassadeur
-                  </a>
-                </li>
-                <li
-                  class="c45"
-                >
-                  <a
-                    class="c46"
                     href="https://github.com/SocialGouv/code-du-travail-numerique/tree/vX.Y.Z"
                     rel="noopener noreferrer"
                     target="_blank"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire.test.js.snap
@@ -3946,18 +3946,6 @@ exports[`<Glossaire /> should render 1`] = `
                 >
                   <a
                     class="c49"
-                    href="https://calendly.com/code-du-travail-numerique/ambassadeur-du-code-du-travail-numerique"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Devenir ambassadeur
-                  </a>
-                </li>
-                <li
-                  class="c48"
-                >
-                  <a
-                    class="c49"
                     href="https://github.com/SocialGouv/code-du-travail-numerique/tree/vX.Y.Z"
                     rel="noopener noreferrer"
                     target="_blank"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/index.test.js.snap
@@ -3105,18 +3105,6 @@ exports[`<Home /> should render 1`] = `
                 >
                   <a
                     class="c73"
-                    href="https://calendly.com/code-du-travail-numerique/ambassadeur-du-code-du-travail-numerique"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Devenir ambassadeur
-                  </a>
-                </li>
-                <li
-                  class="c72"
-                >
-                  <a
-                    class="c73"
                     href="https://github.com/SocialGouv/code-du-travail-numerique/tree/vX.Y.Z"
                     rel="noopener noreferrer"
                     target="_blank"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/mentions-legales.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/mentions-legales.test.js.snap
@@ -1665,18 +1665,6 @@ exports[`<MentionLegales /> should render 1`] = `
                 >
                   <a
                     class="c49"
-                    href="https://calendly.com/code-du-travail-numerique/ambassadeur-du-code-du-travail-numerique"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Devenir ambassadeur
-                  </a>
-                </li>
-                <li
-                  class="c48"
-                >
-                  <a
-                    class="c49"
                     href="https://github.com/SocialGouv/code-du-travail-numerique/tree/vX.Y.Z"
                     rel="noopener noreferrer"
                     target="_blank"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers-[slug].test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers-[slug].test.js.snap
@@ -2431,18 +2431,6 @@ exports[`<ModelesDeCourrier /> should render 1`] = `
                 >
                   <a
                     class="c78"
-                    href="https://calendly.com/code-du-travail-numerique/ambassadeur-du-code-du-travail-numerique"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Devenir ambassadeur
-                  </a>
-                </li>
-                <li
-                  class="c77"
-                >
-                  <a
-                    class="c78"
                     href="https://github.com/SocialGouv/code-du-travail-numerique/tree/vX.Y.Z"
                     rel="noopener noreferrer"
                     target="_blank"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers.test.js.snap
@@ -1788,18 +1788,6 @@ exports[`<ModelesDeCourriers /> should render 1`] = `
                 >
                   <a
                     class="c58"
-                    href="https://calendly.com/code-du-travail-numerique/ambassadeur-du-code-du-travail-numerique"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Devenir ambassadeur
-                  </a>
-                </li>
-                <li
-                  class="c57"
-                >
-                  <a
-                    class="c58"
                     href="https://github.com/SocialGouv/code-du-travail-numerique/tree/vX.Y.Z"
                     rel="noopener noreferrer"
                     target="_blank"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/outils.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/outils.test.js.snap
@@ -2670,18 +2670,6 @@ exports[`<Outils /> should render 1`] = `
                 >
                   <a
                     class="c61"
-                    href="https://calendly.com/code-du-travail-numerique/ambassadeur-du-code-du-travail-numerique"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Devenir ambassadeur
-                  </a>
-                </li>
-                <li
-                  class="c60"
-                >
-                  <a
-                    class="c61"
                     href="https://github.com/SocialGouv/code-du-travail-numerique/tree/vX.Y.Z"
                     rel="noopener noreferrer"
                     target="_blank"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/politique-confidentialite.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/politique-confidentialite.test.js.snap
@@ -1630,18 +1630,6 @@ exports[`<CookiePolicy /> should render 1`] = `
                 >
                   <a
                     class="c47"
-                    href="https://calendly.com/code-du-travail-numerique/ambassadeur-du-code-du-travail-numerique"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Devenir ambassadeur
-                  </a>
-                </li>
-                <li
-                  class="c46"
-                >
-                  <a
-                    class="c47"
                     href="https://github.com/SocialGouv/code-du-travail-numerique/tree/vX.Y.Z"
                     rel="noopener noreferrer"
                     target="_blank"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/recherche.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/recherche.test.js.snap
@@ -1545,18 +1545,6 @@ exports[`<Recherche /> should render 1`] = `
                 >
                   <a
                     class="c47"
-                    href="https://calendly.com/code-du-travail-numerique/ambassadeur-du-code-du-travail-numerique"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Devenir ambassadeur
-                  </a>
-                </li>
-                <li
-                  class="c46"
-                >
-                  <a
-                    class="c47"
                     href="https://github.com/SocialGouv/code-du-travail-numerique/tree/vX.Y.Z"
                     rel="noopener noreferrer"
                     target="_blank"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/stats.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/stats.test.js.snap
@@ -1733,18 +1733,6 @@ exports[`<Stats /> should render 1`] = `
                 >
                   <a
                     class="c50"
-                    href="https://calendly.com/code-du-travail-numerique/ambassadeur-du-code-du-travail-numerique"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Devenir ambassadeur
-                  </a>
-                </li>
-                <li
-                  class="c49"
-                >
-                  <a
-                    class="c50"
                     href="https://github.com/SocialGouv/code-du-travail-numerique/tree/vX.Y.Z"
                     rel="noopener noreferrer"
                     target="_blank"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/themes.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/themes.test.js.snap
@@ -1359,18 +1359,6 @@ exports[`<Theme /> should render 1`] = `
                 >
                   <a
                     class="c41"
-                    href="https://calendly.com/code-du-travail-numerique/ambassadeur-du-code-du-travail-numerique"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Devenir ambassadeur
-                  </a>
-                </li>
-                <li
-                  class="c40"
-                >
-                  <a
-                    class="c41"
                     href="https://github.com/SocialGouv/code-du-travail-numerique/tree/vX.Y.Z"
                     rel="noopener noreferrer"
                     target="_blank"

--- a/packages/code-du-travail-frontend/src/layout/Footer.js
+++ b/packages/code-du-travail-frontend/src/layout/Footer.js
@@ -121,15 +121,6 @@ const Footer = () => {
                 <StyledList>
                   <StyledListItem>
                     <StyledLink
-                      href="https://calendly.com/code-du-travail-numerique/ambassadeur-du-code-du-travail-numerique"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      Devenir ambassadeur
-                    </StyledLink>
-                  </StyledListItem>
-                  <StyledListItem>
-                    <StyledLink
                       href={`${GITHUB_REPO}/tree/${publicRuntimeConfig.PACKAGE_VERSION}`}
                       target="_blank"
                       rel="noopener noreferrer"

--- a/packages/code-du-travail-frontend/src/layout/__tests__/__snapshots__/Footer.test.js.snap
+++ b/packages/code-du-travail-frontend/src/layout/__tests__/__snapshots__/Footer.test.js.snap
@@ -579,18 +579,6 @@ exports[`<Footer /> should render 1`] = `
                 >
                   <a
                     class="c19"
-                    href="https://calendly.com/code-du-travail-numerique/ambassadeur-du-code-du-travail-numerique"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Devenir ambassadeur
-                  </a>
-                </li>
-                <li
-                  class="c18"
-                >
-                  <a
-                    class="c19"
                     href="https://github.com/SocialGouv/code-du-travail-numerique/tree/vX.Y.Z"
                     rel="noopener noreferrer"
                     target="_blank"

--- a/packages/code-du-travail-frontend/src/layout/__tests__/__snapshots__/Layout.test.js.snap
+++ b/packages/code-du-travail-frontend/src/layout/__tests__/__snapshots__/Layout.test.js.snap
@@ -1315,18 +1315,6 @@ exports[`<Layout /> should render 1`] = `
                 >
                   <a
                     class="c39"
-                    href="https://calendly.com/code-du-travail-numerique/ambassadeur-du-code-du-travail-numerique"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Devenir ambassadeur
-                  </a>
-                </li>
-                <li
-                  class="c38"
-                >
-                  <a
-                    class="c39"
                     href="https://github.com/SocialGouv/code-du-travail-numerique/tree/vX.Y.Z"
                     rel="noopener noreferrer"
                     target="_blank"


### PR DESCRIPTION

<img width="720" alt="Screenshot 2020-03-02 at 17 14 06" src="https://user-images.githubusercontent.com/705453/75695032-bf7ba000-5ca9-11ea-8718-924047036f5c.png">

@virginielastisneres @ClementChapalain  Du coup les deux liens qu'on devait ajouter pour "équilibrer" le footer ne sont plus