### PR TITLE
fix(data): requetes DF : order by position

### DIFF
--- a/packages/code-du-travail-data/dataset/datafiller/__test__/__snapshots__/fetch-requetes.test.js.snap
+++ b/packages/code-du-travail-data/dataset/datafiller/__test__/__snapshots__/fetch-requetes.test.js.snap
@@ -5,34 +5,34 @@ Array [
   Object {
     "refs": Array [
       Object {
-        "relevance": 5,
-        "title": "Fiche 2",
-        "url": "/fiche-service-public/fiche-2",
-      },
-      Object {
-        "relevance": 5,
+        "position": 1,
         "title": "HTML page title",
         "url": "https://www.telerc.travail.gouv.fr/RuptureConventionnellePortailPublic/jsp/site/Portal.jsp?page_id=14",
       },
       Object {
-        "relevance": 5,
+        "position": 2,
+        "title": "Conclusion du contrat de travail à durée déterminée (CDD)",
+        "url": "/fiche-service-public/conclusion-du-contrat-de-travail-a-duree-determinee-cdd",
+      },
+      Object {
+        "position": 3,
         "title": "/some-unknown-source/test",
         "url": "/some-unknown-source/test",
       },
       Object {
-        "relevance": 5,
-        "title": "Article L1221-3",
-        "url": "/code-du-travail/l1221-3",
-      },
-      Object {
-        "relevance": 4,
+        "position": 4,
         "title": "Fiche 3",
         "url": "/fiche-service-public/fiche-3",
       },
       Object {
-        "relevance": 2,
-        "title": "Conclusion du contrat de travail à durée déterminée (CDD)",
-        "url": "/fiche-service-public/conclusion-du-contrat-de-travail-a-duree-determinee-cdd",
+        "position": 5,
+        "title": "Article L1221-3",
+        "url": "/code-du-travail/l1221-3",
+      },
+      Object {
+        "position": 8,
+        "title": "Fiche 2",
+        "url": "/fiche-service-public/fiche-2",
       },
     ],
     "theme": "theme1",
@@ -46,19 +46,19 @@ Array [
   Object {
     "refs": Array [
       Object {
-        "relevance": 5,
-        "title": "Article L3221-3",
-        "url": "/code-du-travail/l3221-3",
+        "position": 1,
+        "title": "Thématique",
+        "url": "/themes/theme1",
       },
       Object {
-        "relevance": 3,
+        "position": 3,
         "title": "Le salaire : quelles sont les modalités de paiement ?",
         "url": "/fiche-ministere-travail/le-salaire-quelles-sont-les-modalites-de-paiement",
       },
       Object {
-        "relevance": 1,
-        "title": "Thématique",
-        "url": "/themes/theme1",
+        "position": 5,
+        "title": "Article L3221-3",
+        "url": "/code-du-travail/l3221-3",
       },
     ],
     "theme": "theme2",
@@ -75,34 +75,34 @@ Array [
 exports[`refs should be sorted by relevance and source type 1`] = `
 Array [
   Object {
-    "relevance": 5,
-    "title": "Fiche 2",
-    "url": "/fiche-service-public/fiche-2",
-  },
-  Object {
-    "relevance": 5,
+    "position": 1,
     "title": "HTML page title",
     "url": "https://www.telerc.travail.gouv.fr/RuptureConventionnellePortailPublic/jsp/site/Portal.jsp?page_id=14",
   },
   Object {
-    "relevance": 5,
+    "position": 2,
+    "title": "Conclusion du contrat de travail à durée déterminée (CDD)",
+    "url": "/fiche-service-public/conclusion-du-contrat-de-travail-a-duree-determinee-cdd",
+  },
+  Object {
+    "position": 3,
     "title": "/some-unknown-source/test",
     "url": "/some-unknown-source/test",
   },
   Object {
-    "relevance": 5,
-    "title": "Article L1221-3",
-    "url": "/code-du-travail/l1221-3",
-  },
-  Object {
-    "relevance": 4,
+    "position": 4,
     "title": "Fiche 3",
     "url": "/fiche-service-public/fiche-3",
   },
   Object {
-    "relevance": 2,
-    "title": "Conclusion du contrat de travail à durée déterminée (CDD)",
-    "url": "/fiche-service-public/conclusion-du-contrat-de-travail-a-duree-determinee-cdd",
+    "position": 5,
+    "title": "Article L1221-3",
+    "url": "/code-du-travail/l1221-3",
+  },
+  Object {
+    "position": 8,
+    "title": "Fiche 2",
+    "url": "/fiche-service-public/fiche-2",
   },
 ]
 `;

--- a/packages/code-du-travail-data/dataset/datafiller/__test__/fetch-requetes.test.js
+++ b/packages/code-du-travail-data/dataset/datafiller/__test__/fetch-requetes.test.js
@@ -6,33 +6,33 @@ const requetes = [
       {
         url: "/code-du-travail/l1221-3",
         title: "Article L1221-3",
-        relevance: 5
+        position: 5
       },
       {
         url:
           "/fiche-service-public/conclusion-du-contrat-de-travail-a-duree-determinee-cdd",
         title:
           "Conclusion du contrat de travail \u00e0 dur\u00e9e d\u00e9termin\u00e9e (CDD)",
-        relevance: 2
+        position: 2
       },
       {
         url: "/fiche-service-public/fiche-3",
         title: "Fiche 3",
-        relevance: 4
+        position: 4
       },
       {
         url: "/fiche-service-public/fiche-2",
         title: "Fiche 2",
-        relevance: 5
+        position: 8
       },
       {
         url:
           "https://www.telerc.travail.gouv.fr/RuptureConventionnellePortailPublic/jsp/site/Portal.jsp?page_id=14",
-        relevance: 5
+        position: 1
       },
       {
         url: "/some-unknown-source/test",
-        relevance: 5
+        position: 3
       }
     ],
     theme: "theme1",
@@ -44,18 +44,18 @@ const requetes = [
       {
         url: "/code-du-travail/l3221-3",
         title: "Article L3221-3",
-        relevance: 5
+        position: 5
       },
       {
         url: "/themes/theme1",
         title: "Thématique",
-        relevance: 1
+        position: 1
       },
       {
         url:
           "/fiche-ministere-travail/le-salaire-quelles-sont-les-modalites-de-paiement",
         title: "Le salaire : quelles sont les modalités de paiement ?",
-        relevance: 3
+        position: 3
       }
     ],
     theme: "theme2",

--- a/packages/code-du-travail-data/dataset/datafiller/fetch-requetes.js
+++ b/packages/code-du-travail-data/dataset/datafiller/fetch-requetes.js
@@ -1,6 +1,6 @@
 const fetch = require("node-fetch");
 
-const { sortRowRefsByRelevance, getVariants, decodeHTML } = require("./utils");
+const { sortRowRefsByPosition, getVariants, decodeHTML } = require("./utils");
 
 /*
  fetch raw datafiller requetes data, filter and sort properly
@@ -10,22 +10,6 @@ const DATAFILLER_URL =
   process.env.DATAFILLER_URL || "https://datafiller.num.social.gouv.fr";
 
 const RECORDS_URL = `${DATAFILLER_URL}/kinto/v1/buckets/datasets/collections/requetes/records?_sort=title`;
-/*
-
- {
-  id: "fzef-zefzef-zefzef-zefzef",
-  title: "some title",
-  variants: "variant 1\nvariant 2\nvariant 3",
-  refs:[{
-    url: "/fiche-service-public/titre-de-la-fiche,
-    relevance: 5
-  },{
-    url: "/fiche-service-public/titre-de-la-fiche-2,
-    relevance: 2
-  }]
- }
-
-*/
 
 // fetch title from remote url
 const getPageTitle = async url => {
@@ -80,7 +64,7 @@ const fetchAll = async () => {
       }))
   );
 
-  const sortedRows = await rows.map(sortRowRefsByRelevance);
+  const sortedRows = await rows.map(sortRowRefsByPosition);
 
   return sortedRows;
 };

--- a/packages/code-du-travail-data/dataset/datafiller/fetch-requetes.js
+++ b/packages/code-du-travail-data/dataset/datafiller/fetch-requetes.js
@@ -41,7 +41,7 @@ const fixRefsTitles = refs =>
     refs.map(async ref => ({
       url: ref.url,
       title: await getTitle(ref),
-      relevance: ref.relevance
+      position: ref.position
     }))
   );
 


### PR DESCRIPTION
Suite aux changement sur l'ordering des résultats des requêtes DF dans #2391, on doit ordonner de la même manière à la récupération