### PR TITLE
feat(outils): use css grids for multi line fields

### DIFF
--- a/packages/code-du-travail-frontend/.stylelintrc
+++ b/packages/code-du-travail-frontend/.stylelintrc
@@ -8,6 +8,14 @@
   ],
   "plugins": ["stylelint-order", "stylelint-config-rational-order/plugin"],
   "rules": {
+    "property-no-vendor-prefix": [
+      true,
+      ignoreProperties: ["/grid/"]
+    ],
+    "value-no-vendor-prefix": [
+      true,
+      ignoreValues: ["grid"]
+    ],
     "order/properties-order": [[], { severity: "warning" }],
     "plugin/rational-order": [
       true,

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/recherche.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/recherche.test.js.snap
@@ -1385,7 +1385,7 @@ exports[`<Recherche /> should render 1`] = `
               <div
                 class="c28"
               />
-              Vous n'avez pas trouvé ce que vous cherchiez ? Essayez …
+              Vous n’avez pas trouvé ce que vous cherchiez ? Essayez …
             </h3>
             <div
               class="c29"

--- a/packages/code-du-travail-frontend/pages/recherche.js
+++ b/packages/code-du-travail-frontend/pages/recherche.js
@@ -86,7 +86,7 @@ class SearchPage extends React.Component {
                     variant="primary"
                     stripped
                   >
-                    Vous n&apos;avez pas trouvé ce que vous cherchiez ? Essayez
+                    Vous n’avez pas trouvé ce que vous cherchiez ? Essayez
                     &hellip;
                   </Heading>
                   <StyledContent>

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/__tests__/__snapshots__/SansIndemniteLicenciement.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/__tests__/__snapshots__/SansIndemniteLicenciement.test.js.snap
@@ -39,22 +39,6 @@ exports[`<SansIndemniteLicenciement /> should render 1`] = `
   text-align: left;
 }
 
-.c4 {
-  margin-top: 3.2rem;
-  margin-bottom: 2rem;
-  color: #4d73b8;
-  font-weight: 600;
-  font-size: 1.8rem;
-  font-family: "Open Sans",sans-serif;
-}
-
-.c5 {
-  color: #f66663;
-  font-weight: 700;
-  font-size: 1.8rem;
-  white-space: pre-line;
-}
-
 .c7 {
   display: block;
   margin-bottom: 1.6rem;
@@ -79,6 +63,22 @@ exports[`<SansIndemniteLicenciement /> should render 1`] = `
 
 .c11 {
   margin: 1.6rem 0;
+}
+
+.c4 {
+  margin-top: 3.2rem;
+  margin-bottom: 2rem;
+  color: #4d73b8;
+  font-weight: 600;
+  font-size: 1.8rem;
+  font-family: "Open Sans",sans-serif;
+}
+
+.c5 {
+  color: #f66663;
+  font-weight: 700;
+  font-size: 1.8rem;
+  white-space: pre-line;
 }
 
 @media (max-width:600px) {

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/0016/CategoriePeriod.js
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/0016/CategoriePeriod.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { Field } from "react-final-form";
 import styled from "styled-components";
-import { theme } from "@socialgouv/react-ui";
+import { Input, theme } from "@socialgouv/react-ui";
 
-import { SectionTitle, Input } from "../../../common/stepStyles";
+import { SectionTitle } from "../../../common/stepStyles";
 import { InlineError } from "../../../common/ErrorField";
 import { isNumber } from "../../../common/validators";
 

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/0016/__tests__/__snapshots__/CategoriePeriod.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/0016/__tests__/__snapshots__/CategoriePeriod.test.js.snap
@@ -2,17 +2,91 @@
 
 exports[`<CategoryPeriod /> should render 1`] = `
 .c2 {
-  width: 10em;
-  text-align: right;
-  border-color: #bbcadf;
+  position: relative;
+  display: inline-block;
 }
 
-.c2::-webkit-outer-spin-button,
-.c2::-webkit-inner-spin-button {
+.c3 {
+  width: 100%;
+  height: 5.4rem;
+  padding: 0 2rem;
+  padding-right: 2rem;
+  color: #3e486e;
+  font-weight: normal;
+  font-size: 1.6rem;
+  font-family: "Open Sans",sans-serif;
+  font-style: normal;
+  line-height: inherit;
+  text-align: right;
+  background: #fff;
+  border: 1px solid transparent;
+  border-color: transparent;
+  border-radius: 0.6rem;
+  box-shadow: 0 1rem 2rem rgba(121,148,212,0.2);
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c3::-webkit-outer-spin-button,
+.c3::-webkit-inner-spin-button {
   margin: 0;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  display: block;
+  width: 3.2rem;
+  height: 3.2rem;
+  margin-right: -2rem;
+  color: rgba(0,0,0,0);
+  background-color: #9298af;
+  cursor: pointer;
+  opacity: 1;
+  -webkit-mask-image: url("data:image/svg+xml;,%3Csvg%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M20.947%207.601h1.601c1.472%200%202.521%201.198%202.521%202.669v2.306l-.001%2010.392c0%201.472-1.049%202.669-2.521%202.669H8.669A2.672%202.672%200%20016%2022.967l.001-12.697a2.672%202.672%200%20012.67-2.669h1.331V6h.999v1.601H20V6h.947v1.601zm1.6%2017.036c.883%200%201.454-.786%201.454-1.67v-10.33h-17L7%2022.967c0%20.884.785%201.67%201.668%201.67h13.879zm-15.548-13h17.002l.001-1.367c0-.883-.57-1.601-1.453-1.601h-1.6v1.068H20V8.669h-9v1.068h-1V8.669H8.669C7.786%208.669%207%209.387%207%2010.27v1.367zm9.677%206.277h-2.135a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203h-2.135v2.135h2.136v-2.135zm3.203%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068H19.88a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135H19.88v-2.135zm-8.54%208.541H9.204a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H9.204v2.135h2.136l-.001-2.135zm3.202%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068h-2.135a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135h-2.136v-2.135zm7.473%203.203H19.88a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H19.88v2.135h2.136v-2.135z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E");
+  mask-image: url("data:image/svg+xml;,%3Csvg%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M20.947%207.601h1.601c1.472%200%202.521%201.198%202.521%202.669v2.306l-.001%2010.392c0%201.472-1.049%202.669-2.521%202.669H8.669A2.672%202.672%200%20016%2022.967l.001-12.697a2.672%202.672%200%20012.67-2.669h1.331V6h.999v1.601H20V6h.947v1.601zm1.6%2017.036c.883%200%201.454-.786%201.454-1.67v-10.33h-17L7%2022.967c0%20.884.785%201.67%201.668%201.67h13.879zm-15.548-13h17.002l.001-1.367c0-.883-.57-1.601-1.453-1.601h-1.6v1.068H20V8.669h-9v1.068h-1V8.669H8.669C7.786%208.669%207%209.387%207%2010.27v1.367zm9.677%206.277h-2.135a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203h-2.135v2.135h2.136v-2.135zm3.203%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068H19.88a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135H19.88v-2.135zm-8.54%208.541H9.204a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H9.204v2.135h2.136l-.001-2.135zm3.202%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068h-2.135a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135h-2.136v-2.135zm7.473%203.203H19.88a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H19.88v2.135h2.136v-2.135z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E");
+}
+
+.c3:invalid {
+  border-color: #eb5757;
+}
+
+.c3::-webkit-input-placeholder {
+  color: #9298af;
+}
+
+.c3::-moz-placeholder {
+  color: #9298af;
+}
+
+.c3:-ms-input-placeholder {
+  color: #9298af;
+}
+
+.c3::placeholder {
+  color: #9298af;
+}
+
+.c3:focus {
+  border-color: #7994d4;
+}
+
+.c3:focus::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.c3:focus::-moz-placeholder {
+  color: transparent;
+}
+
+.c3:focus:-ms-input-placeholder {
+  color: transparent;
+}
+
+.c3:focus::placeholder {
+  color: transparent;
 }
 
 .c0 {
@@ -34,6 +108,19 @@ exports[`<CategoryPeriod /> should render 1`] = `
   flex-direction: column;
 }
 
+@media (max-width:600px) {
+  .c2 {
+    width: 100%;
+  }
+}
+
+@media (max-width:600px) {
+  .c3 {
+    padding: 0 1rem;
+    padding-right: 2rem;
+  }
+}
+
 <div>
   <h2
     class="c0"
@@ -47,13 +134,17 @@ exports[`<CategoryPeriod /> should render 1`] = `
       Période passée en tant que TAM ou employé
     </p>
     <div>
-      <input
+      <span
         class="c2"
-        min="0"
-        name="tamDuration"
-        type="number"
-        value=""
-      />
+      >
+        <input
+          class="c3"
+          min="0"
+          name="tamDuration"
+          type="number"
+          value=""
+        />
+      </span>
        
       mois
     </div>
@@ -65,13 +156,17 @@ exports[`<CategoryPeriod /> should render 1`] = `
       Période passée en tant que cadre
     </p>
     <div>
-      <input
+      <span
         class="c2"
-        min="0"
-        name="cadreDuration"
-        type="number"
-        value=""
-      />
+      >
+        <input
+          class="c3"
+          min="0"
+          name="cadreDuration"
+          type="number"
+          value=""
+        />
+      </span>
        
       mois
     </div>

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/0016/__tests__/__snapshots__/Result.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/0016/__tests__/__snapshots__/Result.test.js.snap
@@ -17,11 +17,6 @@ exports[`<Result /> should render 1`] = `
   white-space: pre-line;
 }
 
-.c8 {
-  display: block;
-  margin-bottom: 1.6rem;
-}
-
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -49,6 +44,11 @@ exports[`<Result /> should render 1`] = `
   margin-left: 1.6rem;
   color: #4d73b8;
   font-size: 1.8rem;
+}
+
+.c8 {
+  display: block;
+  margin-bottom: 1.6rem;
 }
 
 .c7 {

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/0016/__tests__/__snapshots__/Step.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/0016/__tests__/__snapshots__/Step.test.js.snap
@@ -1,9 +1,92 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Step /> should ask detail about categories 1`] = `
-.c10 {
+.c6 {
   position: relative;
   display: inline-block;
+}
+
+.c7 {
+  width: 100%;
+  height: 5.4rem;
+  padding: 0 2rem;
+  padding-right: 2rem;
+  color: #3e486e;
+  font-weight: normal;
+  font-size: 1.6rem;
+  font-family: "Open Sans",sans-serif;
+  font-style: normal;
+  line-height: inherit;
+  text-align: right;
+  background: #fff;
+  border: 1px solid transparent;
+  border-color: transparent;
+  border-radius: 0.6rem;
+  box-shadow: 0 1rem 2rem rgba(121,148,212,0.2);
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c7::-webkit-outer-spin-button,
+.c7::-webkit-inner-spin-button {
+  margin: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  display: block;
+  width: 3.2rem;
+  height: 3.2rem;
+  margin-right: -2rem;
+  color: rgba(0,0,0,0);
+  background-color: #9298af;
+  cursor: pointer;
+  opacity: 1;
+  -webkit-mask-image: url("data:image/svg+xml;,%3Csvg%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M20.947%207.601h1.601c1.472%200%202.521%201.198%202.521%202.669v2.306l-.001%2010.392c0%201.472-1.049%202.669-2.521%202.669H8.669A2.672%202.672%200%20016%2022.967l.001-12.697a2.672%202.672%200%20012.67-2.669h1.331V6h.999v1.601H20V6h.947v1.601zm1.6%2017.036c.883%200%201.454-.786%201.454-1.67v-10.33h-17L7%2022.967c0%20.884.785%201.67%201.668%201.67h13.879zm-15.548-13h17.002l.001-1.367c0-.883-.57-1.601-1.453-1.601h-1.6v1.068H20V8.669h-9v1.068h-1V8.669H8.669C7.786%208.669%207%209.387%207%2010.27v1.367zm9.677%206.277h-2.135a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203h-2.135v2.135h2.136v-2.135zm3.203%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068H19.88a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135H19.88v-2.135zm-8.54%208.541H9.204a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H9.204v2.135h2.136l-.001-2.135zm3.202%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068h-2.135a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135h-2.136v-2.135zm7.473%203.203H19.88a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H19.88v2.135h2.136v-2.135z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E");
+  mask-image: url("data:image/svg+xml;,%3Csvg%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M20.947%207.601h1.601c1.472%200%202.521%201.198%202.521%202.669v2.306l-.001%2010.392c0%201.472-1.049%202.669-2.521%202.669H8.669A2.672%202.672%200%20016%2022.967l.001-12.697a2.672%202.672%200%20012.67-2.669h1.331V6h.999v1.601H20V6h.947v1.601zm1.6%2017.036c.883%200%201.454-.786%201.454-1.67v-10.33h-17L7%2022.967c0%20.884.785%201.67%201.668%201.67h13.879zm-15.548-13h17.002l.001-1.367c0-.883-.57-1.601-1.453-1.601h-1.6v1.068H20V8.669h-9v1.068h-1V8.669H8.669C7.786%208.669%207%209.387%207%2010.27v1.367zm9.677%206.277h-2.135a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203h-2.135v2.135h2.136v-2.135zm3.203%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068H19.88a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135H19.88v-2.135zm-8.54%208.541H9.204a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H9.204v2.135h2.136l-.001-2.135zm3.202%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068h-2.135a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135h-2.136v-2.135zm7.473%203.203H19.88a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H19.88v2.135h2.136v-2.135z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E");
+}
+
+.c7:invalid {
+  border-color: #eb5757;
+}
+
+.c7::-webkit-input-placeholder {
+  color: #9298af;
+}
+
+.c7::-moz-placeholder {
+  color: #9298af;
+}
+
+.c7:-ms-input-placeholder {
+  color: #9298af;
+}
+
+.c7::placeholder {
+  color: #9298af;
+}
+
+.c7:focus {
+  border-color: #7994d4;
+}
+
+.c7:focus::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.c7:focus::-moz-placeholder {
+  color: transparent;
+}
+
+.c7:focus:-ms-input-placeholder {
+  color: transparent;
+}
+
+.c7:focus::placeholder {
+  color: transparent;
 }
 
 .c11 {
@@ -158,20 +241,6 @@ exports[`<Step /> should ask detail about categories 1`] = `
   background-color: #e4e8ef;
 }
 
-.c6 {
-  width: 10em;
-  text-align: right;
-  border-color: #bbcadf;
-}
-
-.c6::-webkit-outer-spin-button,
-.c6::-webkit-inner-spin-button {
-  margin: 0;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -204,7 +273,7 @@ exports[`<Step /> should ask detail about categories 1`] = `
   flex-direction: column;
 }
 
-.c7 {
+.c8 {
   display: block;
   margin-top: 2rem;
   margin-bottom: 1rem;
@@ -213,13 +282,13 @@ exports[`<Step /> should ask detail about categories 1`] = `
   cursor: pointer;
 }
 
-.c8 {
+.c9 {
   display: inline-block;
   margin-left: 1rem;
   color: #eb5757;
 }
 
-.c9 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -232,8 +301,15 @@ exports[`<Step /> should ask detail about categories 1`] = `
 }
 
 @media (max-width:600px) {
-  .c10 {
+  .c6 {
     width: 100%;
+  }
+}
+
+@media (max-width:600px) {
+  .c7 {
+    padding: 0 1rem;
+    padding-right: 2rem;
   }
 }
 
@@ -251,7 +327,7 @@ exports[`<Step /> should ask detail about categories 1`] = `
 }
 
 @media (max-width:600px) {
-  .c7 {
+  .c8 {
     font-size: 1.6rem;
   }
 }
@@ -340,13 +416,17 @@ exports[`<Step /> should ask detail about categories 1`] = `
       Période passée en tant que TAM ou employé
     </p>
     <div>
-      <input
+      <span
         class="c6"
-        min="0"
-        name="tamDuration"
-        type="number"
-        value=""
-      />
+      >
+        <input
+          class="c7"
+          min="0"
+          name="tamDuration"
+          type="number"
+          value=""
+        />
+      </span>
        
       mois
     </div>
@@ -358,34 +438,38 @@ exports[`<Step /> should ask detail about categories 1`] = `
       Période passée en tant que cadre
     </p>
     <div>
-      <input
+      <span
         class="c6"
-        min="0"
-        name="cadreDuration"
-        type="number"
-        value=""
-      />
+      >
+        <input
+          class="c7"
+          min="0"
+          name="cadreDuration"
+          type="number"
+          value=""
+        />
+      </span>
        
       mois
     </div>
   </label>
   <label
-    class="c7"
+    class="c8"
     for="2"
   >
     Quel est l'âge du salarié à la date du licenciement ?
     <span
       aria-label="champs obligatoire"
-      class="c8"
+      class="c9"
     >
       *
     </span>
   </label>
   <div
-    class="c9"
+    class="c10"
   >
     <span
-      class="c10"
+      class="c6"
     >
       <input
         class="c11"

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/0044/__tests__/__snapshots__/Result.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/0044/__tests__/__snapshots__/Result.test.js.snap
@@ -17,11 +17,6 @@ exports[`<Result /> should render 1`] = `
   white-space: pre-line;
 }
 
-.c8 {
-  display: block;
-  margin-bottom: 1.6rem;
-}
-
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -49,6 +44,11 @@ exports[`<Result /> should render 1`] = `
   margin-left: 1.6rem;
   color: #4d73b8;
   font-size: 1.8rem;
+}
+
+.c8 {
+  display: block;
+  margin-bottom: 1.6rem;
 }
 
 .c7 {

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/1486/steps/AncienneteETAMIC.js
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/1486/steps/AncienneteETAMIC.js
@@ -1,9 +1,9 @@
 import React from "react";
 import styled from "styled-components";
 import { Field } from "react-final-form";
-import { Toast, theme } from "@socialgouv/react-ui";
+import { Input, Toast, theme } from "@socialgouv/react-ui";
 
-import { Label, Input, SectionTitle } from "../../../../common/stepStyles";
+import { Label, SectionTitle } from "../../../../common/stepStyles";
 import { isNumber } from "../../../../common/validators";
 import { Error } from "../../../../common/ErrorField";
 import { YesNoQuestion } from "../../../../common/YesNoQuestion";

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/1486/steps/Salaire.js
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/1486/steps/Salaire.js
@@ -4,10 +4,9 @@ import { FieldArray } from "react-final-form-arrays";
 import styled from "styled-components";
 import { subMonths, format } from "date-fns";
 import frLocale from "date-fns/locale/fr";
-import { Table as UITable, Toast, theme } from "@socialgouv/react-ui";
+import { Input, Table as UITable, Toast, theme } from "@socialgouv/react-ui";
 
 import { parse } from "../../../../common/date";
-import { Input } from "../../../../common/stepStyles";
 import { InlineError } from "../../../../common/ErrorField";
 import { isNumber } from "../../../../common/validators";
 import { YesNoQuestion } from "../../../../common/YesNoQuestion";

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/1486/steps/__tests__/__snapshots__/AncienneteETAMIC.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/1486/steps/__tests__/__snapshots__/AncienneteETAMIC.test.js.snap
@@ -35,9 +35,92 @@ exports[`<AncienneteETAMIC /> asks to fill duration, indemnité and consideratio
   text-align: left;
 }
 
-.c13 {
+.c10 {
   position: relative;
   display: inline-block;
+}
+
+.c11 {
+  width: 100%;
+  height: 5.4rem;
+  padding: 0 2rem;
+  padding-right: 2rem;
+  color: #3e486e;
+  font-weight: normal;
+  font-size: 1.6rem;
+  font-family: "Open Sans",sans-serif;
+  font-style: normal;
+  line-height: inherit;
+  text-align: right;
+  background: #fff;
+  border: 1px solid transparent;
+  border-color: transparent;
+  border-radius: 0.6rem;
+  box-shadow: 0 1rem 2rem rgba(121,148,212,0.2);
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c11::-webkit-outer-spin-button,
+.c11::-webkit-inner-spin-button {
+  margin: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  display: block;
+  width: 3.2rem;
+  height: 3.2rem;
+  margin-right: -2rem;
+  color: rgba(0,0,0,0);
+  background-color: #9298af;
+  cursor: pointer;
+  opacity: 1;
+  -webkit-mask-image: url("data:image/svg+xml;,%3Csvg%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M20.947%207.601h1.601c1.472%200%202.521%201.198%202.521%202.669v2.306l-.001%2010.392c0%201.472-1.049%202.669-2.521%202.669H8.669A2.672%202.672%200%20016%2022.967l.001-12.697a2.672%202.672%200%20012.67-2.669h1.331V6h.999v1.601H20V6h.947v1.601zm1.6%2017.036c.883%200%201.454-.786%201.454-1.67v-10.33h-17L7%2022.967c0%20.884.785%201.67%201.668%201.67h13.879zm-15.548-13h17.002l.001-1.367c0-.883-.57-1.601-1.453-1.601h-1.6v1.068H20V8.669h-9v1.068h-1V8.669H8.669C7.786%208.669%207%209.387%207%2010.27v1.367zm9.677%206.277h-2.135a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203h-2.135v2.135h2.136v-2.135zm3.203%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068H19.88a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135H19.88v-2.135zm-8.54%208.541H9.204a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H9.204v2.135h2.136l-.001-2.135zm3.202%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068h-2.135a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135h-2.136v-2.135zm7.473%203.203H19.88a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H19.88v2.135h2.136v-2.135z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E");
+  mask-image: url("data:image/svg+xml;,%3Csvg%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M20.947%207.601h1.601c1.472%200%202.521%201.198%202.521%202.669v2.306l-.001%2010.392c0%201.472-1.049%202.669-2.521%202.669H8.669A2.672%202.672%200%20016%2022.967l.001-12.697a2.672%202.672%200%20012.67-2.669h1.331V6h.999v1.601H20V6h.947v1.601zm1.6%2017.036c.883%200%201.454-.786%201.454-1.67v-10.33h-17L7%2022.967c0%20.884.785%201.67%201.668%201.67h13.879zm-15.548-13h17.002l.001-1.367c0-.883-.57-1.601-1.453-1.601h-1.6v1.068H20V8.669h-9v1.068h-1V8.669H8.669C7.786%208.669%207%209.387%207%2010.27v1.367zm9.677%206.277h-2.135a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203h-2.135v2.135h2.136v-2.135zm3.203%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068H19.88a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135H19.88v-2.135zm-8.54%208.541H9.204a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H9.204v2.135h2.136l-.001-2.135zm3.202%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068h-2.135a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135h-2.136v-2.135zm7.473%203.203H19.88a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H19.88v2.135h2.136v-2.135z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E");
+}
+
+.c11:invalid {
+  border-color: #eb5757;
+}
+
+.c11::-webkit-input-placeholder {
+  color: #9298af;
+}
+
+.c11::-moz-placeholder {
+  color: #9298af;
+}
+
+.c11:-ms-input-placeholder {
+  color: #9298af;
+}
+
+.c11::placeholder {
+  color: #9298af;
+}
+
+.c11:focus {
+  border-color: #7994d4;
+}
+
+.c11:focus::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.c11:focus::-moz-placeholder {
+  color: transparent;
+}
+
+.c11:focus:-ms-input-placeholder {
+  color: transparent;
+}
+
+.c11:focus::placeholder {
+  color: transparent;
 }
 
 .c14 {
@@ -188,20 +271,6 @@ exports[`<AncienneteETAMIC /> asks to fill duration, indemnité and consideratio
   display: block;
 }
 
-.c10 {
-  width: 10em;
-  text-align: right;
-  border-color: #bbcadf;
-}
-
-.c10::-webkit-outer-spin-button,
-.c10::-webkit-inner-spin-button {
-  margin: 0;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
 .c9 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -252,7 +321,7 @@ exports[`<AncienneteETAMIC /> asks to fill duration, indemnité and consideratio
   cursor: default;
 }
 
-.c11 {
+.c12 {
   display: block;
   margin-top: 2rem;
   margin-bottom: 1rem;
@@ -267,7 +336,7 @@ exports[`<AncienneteETAMIC /> asks to fill duration, indemnité and consideratio
   color: #eb5757;
 }
 
-.c12 {
+.c13 {
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -286,8 +355,15 @@ exports[`<AncienneteETAMIC /> asks to fill duration, indemnité and consideratio
 }
 
 @media (max-width:600px) {
-  .c13 {
+  .c10 {
     width: 100%;
+  }
+}
+
+@media (max-width:600px) {
+  .c11 {
+    padding: 0 1rem;
+    padding-right: 2rem;
   }
 }
 
@@ -305,13 +381,13 @@ exports[`<AncienneteETAMIC /> asks to fill duration, indemnité and consideratio
 }
 
 @media (max-width:600px) {
-  .c11 {
+  .c12 {
     font-size: 1.6rem;
   }
 }
 
 @media (max-width:600px) {
-  .c12 {
+  .c13 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -405,13 +481,17 @@ exports[`<AncienneteETAMIC /> asks to fill duration, indemnité and consideratio
   >
     Durée des contrats de travail précédents (en mois)
   </label>
-  <input
+  <span
     class="c10"
-    id="duration"
-    name="brancheContrat.duration"
-    type="number"
-    value="3"
-  />
+  >
+    <input
+      class="c11"
+      id="duration"
+      name="brancheContrat.duration"
+      type="number"
+      value="3"
+    />
+  </span>
   <div
     class="c1 c2"
   >
@@ -423,16 +503,16 @@ exports[`<AncienneteETAMIC /> asks to fill duration, indemnité and consideratio
     </div>
   </div>
   <label
-    class="c11"
+    class="c12"
     for="currency-1"
   >
     Indemnité de licenciement précédemment perçue
   </label>
   <div
-    class="c12"
+    class="c13"
   >
     <span
-      class="c13"
+      class="c10"
     >
       <input
         class="c14"

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/1486/steps/__tests__/__snapshots__/Result.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/1486/steps/__tests__/__snapshots__/Result.test.js.snap
@@ -51,11 +51,6 @@ exports[`<Result /> renders conventionnal indemnite with warning toast 1`] = `
   white-space: pre-line;
 }
 
-.c8 {
-  display: block;
-  margin-bottom: 1.6rem;
-}
-
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -83,6 +78,11 @@ exports[`<Result /> renders conventionnal indemnite with warning toast 1`] = `
   margin-left: 1.6rem;
   color: #4d73b8;
   font-size: 1.8rem;
+}
+
+.c8 {
+  display: block;
+  margin-bottom: 1.6rem;
 }
 
 .c7 {
@@ -438,11 +438,6 @@ exports[`<Result /> renders legal indemnite 1`] = `
   white-space: pre-line;
 }
 
-.c8 {
-  display: block;
-  margin-bottom: 1.6rem;
-}
-
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -470,6 +465,11 @@ exports[`<Result /> renders legal indemnite 1`] = `
   margin-left: 1.6rem;
   color: #4d73b8;
   font-size: 1.8rem;
+}
+
+.c8 {
+  display: block;
+  margin-bottom: 1.6rem;
 }
 
 .c7 {

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/1486/steps/__tests__/__snapshots__/Salaire.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/1486/steps/__tests__/__snapshots__/Salaire.test.js.snap
@@ -598,6 +598,94 @@ exports[`<Salaire /> renders a table of fields of type number 1`] = `
   text-align: left;
 }
 
+.c13 {
+  position: relative;
+  display: inline-block;
+}
+
+.c15 {
+  width: 100%;
+  height: 5.4rem;
+  padding: 0 2rem;
+  padding-right: 2rem;
+  color: #3e486e;
+  font-weight: normal;
+  font-size: 1.6rem;
+  font-family: "Open Sans",sans-serif;
+  font-style: normal;
+  line-height: inherit;
+  text-align: right;
+  background: #fff;
+  border: 1px solid transparent;
+  border-color: transparent;
+  border-radius: 0.6rem;
+  box-shadow: 0 1rem 2rem rgba(121,148,212,0.2);
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c15::-webkit-outer-spin-button,
+.c15::-webkit-inner-spin-button {
+  margin: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c15::-webkit-calendar-picker-indicator {
+  display: block;
+  width: 3.2rem;
+  height: 3.2rem;
+  margin-right: -2rem;
+  color: rgba(0,0,0,0);
+  background-color: #9298af;
+  cursor: pointer;
+  opacity: 1;
+  -webkit-mask-image: url("data:image/svg+xml;,%3Csvg%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M20.947%207.601h1.601c1.472%200%202.521%201.198%202.521%202.669v2.306l-.001%2010.392c0%201.472-1.049%202.669-2.521%202.669H8.669A2.672%202.672%200%20016%2022.967l.001-12.697a2.672%202.672%200%20012.67-2.669h1.331V6h.999v1.601H20V6h.947v1.601zm1.6%2017.036c.883%200%201.454-.786%201.454-1.67v-10.33h-17L7%2022.967c0%20.884.785%201.67%201.668%201.67h13.879zm-15.548-13h17.002l.001-1.367c0-.883-.57-1.601-1.453-1.601h-1.6v1.068H20V8.669h-9v1.068h-1V8.669H8.669C7.786%208.669%207%209.387%207%2010.27v1.367zm9.677%206.277h-2.135a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203h-2.135v2.135h2.136v-2.135zm3.203%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068H19.88a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135H19.88v-2.135zm-8.54%208.541H9.204a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H9.204v2.135h2.136l-.001-2.135zm3.202%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068h-2.135a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135h-2.136v-2.135zm7.473%203.203H19.88a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H19.88v2.135h2.136v-2.135z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E");
+  mask-image: url("data:image/svg+xml;,%3Csvg%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M20.947%207.601h1.601c1.472%200%202.521%201.198%202.521%202.669v2.306l-.001%2010.392c0%201.472-1.049%202.669-2.521%202.669H8.669A2.672%202.672%200%20016%2022.967l.001-12.697a2.672%202.672%200%20012.67-2.669h1.331V6h.999v1.601H20V6h.947v1.601zm1.6%2017.036c.883%200%201.454-.786%201.454-1.67v-10.33h-17L7%2022.967c0%20.884.785%201.67%201.668%201.67h13.879zm-15.548-13h17.002l.001-1.367c0-.883-.57-1.601-1.453-1.601h-1.6v1.068H20V8.669h-9v1.068h-1V8.669H8.669C7.786%208.669%207%209.387%207%2010.27v1.367zm9.677%206.277h-2.135a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203h-2.135v2.135h2.136v-2.135zm3.203%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068H19.88a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135H19.88v-2.135zm-8.54%208.541H9.204a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H9.204v2.135h2.136l-.001-2.135zm3.202%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068h-2.135a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135h-2.136v-2.135zm7.473%203.203H19.88a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H19.88v2.135h2.136v-2.135z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E");
+}
+
+.c15:invalid {
+  border-color: #eb5757;
+}
+
+.c15::-webkit-input-placeholder {
+  color: #9298af;
+}
+
+.c15::-moz-placeholder {
+  color: #9298af;
+}
+
+.c15:-ms-input-placeholder {
+  color: #9298af;
+}
+
+.c15::placeholder {
+  color: #9298af;
+}
+
+.c15:focus {
+  border-color: #7994d4;
+}
+
+.c15:focus::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.c15:focus::-moz-placeholder {
+  color: transparent;
+}
+
+.c15:focus:-ms-input-placeholder {
+  color: transparent;
+}
+
+.c15:focus::placeholder {
+  color: transparent;
+}
+
 .c6 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -695,20 +783,9 @@ exports[`<Salaire /> renders a table of fields of type number 1`] = `
   text-align: left;
 }
 
-.c13 {
-  width: 10em;
-  text-align: right;
-  border-color: #bbcadf;
+.c14 {
   padding-right: 1.6rem;
   text-align: right;
-}
-
-.c13::-webkit-outer-spin-button,
-.c13::-webkit-inner-spin-button {
-  margin: 0;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
 }
 
 .c12 {
@@ -717,7 +794,7 @@ exports[`<Salaire /> renders a table of fields of type number 1`] = `
   margin-right: 2rem;
 }
 
-.c14 {
+.c16 {
   position: absolute;
   top: 50%;
   right: 0.25rem;
@@ -749,6 +826,19 @@ exports[`<Salaire /> renders a table of fields of type number 1`] = `
 @media print {
   .c0 {
     display: none;
+  }
+}
+
+@media (max-width:600px) {
+  .c13 {
+    width: 100%;
+  }
+}
+
+@media (max-width:600px) {
+  .c15 {
+    padding: 0 1rem;
+    padding-right: 2rem;
   }
 }
 
@@ -916,16 +1006,20 @@ exports[`<Salaire /> renders a table of fields of type number 1`] = `
               <div
                 class="c12"
               >
-                <input
-                  class="stepStyles__Input-sc-1cym743-0 c13"
-                  id="salaire0"
-                  name="brancheNewIrregularSalaire[0].salary"
-                  type="number"
-                  value=""
-                />
+                <span
+                  class="c13 c14"
+                >
+                  <input
+                    class="c15"
+                    id="salaire0"
+                    name="brancheNewIrregularSalaire[0].salary"
+                    type="number"
+                    value=""
+                  />
+                </span>
                 <span
                   aria-hidden="true"
-                  class="c14"
+                  class="c16"
                 >
                   €
                 </span>
@@ -944,16 +1038,20 @@ exports[`<Salaire /> renders a table of fields of type number 1`] = `
               <div
                 class="c12"
               >
-                <input
-                  class="stepStyles__Input-sc-1cym743-0 c13"
-                  id="salaire1"
-                  name="brancheNewIrregularSalaire[1].salary"
-                  type="number"
-                  value=""
-                />
+                <span
+                  class="c13 c14"
+                >
+                  <input
+                    class="c15"
+                    id="salaire1"
+                    name="brancheNewIrregularSalaire[1].salary"
+                    type="number"
+                    value=""
+                  />
+                </span>
                 <span
                   aria-hidden="true"
-                  class="c14"
+                  class="c16"
                 >
                   €
                 </span>
@@ -1000,6 +1098,94 @@ exports[`<Salaire /> renders an input field of type number 1`] = `
   align-self: center;
   padding: 1rem 1.6rem;
   text-align: left;
+}
+
+.c9 {
+  position: relative;
+  display: inline-block;
+}
+
+.c11 {
+  width: 100%;
+  height: 5.4rem;
+  padding: 0 2rem;
+  padding-right: 2rem;
+  color: #3e486e;
+  font-weight: normal;
+  font-size: 1.6rem;
+  font-family: "Open Sans",sans-serif;
+  font-style: normal;
+  line-height: inherit;
+  text-align: right;
+  background: #fff;
+  border: 1px solid transparent;
+  border-color: transparent;
+  border-radius: 0.6rem;
+  box-shadow: 0 1rem 2rem rgba(121,148,212,0.2);
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c11::-webkit-outer-spin-button,
+.c11::-webkit-inner-spin-button {
+  margin: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  display: block;
+  width: 3.2rem;
+  height: 3.2rem;
+  margin-right: -2rem;
+  color: rgba(0,0,0,0);
+  background-color: #9298af;
+  cursor: pointer;
+  opacity: 1;
+  -webkit-mask-image: url("data:image/svg+xml;,%3Csvg%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M20.947%207.601h1.601c1.472%200%202.521%201.198%202.521%202.669v2.306l-.001%2010.392c0%201.472-1.049%202.669-2.521%202.669H8.669A2.672%202.672%200%20016%2022.967l.001-12.697a2.672%202.672%200%20012.67-2.669h1.331V6h.999v1.601H20V6h.947v1.601zm1.6%2017.036c.883%200%201.454-.786%201.454-1.67v-10.33h-17L7%2022.967c0%20.884.785%201.67%201.668%201.67h13.879zm-15.548-13h17.002l.001-1.367c0-.883-.57-1.601-1.453-1.601h-1.6v1.068H20V8.669h-9v1.068h-1V8.669H8.669C7.786%208.669%207%209.387%207%2010.27v1.367zm9.677%206.277h-2.135a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203h-2.135v2.135h2.136v-2.135zm3.203%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068H19.88a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135H19.88v-2.135zm-8.54%208.541H9.204a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H9.204v2.135h2.136l-.001-2.135zm3.202%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068h-2.135a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135h-2.136v-2.135zm7.473%203.203H19.88a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H19.88v2.135h2.136v-2.135z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E");
+  mask-image: url("data:image/svg+xml;,%3Csvg%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M20.947%207.601h1.601c1.472%200%202.521%201.198%202.521%202.669v2.306l-.001%2010.392c0%201.472-1.049%202.669-2.521%202.669H8.669A2.672%202.672%200%20016%2022.967l.001-12.697a2.672%202.672%200%20012.67-2.669h1.331V6h.999v1.601H20V6h.947v1.601zm1.6%2017.036c.883%200%201.454-.786%201.454-1.67v-10.33h-17L7%2022.967c0%20.884.785%201.67%201.668%201.67h13.879zm-15.548-13h17.002l.001-1.367c0-.883-.57-1.601-1.453-1.601h-1.6v1.068H20V8.669h-9v1.068h-1V8.669H8.669C7.786%208.669%207%209.387%207%2010.27v1.367zm9.677%206.277h-2.135a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203h-2.135v2.135h2.136v-2.135zm3.203%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068H19.88a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135H19.88v-2.135zm-8.54%208.541H9.204a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H9.204v2.135h2.136l-.001-2.135zm3.202%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068h-2.135a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135h-2.136v-2.135zm7.473%203.203H19.88a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H19.88v2.135h2.136v-2.135z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E");
+}
+
+.c11:invalid {
+  border-color: #eb5757;
+}
+
+.c11::-webkit-input-placeholder {
+  color: #9298af;
+}
+
+.c11::-moz-placeholder {
+  color: #9298af;
+}
+
+.c11:-ms-input-placeholder {
+  color: #9298af;
+}
+
+.c11::placeholder {
+  color: #9298af;
+}
+
+.c11:focus {
+  border-color: #7994d4;
+}
+
+.c11:focus::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.c11:focus::-moz-placeholder {
+  color: transparent;
+}
+
+.c11:focus:-ms-input-placeholder {
+  color: transparent;
+}
+
+.c11:focus::placeholder {
+  color: transparent;
 }
 
 .c6 {
@@ -1094,20 +1280,9 @@ exports[`<Salaire /> renders an input field of type number 1`] = `
   margin-top: 2rem;
 }
 
-.c9 {
-  width: 10em;
-  text-align: right;
-  border-color: #bbcadf;
+.c10 {
   padding-right: 1.6rem;
   text-align: right;
-}
-
-.c9::-webkit-outer-spin-button,
-.c9::-webkit-inner-spin-button {
-  margin: 0;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
 }
 
 .c8 {
@@ -1116,7 +1291,7 @@ exports[`<Salaire /> renders an input field of type number 1`] = `
   margin-right: 2rem;
 }
 
-.c10 {
+.c12 {
   position: absolute;
   top: 50%;
   right: 0.25rem;
@@ -1129,6 +1304,19 @@ exports[`<Salaire /> renders an input field of type number 1`] = `
 @media print {
   .c0 {
     display: none;
+  }
+}
+
+@media (max-width:600px) {
+  .c9 {
+    width: 100%;
+  }
+}
+
+@media (max-width:600px) {
+  .c11 {
+    padding: 0 1rem;
+    padding-right: 2rem;
   }
 }
 
@@ -1270,15 +1458,19 @@ exports[`<Salaire /> renders an input field of type number 1`] = `
   <div
     class="c8"
   >
-    <input
-      class="stepStyles__Input-sc-1cym743-0 c9"
-      name="brancheNewRegularSalaire"
-      type="number"
-      value=""
-    />
+    <span
+      class="c9 c10"
+    >
+      <input
+        class="c11"
+        name="brancheNewRegularSalaire"
+        type="number"
+        value=""
+      />
+    </span>
     <span
       aria-hidden="true"
-      class="c10"
+      class="c12"
     >
       €
     </span>

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/2120/__tests__/__snapshots__/Result.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/2120/__tests__/__snapshots__/Result.test.js.snap
@@ -17,11 +17,6 @@ exports[`<Result /> should render 1`] = `
   white-space: pre-line;
 }
 
-.c8 {
-  display: block;
-  margin-bottom: 1.6rem;
-}
-
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -49,6 +44,11 @@ exports[`<Result /> should render 1`] = `
   margin-left: 1.6rem;
   color: #4d73b8;
   font-size: 1.8rem;
+}
+
+.c8 {
+  display: block;
+  margin-bottom: 1.6rem;
 }
 
 .c7 {

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/3043/__tests__/__snapshots__/Result.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/ccn/3043/__tests__/__snapshots__/Result.test.js.snap
@@ -17,11 +17,6 @@ exports[`<Result /> should render 1`] = `
   white-space: pre-line;
 }
 
-.c8 {
-  display: block;
-  margin-bottom: 1.6rem;
-}
-
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -49,6 +44,11 @@ exports[`<Result /> should render 1`] = `
   margin-left: 1.6rem;
   color: #4d73b8;
   font-size: 1.8rem;
+}
+
+.c8 {
+  display: block;
+  margin-bottom: 1.6rem;
 }
 
 .c7 {

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/components/AbsencePeriods.js
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/components/AbsencePeriods.js
@@ -3,144 +3,15 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import { Field } from "react-final-form";
 import { FieldArray } from "react-final-form-arrays";
-import { OnChange } from "react-final-form-listeners";
-import { Input, Select, Text, theme } from "@socialgouv/react-ui";
-import { Error } from "../../common/ErrorField";
-import { isNumber } from "../../common/validators";
+import { Input, Label, Select, Text, theme } from "@socialgouv/react-ui";
+
 import { AddButton, DelButton } from "../../common/Buttons";
+import { Error } from "../../common/ErrorField";
+import { MultiFieldRow } from "../../common/MultiFieldRow";
 import { Question } from "../../common/Question";
-import {
-  Row,
-  MobileOnlyCell,
-  DesktopOnly,
-  CellHeader,
-} from "../../common/stepStyles";
+import { isNumber } from "../../common/validators";
 
-function AbsencePeriods({ name, visible = true, onChange }) {
-  return (
-    <FieldArray name={name}>
-      {({ fields }) => (
-        <>
-          {visible && (
-            <>
-              <p>
-                Les congés payés, le congé de maternité ou d&apos;adoption, le
-                congé de présence parental ,l&apos;arrêt de travail lié à un
-                accident du travail ou une maladie professionnelle, le congé
-                individuel de formation (CIF), le congé de solidarité
-                internationale, le congé de solidarité familiale et le stage de
-                fin d&apos;étude de plus de 2 mois sont déjà prises en compte
-                dans l&apos;ancienneté et ne sont pas des périodes à renseigner
-                ci-après :
-              </p>
-              <Question as="p">
-                Quels sont le motif et la durée de ces absences
-                prolongées&nbsp;?
-              </Question>
-              <Row as={DesktopOnly}>
-                <CellHeader as={MotifCell}>Motif</CellHeader>
-                <CellHeader as={DurationCell}>Durée (en mois)</CellHeader>
-              </Row>
-            </>
-          )}
-          {fields.map((name, index) => (
-            <Row key={name}>
-              <MobileOnlyCell>
-                <Text variant="secondary" fontSize="hsmall">
-                  Période {index + 1}
-                </Text>
-                <DelButton small onClick={() => fields.remove(index)}>
-                  Supprimer
-                </DelButton>
-              </MobileOnlyCell>
-              <MotifCell>
-                <CellHeader as={MobileOnlyCell}>Motif</CellHeader>
-                <Field name={`${name}.type`} component={Select}>
-                  {motifs.map(({ label }) => (
-                    <option key={label}>{label}</option>
-                  ))}
-                </Field>
-              </MotifCell>
-              <DurationCell>
-                <CellHeader as={MobileOnlyCell}>Durée (en mois)</CellHeader>
-                <Field
-                  name={`${name}.duration`}
-                  validate={isNumber}
-                  subscription={{
-                    value: true,
-                    error: true,
-                    touched: true,
-                    invalid: true,
-                  }}
-                  render={({ input, meta: { touched, error, invalid } }) => (
-                    <>
-                      <Input
-                        {...input}
-                        type="number"
-                        invalid={touched && invalid}
-                      />
-                      {error && touched && invalid && <Error>{error}</Error>}
-                    </>
-                  )}
-                />
-              </DurationCell>
-              <DesktopOnly>
-                <DelButton onClick={() => fields.remove(index)}>
-                  Supprimer
-                </DelButton>
-              </DesktopOnly>
-            </Row>
-          ))}
-          {visible && (
-            <AddButton
-              onClick={() =>
-                fields.push({
-                  type: "Absence pour maladie non professionnelle",
-                  duration: null,
-                })
-              }
-            >
-              Ajouter une période
-            </AddButton>
-          )}
-          {onChange && (
-            <OnChange name={name}>
-              {(values) => {
-                onChange(values);
-              }}
-            </OnChange>
-          )}
-        </>
-      )}
-    </FieldArray>
-  );
-}
-
-AbsencePeriods.propTypes = {
-  name: PropTypes.string.isRequired,
-};
-
-export { AbsencePeriods };
-
-const { spacings } = theme;
-
-const MotifCell = styled.div`
-  flex: 0 1 35rem;
-  margin-right: ${spacings.medium};
-  @media (max-width: ${theme.breakpoints.mobile}) {
-    flex-basis: 100%;
-    margin-right: 0;
-  }
-`;
-const DurationCell = styled.div`
-  margin-right: ${spacings.medium};
-  @media (max-width: ${theme.breakpoints.mobile}) {
-    flex-basis: 100%;
-    margin-right: 0;
-  }
-`;
-
-export const motifs = [
+export const MOTIFS = [
   { label: "Absence pour maladie non professionnelle", value: 1.0 },
   { label: "Arrêt maladie lié à un accident de trajet", value: 1.0 },
   { label: "Congé sabbatique", value: 1.0 },
@@ -152,3 +23,135 @@ export const motifs = [
   { label: "Maladie d'origine non professionnelle", value: 1.0 },
   { label: "Congé de paternité", value: 1.0 },
 ];
+
+export const AbsencePeriods = ({ name }) => (
+  <FieldArray name={name}>
+    {({ fields }) =>
+      fields.length > 0 && (
+        <>
+          <p>
+            Les congés payés, le congé de maternité ou d&apos;adoption, le congé
+            de présence parental ,l&apos;arrêt de travail lié à un accident du
+            travail ou une maladie professionnelle, le congé individuel de
+            formation (CIF), le congé de solidarité internationale, le congé de
+            solidarité familiale et le stage de fin d&apos;étude de plus de 2
+            mois sont déjà prises en compte dans l&apos;ancienneté et ne sont
+            pas des périodes à renseigner ci-après :
+          </p>
+          <Question as="p">
+            Quels sont le motif et la durée de ces absences prolongées&nbsp;?
+          </Question>
+          {fields.map((name, index) => (
+            <RelativeDiv key={name}>
+              <RowTitle>
+                <Text variant="secondary" fontSize="hsmall">
+                  Absence {index + 1}
+                </Text>
+              </RowTitle>
+              <MultiFieldRow
+                gridRows={["auto", "auto"]}
+                gridColumns={["2fr", "1fr", "13rem"]}
+                emptyCells={[5]}
+              >
+                <Label htmlFor={`${name}.type`}>Motif</Label>
+                <FieldWrapper>
+                  <Field
+                    name={`${name}.type`}
+                    id={`${name}.type`}
+                    component={StyledSelect}
+                  >
+                    {MOTIFS.map(({ label }) => (
+                      <option key={label}>{label}</option>
+                    ))}
+                  </Field>
+                </FieldWrapper>
+                <Label htmlFor={`${name}.duration`}>Durée (en mois)</Label>
+                <div>
+                  <Field
+                    name={`${name}.duration`}
+                    validate={isNumber}
+                    subscription={{
+                      value: true,
+                      error: true,
+                      touched: true,
+                      invalid: true,
+                    }}
+                    render={({ input, meta: { touched, error, invalid } }) => (
+                      <>
+                        <Input
+                          {...input}
+                          id={`${name}.duration`}
+                          type="number"
+                          invalid={touched && invalid}
+                        />
+                        {error && touched && invalid && (
+                          <StyledError>{error}</StyledError>
+                        )}
+                      </>
+                    )}
+                  />
+                </div>
+                {fields.length > 1 && (
+                  <StyledDelButton onClick={() => fields.remove(index)}>
+                    Supprimer
+                  </StyledDelButton>
+                )}
+              </MultiFieldRow>
+            </RelativeDiv>
+          ))}
+          <AddButton
+            onClick={() =>
+              fields.push({
+                type: "Absence pour maladie non professionnelle",
+                duration: null,
+              })
+            }
+          >
+            Ajouter une absence
+          </AddButton>
+        </>
+      )
+    }
+  </FieldArray>
+);
+
+AbsencePeriods.propTypes = {
+  name: PropTypes.string.isRequired,
+};
+
+const { breakpoints, spacings } = theme;
+
+const RelativeDiv = styled.div`
+  position: relative;
+`;
+
+const RowTitle = styled.div`
+  margin-bottom: ${spacings.base};
+  padding-top: ${spacings.small};
+`;
+
+const StyledSelect = styled(Select)`
+  display: flex;
+`;
+
+const FieldWrapper = styled.div`
+  margin-right: ${spacings.base};
+  @media (max-width: ${breakpoints.mobile}) {
+    margin-right: 0;
+    margin-bottom: ${spacings.base};
+  }
+`;
+
+const StyledError = styled(Error)`
+  margin-bottom: 0;
+`;
+
+const StyledDelButton = styled(DelButton)`
+  margin-top: ${spacings.xsmall};
+  @media (max-width: ${breakpoints.mobile}) {
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin-top: 0;
+  }
+`;

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/components/FormulaDetails.js
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/components/FormulaDetails.js
@@ -5,7 +5,6 @@ import styled from "styled-components";
 import MathJax from "react-mathjax-preview";
 
 import { ErrorBoundary } from "../../../common/ErrorBoundary";
-import { Summary } from "../../common/stepStyles";
 
 function FormulaDetails({ infoCalcul: { labels, formula } }) {
   return (
@@ -39,6 +38,11 @@ FormulaDetails.propTypes = {
 };
 
 const { spacings, fonts } = theme;
+
+export const Summary = styled.summary`
+  display: block;
+  margin-bottom: ${spacings.base};
+`;
 
 const Details = styled.details`
   margin-top: ${spacings.medium};

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/components/Primes.js
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/components/Primes.js
@@ -4,7 +4,9 @@ import { Field } from "react-final-form";
 import styled from "styled-components";
 import { FieldArray } from "react-final-form-arrays";
 import { OnChange } from "react-final-form-listeners";
-import { Button, icons, Input, theme } from "@socialgouv/react-ui";
+import { icons, Input, theme } from "@socialgouv/react-ui";
+
+import { AddButton, DelButton } from "../../common/Buttons";
 import { InlineError } from "../../common/ErrorField";
 import { isNumber } from "../../common/validators";
 
@@ -44,16 +46,13 @@ function Primes({ name, visible = true, onChange }) {
                   </div>
                 )}
               />
-              <DelButton variant="flat" onClick={() => fields.remove(index)}>
+              <StyledDelButton onClick={() => fields.remove(index)}>
                 Supprimer
-              </DelButton>
+              </StyledDelButton>
             </Row>
           ))}
           {visible && (
-            <AddButton
-              variant="link"
-              onClick={() => fields.push({ prime: null })}
-            >
+            <AddButton onClick={() => fields.push({ prime: null })}>
               Ajouter une prime
             </AddButton>
           )}
@@ -74,15 +73,11 @@ const { spacings } = theme;
 
 const Row = styled.div`
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: flex-start;
   margin-bottom: ${spacings.tiny};
 `;
 
-const DelButton = styled(Button).attrs(() => ({ type: "button" }))`
-  margin-left: ${spacings.medium};
-`;
-
-const AddButton = styled(Button).attrs(() => ({ type: "button" }))`
-  margin: ${spacings.medium} 0;
+const StyledDelButton = styled(DelButton)`
+  margin-left: ${spacings.base};
 `;

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/components/SalaireTempsPartiel.js
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/components/SalaireTempsPartiel.js
@@ -2,169 +2,163 @@ import React from "react";
 import styled from "styled-components";
 import { Field } from "react-final-form";
 import { FieldArray } from "react-final-form-arrays";
-import { OnChange } from "react-final-form-listeners";
-import { Input, Select, Text, icons, theme } from "@socialgouv/react-ui";
+import { icons, Input, Label, Select, Text, theme } from "@socialgouv/react-ui";
+
 import { AddButton, DelButton } from "../../common/Buttons";
 import { Error } from "../../common/ErrorField";
+import { MultiFieldRow } from "../../common/MultiFieldRow";
 import { Question } from "../../common/Question";
 import { isNumber } from "../../common/validators";
-import {
-  Row,
-  MobileOnlyCell,
-  DesktopOnly,
-  CellHeader,
-} from "../../common/stepStyles";
-
-const mobileMediaQuery = `(max-width: ${theme.breakpoints.mobile})`;
-
-function SalaireTempsPartiel({ name, visible = true, onChange }) {
-  return (
-    <FieldArray name={name}>
-      {({ fields }) => (
-        <>
-          {visible && (
-            <>
-              <Question>
-                Quels ont été les durées et les salaires des périodes à temps
-                plein et à temps partiel&nbsp;?
-              </Question>
-              <Row as={DesktopOnly}>
-                <CellHeader as={CellType}>Type de durée de travail</CellHeader>
-                <CellHeader as={CellDuration}>Durée (en mois)</CellHeader>
-                <CellHeader>Rémunération</CellHeader>
-              </Row>
-            </>
-          )}
-          {fields.map((name, index) => (
-            <Row key={name}>
-              <MobileOnlyCell>
-                <Text variant="secondary" fontSize="hsmall">
-                  Période {index + 1}
-                </Text>
-                <DelButton small onClick={() => fields.remove(index)}>
-                  Supprimer
-                </DelButton>
-              </MobileOnlyCell>
-              <CellType>
-                <CellHeader as={MobileOnlyCell}>
-                  Type de durée de travail
-                </CellHeader>
-                <Field name={`${name}.type`}>
-                  {({ input }) => (
-                    <Select {...input}>
-                      {typePeriod.map((item) => (
-                        <option key={item}>{item}</option>
-                      ))}
-                    </Select>
-                  )}
-                </Field>
-              </CellType>
-              <CellDuration>
-                <CellHeader as={MobileOnlyCell}>Durée (en mois)</CellHeader>
-                <Field
-                  name={`${name}.duration`}
-                  validate={isNumber}
-                  subscription={{
-                    value: true,
-                    error: true,
-                    touched: true,
-                    invalid: true,
-                  }}
-                  render={({ input, meta: { touched, error, invalid } }) => (
-                    <>
-                      <Input
-                        {...input}
-                        type="number"
-                        invalid={touched && invalid}
-                      />
-                      {error && touched && invalid ? (
-                        <Error>{error}</Error>
-                      ) : null}
-                    </>
-                  )}
-                />
-              </CellDuration>
-              <CellRemuneration>
-                <CellHeader as={MobileOnlyCell}>Rémunération</CellHeader>
-                <Field
-                  name={`${name}.salary`}
-                  validate={isNumber}
-                  subscription={{
-                    value: true,
-                    error: true,
-                    touched: true,
-                    invalid: true,
-                  }}
-                  render={({ input, meta: { touched, error, invalid } }) => (
-                    <>
-                      <Input
-                        {...input}
-                        type="number"
-                        invalid={touched && invalid}
-                        icon={icons.Euro}
-                      />
-                      {error && touched && invalid ? (
-                        <Error>{error}</Error>
-                      ) : null}
-                    </>
-                  )}
-                />
-              </CellRemuneration>
-              <DesktopOnly>
-                <DelButton onClick={() => fields.remove(index)}>
-                  Supprimer
-                </DelButton>
-              </DesktopOnly>
-            </Row>
-          ))}
-          {visible && (
-            <AddButton
-              onClick={() =>
-                fields.push({
-                  type: TEMPS_PARTIEL,
-                  duration: null,
-                  salary: null,
-                })
-              }
-            >
-              Ajouter une période
-            </AddButton>
-          )}
-          {onChange && (
-            <OnChange name={name}>{(values) => onChange(values)}</OnChange>
-          )}
-        </>
-      )}
-    </FieldArray>
-  );
-}
-export { SalaireTempsPartiel };
-
-const { spacings } = theme;
-
-const CellType = styled.div`
-  flex-basis: 20rem;
-  margin-right: ${spacings.medium};
-  @media ${mobileMediaQuery} {
-    flex-basis: 100%;
-    margin-right: 0;
-  }
-`;
-const CellDuration = styled.div`
-  flex-basis: 15rem;
-  margin-right: ${spacings.medium};
-  @media ${mobileMediaQuery} {
-    flex-basis: 100%;
-    margin-right: 0;
-  }
-`;
-const CellRemuneration = styled.div`
-  flex-basis: 20rem;
-  @media ${mobileMediaQuery} {
-    flex-basis: 100%;
-  }
-`;
 
 export const TEMPS_PLEIN = "Temps plein";
 export const TEMPS_PARTIEL = "Temps partiel";
-export const typePeriod = [TEMPS_PARTIEL, TEMPS_PLEIN];
+
+const PERIOD_TYPES = [TEMPS_PARTIEL, TEMPS_PLEIN];
+
+export const SalaireTempsPartiel = ({ name }) => (
+  <FieldArray name={name}>
+    {({ fields }) =>
+      fields.length > 0 && (
+        <>
+          <Question as="p">
+            Quels ont été les durées et les salaires des périodes à temps plein
+            et à temps partiel&nbsp;?
+          </Question>
+          {fields.map((name, index) => (
+            <RelativeDiv key={name}>
+              <RowTitle>
+                <Text variant="secondary" fontSize="hsmall">
+                  Période {index + 1}
+                </Text>
+              </RowTitle>
+              <MultiFieldRow
+                gridRows={["auto", "auto"]}
+                gridColumns={["2fr", "1fr", "1fr", "13rem"]}
+                emptyCells={[7]}
+              >
+                <Label htmlFor={`${name}.type`}>Type de durée de travail</Label>
+                <FieldWrapper>
+                  <Field name={`${name}.type`} id={`${name}.type`}>
+                    {({ input }) => (
+                      <StyledSelect {...input}>
+                        {PERIOD_TYPES.map((item) => (
+                          <option key={item}>{item}</option>
+                        ))}
+                      </StyledSelect>
+                    )}
+                  </Field>
+                </FieldWrapper>
+                <Label htmlFor={`${name}.duration`}>Durée (en mois)</Label>
+                <FieldWrapper>
+                  <Field
+                    name={`${name}.duration`}
+                    validate={isNumber}
+                    subscription={{
+                      value: true,
+                      error: true,
+                      touched: true,
+                      invalid: true,
+                    }}
+                    render={({ input, meta: { touched, error, invalid } }) => (
+                      <>
+                        <Input
+                          {...input}
+                          id={`${name}.duration`}
+                          type="number"
+                          invalid={touched && invalid}
+                        />
+                        {error && touched && invalid && (
+                          <StyledError>{error}</StyledError>
+                        )}
+                      </>
+                    )}
+                  />
+                </FieldWrapper>
+                <Label htmlFor={`${name}.salary`}>Rémunération</Label>
+                <div>
+                  <Field
+                    name={`${name}.salary`}
+                    validate={isNumber}
+                    subscription={{
+                      value: true,
+                      error: true,
+                      touched: true,
+                      invalid: true,
+                    }}
+                    render={({ input, meta: { touched, error, invalid } }) => (
+                      <>
+                        <Input
+                          {...input}
+                          id={`${name}.salary`}
+                          type="number"
+                          invalid={touched && invalid}
+                          icon={icons.Euro}
+                        />
+                        {error && touched && invalid && (
+                          <StyledError>{error}</StyledError>
+                        )}
+                      </>
+                    )}
+                  />
+                </div>
+                {fields.length > 1 && (
+                  <StyledDelButton onClick={() => fields.remove(index)}>
+                    Supprimer
+                  </StyledDelButton>
+                )}
+              </MultiFieldRow>
+            </RelativeDiv>
+          ))}
+          <AddButton
+            onClick={() =>
+              fields.push({
+                type: TEMPS_PARTIEL,
+                duration: null,
+                salary: null,
+              })
+            }
+          >
+            Ajouter une période
+          </AddButton>
+        </>
+      )
+    }
+  </FieldArray>
+);
+
+const { breakpoints, spacings } = theme;
+
+const RelativeDiv = styled.div`
+  position: relative;
+`;
+
+const RowTitle = styled.div`
+  margin-bottom: ${spacings.base};
+  padding-top: ${spacings.small};
+`;
+
+const StyledSelect = styled(Select)`
+  display: flex;
+`;
+
+const FieldWrapper = styled.div`
+  margin-right: ${spacings.base};
+  @media (max-width: ${breakpoints.mobile}) {
+    margin-right: 0;
+    margin-bottom: ${spacings.base};
+  }
+`;
+
+const StyledError = styled(Error)`
+  margin-bottom: 0;
+`;
+
+const StyledDelButton = styled(DelButton)`
+  margin-top: ${spacings.xsmall};
+  @media (max-width: ${breakpoints.mobile}) {
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin-top: 0;
+  }
+`;

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/components/__tests__/AbsencePeriods.test.js
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/components/__tests__/AbsencePeriods.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, wait } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { AbsencePeriods } from "../AbsencePeriods";
 import { Form } from "react-final-form";
 import arrayMutators from "final-form-arrays";
@@ -21,7 +21,12 @@ describe("<AbsencePeriods />", () => {
     const onSubmit = jest.fn();
     const { container, getAllByText } = render(
       <Form
-        initialValues={{ absences: [{ type: "Grève", duration: 3 }] }}
+        initialValues={{
+          absences: [
+            { type: "Grève", duration: 3 },
+            { type: "Grève", duration: 3 },
+          ],
+        }}
         mutators={{ ...arrayMutators }}
         onSubmit={onSubmit}
         render={() => <AbsencePeriods name="absences" />}
@@ -29,22 +34,20 @@ describe("<AbsencePeriods />", () => {
     );
     const [deleteButton] = getAllByText(/supprimer/i);
     deleteButton.click();
-    await wait(() => {});
     expect(container).toMatchSnapshot();
   });
   it("should add a period", async () => {
     const onSubmit = jest.fn();
-    const { container, getByText, getAllByText } = render(
+    const { getByText, getAllByText } = render(
       <Form
         mutators={{ ...arrayMutators }}
+        initialValues={{ absences: [{ type: "Grève", duration: 3 }] }}
         onSubmit={onSubmit}
         render={() => <AbsencePeriods name="absences" />}
       />
     );
     const addButton = getByText(/ajouter/i);
     addButton.click();
-
-    await wait(() => getAllByText(/supprimer/i));
-    expect(container).toMatchSnapshot();
+    expect(getAllByText(/supprimer/i).length).toBe(2);
   });
 });

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/components/__tests__/SalaireTempsPartiel.test.js
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/components/__tests__/SalaireTempsPartiel.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, wait } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { SalaireTempsPartiel } from "../SalaireTempsPartiel";
 import { Form } from "react-final-form";
 import arrayMutators from "final-form-arrays";
@@ -39,21 +39,25 @@ describe("<SalaireTempsPartiel />", () => {
     );
     const [deleteButton] = getAllByText(/supprimer/i);
     deleteButton.click();
-    await wait(() => {});
     expect(container).toMatchSnapshot();
   });
   it("should add a period", async () => {
     const onSubmit = jest.fn();
-    const { container, getByText, getAllByText } = render(
+    const { getAllByText, getByText } = render(
       <Form
         mutators={{ ...arrayMutators }}
+        initialValues={{
+          periods: [
+            { type: "Temps plein", duration: 12, salary: 2000 },
+            { type: "Temps partiel", duration: 6, salary: 1000 },
+          ],
+        }}
         onSubmit={onSubmit}
         render={() => <SalaireTempsPartiel name="periods" />}
       />
     );
     const addButton = getByText(/ajouter/i);
     addButton.click();
-    await wait(() => getAllByText(/supprimer/i));
-    expect(container).toMatchSnapshot();
+    expect(getAllByText(/supprimer/i).length).toBe(3);
   });
 });

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/components/__tests__/__snapshots__/AbsencePeriods.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/components/__tests__/__snapshots__/AbsencePeriods.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<AbsencePeriods /> should add a period 1`] = `
-.c8 {
+exports[`<AbsencePeriods /> should delete a period 1`] = `
+.c13 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -38,16 +38,16 @@ exports[`<AbsencePeriods /> should add a period 1`] = `
   opacity: 1;
 }
 
-.c8:link,
-.c8:visited {
+.c13:link,
+.c13:visited {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #3e486e;
 }
 
-.c8:not([disabled]):hover,
-.c8:not([disabled]):active,
-.c8:not([disabled]):focus {
+.c13:not([disabled]):hover,
+.c13:not([disabled]):active,
+.c13:not([disabled]):focus {
   opacity: 0.6;
   -webkit-transform: translateY(-2px);
   -ms-transform: translateY(-2px);
@@ -56,7 +56,7 @@ exports[`<AbsencePeriods /> should add a period 1`] = `
   border-color: transparent;
 }
 
-.c8[disabled] {
+.c13[disabled] {
   background-color: #e4e8ef;
   border-color: #e4e8ef;
   color: #9298af;
@@ -64,82 +64,19 @@ exports[`<AbsencePeriods /> should add a period 1`] = `
   cursor: not-allowed;
 }
 
-.c16 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: content-box;
-  font-weight: 500;
-  font-size: 1.6rem;
-  line-height: 1.125em;
-  text-align: center;
-  vertical-align: middle;
-  border: 1px solid;
-  border-radius: 0.6rem;
-  cursor: pointer;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,-webkit-transform 100ms linear;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  height: 5.2rem;
-  padding: 0 1.9rem;
-  color: #3e486e;
-  background: transparent;
-  border-color: transparent;
-  box-shadow: none;
-  opacity: 1;
-}
-
-.c16:link,
-.c16:visited {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #3e486e;
-}
-
-.c16:not([disabled]):hover,
-.c16:not([disabled]):active,
-.c16:not([disabled]):focus {
-  opacity: 0.6;
-  -webkit-transform: translateY(-2px);
-  -ms-transform: translateY(-2px);
-  transform: translateY(-2px);
-  background: transparent;
-  border-color: transparent;
-}
-
-.c16[disabled] {
-  background-color: #e4e8ef;
-  border-color: #e4e8ef;
-  color: #9298af;
-  box-shadow: none;
-  cursor: not-allowed;
-}
-
-.c7 {
+.c3 {
   color: #7994d4;
   line-height: 1.25;
   font-size: 1.8rem;
   font-weight: 400;
 }
 
-.c14 {
+.c11 {
   position: relative;
   display: inline-block;
 }
 
-.c15 {
+.c12 {
   width: 100%;
   height: 5.4rem;
   padding: 0 2rem;
@@ -161,15 +98,15 @@ exports[`<AbsencePeriods /> should add a period 1`] = `
   appearance: none;
 }
 
-.c15::-webkit-outer-spin-button,
-.c15::-webkit-inner-spin-button {
+.c12::-webkit-outer-spin-button,
+.c12::-webkit-inner-spin-button {
   margin: 0;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c15::-webkit-calendar-picker-indicator {
+.c12::-webkit-calendar-picker-indicator {
   display: block;
   width: 3.2rem;
   height: 3.2rem;
@@ -182,47 +119,61 @@ exports[`<AbsencePeriods /> should add a period 1`] = `
   mask-image: url("data:image/svg+xml;,%3Csvg%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M20.947%207.601h1.601c1.472%200%202.521%201.198%202.521%202.669v2.306l-.001%2010.392c0%201.472-1.049%202.669-2.521%202.669H8.669A2.672%202.672%200%20016%2022.967l.001-12.697a2.672%202.672%200%20012.67-2.669h1.331V6h.999v1.601H20V6h.947v1.601zm1.6%2017.036c.883%200%201.454-.786%201.454-1.67v-10.33h-17L7%2022.967c0%20.884.785%201.67%201.668%201.67h13.879zm-15.548-13h17.002l.001-1.367c0-.883-.57-1.601-1.453-1.601h-1.6v1.068H20V8.669h-9v1.068h-1V8.669H8.669C7.786%208.669%207%209.387%207%2010.27v1.367zm9.677%206.277h-2.135a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203h-2.135v2.135h2.136v-2.135zm3.203%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068H19.88a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135H19.88v-2.135zm-8.54%208.541H9.204a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H9.204v2.135h2.136l-.001-2.135zm3.202%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068h-2.135a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135h-2.136v-2.135zm7.473%203.203H19.88a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H19.88v2.135h2.136v-2.135z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E");
 }
 
-.c15:invalid {
+.c12:invalid {
   border-color: #eb5757;
 }
 
-.c15::-webkit-input-placeholder {
+.c12::-webkit-input-placeholder {
   color: #9298af;
 }
 
-.c15::-moz-placeholder {
+.c12::-moz-placeholder {
   color: #9298af;
 }
 
-.c15:-ms-input-placeholder {
+.c12:-ms-input-placeholder {
   color: #9298af;
 }
 
-.c15::placeholder {
+.c12::placeholder {
   color: #9298af;
 }
 
-.c15:focus {
+.c12:focus {
   border-color: #7994d4;
 }
 
-.c15:focus::-webkit-input-placeholder {
+.c12:focus::-webkit-input-placeholder {
   color: transparent;
 }
 
-.c15:focus::-moz-placeholder {
+.c12:focus::-moz-placeholder {
   color: transparent;
 }
 
-.c15:focus:-ms-input-placeholder {
+.c12:focus:-ms-input-placeholder {
   color: transparent;
 }
 
-.c15:focus::placeholder {
+.c12:focus::placeholder {
   color: transparent;
 }
 
-.c11 {
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding-bottom: 0.4rem;
+  font-weight: 600;
+  font-size: 1.4rem;
+  font-family: "Open Sans",sans-serif;
+  font-style: normal;
+  line-height: 2;
+  cursor: pointer;
+}
+
+.c7 {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -242,7 +193,7 @@ exports[`<AbsencePeriods /> should add a period 1`] = `
   text-align: center;
 }
 
-.c13 {
+.c10 {
   position: absolute;
   top: 1.6rem;
   right: 1.6rem;
@@ -252,7 +203,7 @@ exports[`<AbsencePeriods /> should add a period 1`] = `
   pointer-events: none;
 }
 
-.c12 {
+.c9 {
   width: 100%;
   height: 5.4rem;
   padding: 0 2rem 0;
@@ -273,25 +224,25 @@ exports[`<AbsencePeriods /> should add a period 1`] = `
   appearance: none;
 }
 
-.c12::-ms-expand {
+.c9::-ms-expand {
   background-color: transparent;
   border: 0 transparent;
 }
 
-.c12 *::-ms-backdrop,
-.c12 {
+.c9 *::-ms-backdrop,
+.c9 {
   padding-right: 1.6rem;
 }
 
-.c12:invalid {
+.c9:invalid {
   border-color: #eb5757;
 }
 
-.c12:disabled {
+.c9:disabled {
   background-color: #e4e8ef;
 }
 
-.c17 {
+.c14 {
   -webkit-align-self: flex-start;
   -ms-flex-item-align: start;
   align-self: flex-start;
@@ -299,20 +250,56 @@ exports[`<AbsencePeriods /> should add a period 1`] = `
   padding-left: 0;
 }
 
-.c9 {
-  margin-left: 1rem;
-}
-
-.c10 {
-  width: 2rem;
-  margin-left: 0.4rem;
-  color: #f66663;
-}
-
-.c18 {
+.c15 {
   width: 2rem;
   margin-right: 0.4rem;
   color: #f66663;
+}
+
+.c4 {
+  display: -ms-grid;
+  -ms-grid-rows: auto auto;
+  -ms-grid-columns: 2fr 1fr 13rem;
+  display: grid;
+  grid-template-rows: auto auto;
+  grid-template-columns: 2fr 1fr 13rem;
+  margin-top: 1.6rem;
+  margin-bottom: 1.6rem;
+}
+
+.c4 > *:nth-child(1) {
+  -ms-grid-row: 1;
+  -ms-grid-column: 1;
+  grid-row: 1;
+  grid-column: 1;
+}
+
+.c4 > *:nth-child(2) {
+  -ms-grid-row: 2;
+  -ms-grid-column: 1;
+  grid-row: 2;
+  grid-column: 1;
+}
+
+.c4 > *:nth-child(3) {
+  -ms-grid-row: 1;
+  -ms-grid-column: 2;
+  grid-row: 1;
+  grid-column: 2;
+}
+
+.c4 > *:nth-child(4) {
+  -ms-grid-row: 2;
+  -ms-grid-column: 2;
+  grid-row: 2;
+  grid-column: 2;
+}
+
+.c4 > *:nth-child(5) {
+  -ms-grid-row: 2;
+  -ms-grid-column: 3;
+  grid-row: 2;
+  grid-column: 3;
 }
 
 .c0 {
@@ -324,62 +311,29 @@ exports[`<AbsencePeriods /> should add a period 1`] = `
   cursor: default;
 }
 
+.c1 {
+  position: relative;
+}
+
 .c2 {
+  margin-bottom: 1.6rem;
+  padding-top: 1rem;
+}
+
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  margin-bottom: 1rem;
 }
 
 .c6 {
-  display: none;
-}
-
-.c4 {
-  padding-top: 1rem;
-  padding-bottom: 0.4rem;
-  font-weight: 700;
-  font-size: 1.4rem;
-}
-
-.c3 {
-  -webkit-flex: 0 1 35rem;
-  -ms-flex: 0 1 35rem;
-  flex: 0 1 35rem;
-  margin-right: 2rem;
-}
-
-.c5 {
-  margin-right: 2rem;
+  margin-right: 1.6rem;
 }
 
 @media (max-width:600px) {
-  .c8 {
+  .c13 {
     font-size: 1.4rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c16 {
-    font-size: 1.4rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c14 {
-    width: 100%;
-  }
-}
-
-@media (max-width:600px) {
-  .c15 {
-    padding: 0 1rem;
-    padding-right: 2rem;
   }
 }
 
@@ -390,59 +344,40 @@ exports[`<AbsencePeriods /> should add a period 1`] = `
 }
 
 @media (max-width:600px) {
+  .c12 {
+    padding: 0 1rem;
+    padding-right: 2rem;
+  }
+}
+
+@media (max-width:600px) {
+  .c7 {
+    width: 100%;
+  }
+}
+
+@media (max-width:600px) {
+  .c4 {
+    display: block;
+    margin-bottom: 3.2rem;
+  }
+}
+
+@media (max-width:600px) {
   .c0 {
     font-size: 1.6rem;
   }
 }
 
 @media (max-width:600px) {
-  .c2 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-    margin-bottom: 3.2rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c1 {
-    display: none;
-  }
-}
-
-@media (max-width:600px) {
   .c6 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-align-items: center;
-    -webkit-box-align: center;
-    -ms-flex-align: center;
-    align-items: center;
-    -webkit-box-pack: justify;
-    -webkit-justify-content: space-between;
-    -ms-flex-pack: justify;
-    justify-content: space-between;
+    margin-right: 0;
+    margin-bottom: 1.6rem;
   }
 }
 
 @media (max-width:600px) {
-  .c3 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    margin-right: 0;
-  }
-}
 
-@media (max-width:600px) {
-  .c5 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    margin-right: 0;
-  }
 }
 
 <div>
@@ -455,178 +390,128 @@ exports[`<AbsencePeriods /> should add a period 1`] = `
     Quels sont le motif et la durée de ces absences prolongées ?
   </p>
   <div
-    class="c1 c2"
+    class="c1"
   >
     <div
-      class="c3 c4"
-    >
-      Motif
-    </div>
-    <div
-      class="c5 c4"
-    >
-      Durée (en mois)
-    </div>
-  </div>
-  <div
-    class="c2"
-  >
-    <div
-      class="c6"
+      class="c2"
     >
       <span
-        class="c7"
+        class="c3"
         font-size="hsmall"
         font-weight="400"
       >
-        Période 
+        Absence 
         1
       </span>
-      <button
-        class="c8 c9"
-        type="button"
-      >
-        Supprimer
-        <svg
-          aria-hidden="true"
-          class="c10"
-          fill="none"
-          viewBox="0 0 32 32"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M14.752 16.5L7.258 8.591A.957.957 0 017 7.932c0-.247.093-.484.259-.659A.858.858 0 017.883 7a.86.86 0 01.625.273L16 15.183l7.492-7.91A.859.859 0 0124.117 7c.234 0 .459.098.624.273a.957.957 0 01.259.659.957.957 0 01-.259.66L17.249 16.5l7.492 7.909a.958.958 0 01.259.659.957.957 0 01-.259.659.859.859 0 01-.624.273.86.86 0 01-.625-.273L16 17.817l-7.492 7.91a.859.859 0 01-.625.273.859.859 0 01-.624-.273.957.957 0 01-.259-.659.96.96 0 01.259-.66l7.492-7.908z"
-            fill="currentColor"
-            fill-rule="evenodd"
-          />
-        </svg>
-      </button>
     </div>
     <div
-      class="c3"
+      class="c4"
     >
-      <div
-        class="c6 c4"
+      <label
+        class="c5"
+        for="absences[0].type"
       >
         Motif
-      </div>
+      </label>
       <div
-        class="c11"
+        class="c6"
       >
-        <select
-          class="c12"
-        >
-          <option>
-            Absence pour maladie non professionnelle
-          </option>
-          <option>
-            Arrêt maladie lié à un accident de trajet
-          </option>
-          <option>
-            Congé sabbatique
-          </option>
-          <option>
-            Congé pour création d'entreprise
-          </option>
-          <option>
-            Congé parental d'éducation
-          </option>
-          <option>
-            Congés sans solde
-          </option>
-          <option>
-            Grève
-          </option>
-          <option>
-            Mise à pied
-          </option>
-          <option>
-            Maladie d'origine non professionnelle
-          </option>
-          <option>
-            Congé de paternité
-          </option>
-        </select>
         <div
-          aria-hidden="true"
-          class="c13"
+          class="c7 c8"
         >
-          <svg
-            fill="none"
-            viewBox="0 0 16 16"
+          <select
+            class="c9"
+            id="absences[0].type"
           >
-            <g
-              clip-path="url(#arrow-down_svg__clip0)"
+            <option>
+              Absence pour maladie non professionnelle
+            </option>
+            <option>
+              Arrêt maladie lié à un accident de trajet
+            </option>
+            <option>
+              Congé sabbatique
+            </option>
+            <option>
+              Congé pour création d'entreprise
+            </option>
+            <option>
+              Congé parental d'éducation
+            </option>
+            <option>
+              Congés sans solde
+            </option>
+            <option>
+              Grève
+            </option>
+            <option>
+              Mise à pied
+            </option>
+            <option>
+              Maladie d'origine non professionnelle
+            </option>
+            <option>
+              Congé de paternité
+            </option>
+          </select>
+          <div
+            aria-hidden="true"
+            class="c10"
+          >
+            <svg
+              fill="none"
+              viewBox="0 0 16 16"
             >
-              <path
-                d="M8.425 11.573l7.11-6.072a.709.709 0 00.26-.537.709.709 0 00-.26-.537.973.973 0 00-.629-.223.973.973 0 00-.63.223l-6.48 5.536-6.481-5.536a.973.973 0 00-.63-.223.973.973 0 00-.628.223.708.708 0 00-.261.537c0 .202.094.395.26.537l7.11 6.072a.91.91 0 00.29.165 1.021 1.021 0 00.68 0 .91.91 0 00.29-.165z"
-                fill="currentColor"
-              />
-            </g>
-            <defs>
-              <clippath
-                id="arrow-down_svg__clip0"
+              <g
+                clip-path="url(#arrow-down_svg__clip0)"
               >
                 <path
-                  d="M0 0h16v16H0z"
+                  d="M8.425 11.573l7.11-6.072a.709.709 0 00.26-.537.709.709 0 00-.26-.537.973.973 0 00-.629-.223.973.973 0 00-.63.223l-6.48 5.536-6.481-5.536a.973.973 0 00-.63-.223.973.973 0 00-.628.223.708.708 0 00-.261.537c0 .202.094.395.26.537l7.11 6.072a.91.91 0 00.29.165 1.021 1.021 0 00.68 0 .91.91 0 00.29-.165z"
                   fill="currentColor"
                 />
-              </clippath>
-            </defs>
-          </svg>
+              </g>
+              <defs>
+                <clippath
+                  id="arrow-down_svg__clip0"
+                >
+                  <path
+                    d="M0 0h16v16H0z"
+                    fill="currentColor"
+                  />
+                </clippath>
+              </defs>
+            </svg>
+          </div>
         </div>
       </div>
-    </div>
-    <div
-      class="c5"
-    >
-      <div
-        class="c6 c4"
+      <label
+        class="c5"
+        for="absences[0].duration"
       >
         Durée (en mois)
-      </div>
-      <span
-        class="c14"
-      >
-        <input
-          class="c15"
-          name="absences[0].duration"
-          type="number"
-          value=""
-        />
-      </span>
-    </div>
-    <div
-      class="c1"
-    >
-      <button
-        class="c16 c9"
-        type="button"
-      >
-        Supprimer
-        <svg
-          aria-hidden="true"
-          class="c10"
-          fill="none"
-          viewBox="0 0 32 32"
+      </label>
+      <div>
+        <span
+          class="c11"
         >
-          <path
-            clip-rule="evenodd"
-            d="M14.752 16.5L7.258 8.591A.957.957 0 017 7.932c0-.247.093-.484.259-.659A.858.858 0 017.883 7a.86.86 0 01.625.273L16 15.183l7.492-7.91A.859.859 0 0124.117 7c.234 0 .459.098.624.273a.957.957 0 01.259.659.957.957 0 01-.259.66L17.249 16.5l7.492 7.909a.958.958 0 01.259.659.957.957 0 01-.259.659.859.859 0 01-.624.273.86.86 0 01-.625-.273L16 17.817l-7.492 7.91a.859.859 0 01-.625.273.859.859 0 01-.624-.273.957.957 0 01-.259-.659.96.96 0 01.259-.66l7.492-7.908z"
-            fill="currentColor"
-            fill-rule="evenodd"
+          <input
+            class="c12"
+            id="absences[0].duration"
+            name="absences[0].duration"
+            type="number"
+            value="3"
           />
-        </svg>
-      </button>
+        </span>
+      </div>
     </div>
   </div>
   <button
-    class="c8 c17"
+    class="c13 c14"
     type="button"
   >
     <svg
       aria-hidden="true"
-      class="c18"
+      class="c15"
       fill="none"
       viewBox="0 0 16 16"
     >
@@ -637,240 +522,13 @@ exports[`<AbsencePeriods /> should add a period 1`] = `
         fill-rule="evenodd"
       />
     </svg>
-    Ajouter une période
-  </button>
-</div>
-`;
-
-exports[`<AbsencePeriods /> should delete a period 1`] = `
-.c6 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: content-box;
-  font-weight: 500;
-  font-size: 1.6rem;
-  line-height: 1.125em;
-  text-align: center;
-  vertical-align: middle;
-  border: 1px solid;
-  border-radius: 0.6rem;
-  cursor: pointer;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,-webkit-transform 100ms linear;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  height: 4rem;
-  padding: 0 1rem;
-  color: #3e486e;
-  background: transparent;
-  border-color: transparent;
-  box-shadow: none;
-  opacity: 1;
-}
-
-.c6:link,
-.c6:visited {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #3e486e;
-}
-
-.c6:not([disabled]):hover,
-.c6:not([disabled]):active,
-.c6:not([disabled]):focus {
-  opacity: 0.6;
-  -webkit-transform: translateY(-2px);
-  -ms-transform: translateY(-2px);
-  transform: translateY(-2px);
-  background: transparent;
-  border-color: transparent;
-}
-
-.c6[disabled] {
-  background-color: #e4e8ef;
-  border-color: #e4e8ef;
-  color: #9298af;
-  box-shadow: none;
-  cursor: not-allowed;
-}
-
-.c7 {
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: start;
-  align-self: flex-start;
-  margin: 1rem 0;
-  padding-left: 0;
-}
-
-.c8 {
-  width: 2rem;
-  margin-right: 0.4rem;
-  color: #f66663;
-}
-
-.c0 {
-  display: block;
-  margin-top: 2rem;
-  margin-bottom: 1rem;
-  font-weight: 600;
-  font-size: 1.8rem;
-  cursor: default;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  margin-bottom: 1rem;
-}
-
-.c4 {
-  padding-top: 1rem;
-  padding-bottom: 0.4rem;
-  font-weight: 700;
-  font-size: 1.4rem;
-}
-
-.c3 {
-  -webkit-flex: 0 1 35rem;
-  -ms-flex: 0 1 35rem;
-  flex: 0 1 35rem;
-  margin-right: 2rem;
-}
-
-.c5 {
-  margin-right: 2rem;
-}
-
-@media (max-width:600px) {
-  .c6 {
-    font-size: 1.4rem;
-  }
-}
-
-@media (max-width:600px) {
-
-}
-
-@media (max-width:600px) {
-
-}
-
-@media (max-width:600px) {
-
-}
-
-@media (max-width:600px) {
-
-}
-
-@media (max-width:600px) {
-  .c0 {
-    font-size: 1.6rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c2 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-    margin-bottom: 3.2rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c1 {
-    display: none;
-  }
-}
-
-@media (max-width:600px) {
-
-}
-
-@media (max-width:600px) {
-  .c3 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    margin-right: 0;
-  }
-}
-
-@media (max-width:600px) {
-  .c5 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    margin-right: 0;
-  }
-}
-
-<div>
-  <p>
-    Les congés payés, le congé de maternité ou d'adoption, le congé de présence parental ,l'arrêt de travail lié à un accident du travail ou une maladie professionnelle, le congé individuel de formation (CIF), le congé de solidarité internationale, le congé de solidarité familiale et le stage de fin d'étude de plus de 2 mois sont déjà prises en compte dans l'ancienneté et ne sont pas des périodes à renseigner ci-après :
-  </p>
-  <p
-    class="c0"
-  >
-    Quels sont le motif et la durée de ces absences prolongées ?
-  </p>
-  <div
-    class="c1 c2"
-  >
-    <div
-      class="c3 c4"
-    >
-      Motif
-    </div>
-    <div
-      class="c5 c4"
-    >
-      Durée (en mois)
-    </div>
-  </div>
-  <button
-    class="c6 c7"
-    type="button"
-  >
-    <svg
-      aria-hidden="true"
-      class="c8"
-      fill="none"
-      viewBox="0 0 16 16"
-    >
-      <path
-        clip-rule="evenodd"
-        d="M8 2a1 1 0 00-1 1v4H3a1 1 0 000 2h4v4a1 1 0 102 0V9h4a1 1 0 100-2H9V3a1 1 0 00-1-1z"
-        fill="currentColor"
-        fill-rule="evenodd"
-      />
-    </svg>
-    Ajouter une période
+    Ajouter une absence
   </button>
 </div>
 `;
 
 exports[`<AbsencePeriods /> should render 1`] = `
-.c8 {
+.c13 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -907,16 +565,16 @@ exports[`<AbsencePeriods /> should render 1`] = `
   opacity: 1;
 }
 
-.c8:link,
-.c8:visited {
+.c13:link,
+.c13:visited {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #3e486e;
 }
 
-.c8:not([disabled]):hover,
-.c8:not([disabled]):active,
-.c8:not([disabled]):focus {
+.c13:not([disabled]):hover,
+.c13:not([disabled]):active,
+.c13:not([disabled]):focus {
   opacity: 0.6;
   -webkit-transform: translateY(-2px);
   -ms-transform: translateY(-2px);
@@ -925,7 +583,7 @@ exports[`<AbsencePeriods /> should render 1`] = `
   border-color: transparent;
 }
 
-.c8[disabled] {
+.c13[disabled] {
   background-color: #e4e8ef;
   border-color: #e4e8ef;
   color: #9298af;
@@ -933,82 +591,19 @@ exports[`<AbsencePeriods /> should render 1`] = `
   cursor: not-allowed;
 }
 
-.c16 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: content-box;
-  font-weight: 500;
-  font-size: 1.6rem;
-  line-height: 1.125em;
-  text-align: center;
-  vertical-align: middle;
-  border: 1px solid;
-  border-radius: 0.6rem;
-  cursor: pointer;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,-webkit-transform 100ms linear;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  height: 5.2rem;
-  padding: 0 1.9rem;
-  color: #3e486e;
-  background: transparent;
-  border-color: transparent;
-  box-shadow: none;
-  opacity: 1;
-}
-
-.c16:link,
-.c16:visited {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #3e486e;
-}
-
-.c16:not([disabled]):hover,
-.c16:not([disabled]):active,
-.c16:not([disabled]):focus {
-  opacity: 0.6;
-  -webkit-transform: translateY(-2px);
-  -ms-transform: translateY(-2px);
-  transform: translateY(-2px);
-  background: transparent;
-  border-color: transparent;
-}
-
-.c16[disabled] {
-  background-color: #e4e8ef;
-  border-color: #e4e8ef;
-  color: #9298af;
-  box-shadow: none;
-  cursor: not-allowed;
-}
-
-.c7 {
+.c3 {
   color: #7994d4;
   line-height: 1.25;
   font-size: 1.8rem;
   font-weight: 400;
 }
 
-.c14 {
+.c11 {
   position: relative;
   display: inline-block;
 }
 
-.c15 {
+.c12 {
   width: 100%;
   height: 5.4rem;
   padding: 0 2rem;
@@ -1030,15 +625,15 @@ exports[`<AbsencePeriods /> should render 1`] = `
   appearance: none;
 }
 
-.c15::-webkit-outer-spin-button,
-.c15::-webkit-inner-spin-button {
+.c12::-webkit-outer-spin-button,
+.c12::-webkit-inner-spin-button {
   margin: 0;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c15::-webkit-calendar-picker-indicator {
+.c12::-webkit-calendar-picker-indicator {
   display: block;
   width: 3.2rem;
   height: 3.2rem;
@@ -1051,47 +646,61 @@ exports[`<AbsencePeriods /> should render 1`] = `
   mask-image: url("data:image/svg+xml;,%3Csvg%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M20.947%207.601h1.601c1.472%200%202.521%201.198%202.521%202.669v2.306l-.001%2010.392c0%201.472-1.049%202.669-2.521%202.669H8.669A2.672%202.672%200%20016%2022.967l.001-12.697a2.672%202.672%200%20012.67-2.669h1.331V6h.999v1.601H20V6h.947v1.601zm1.6%2017.036c.883%200%201.454-.786%201.454-1.67v-10.33h-17L7%2022.967c0%20.884.785%201.67%201.668%201.67h13.879zm-15.548-13h17.002l.001-1.367c0-.883-.57-1.601-1.453-1.601h-1.6v1.068H20V8.669h-9v1.068h-1V8.669H8.669C7.786%208.669%207%209.387%207%2010.27v1.367zm9.677%206.277h-2.135a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203h-2.135v2.135h2.136v-2.135zm3.203%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068H19.88a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135H19.88v-2.135zm-8.54%208.541H9.204a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H9.204v2.135h2.136l-.001-2.135zm3.202%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068h-2.135a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135h-2.136v-2.135zm7.473%203.203H19.88a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H19.88v2.135h2.136v-2.135z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E");
 }
 
-.c15:invalid {
+.c12:invalid {
   border-color: #eb5757;
 }
 
-.c15::-webkit-input-placeholder {
+.c12::-webkit-input-placeholder {
   color: #9298af;
 }
 
-.c15::-moz-placeholder {
+.c12::-moz-placeholder {
   color: #9298af;
 }
 
-.c15:-ms-input-placeholder {
+.c12:-ms-input-placeholder {
   color: #9298af;
 }
 
-.c15::placeholder {
+.c12::placeholder {
   color: #9298af;
 }
 
-.c15:focus {
+.c12:focus {
   border-color: #7994d4;
 }
 
-.c15:focus::-webkit-input-placeholder {
+.c12:focus::-webkit-input-placeholder {
   color: transparent;
 }
 
-.c15:focus::-moz-placeholder {
+.c12:focus::-moz-placeholder {
   color: transparent;
 }
 
-.c15:focus:-ms-input-placeholder {
+.c12:focus:-ms-input-placeholder {
   color: transparent;
 }
 
-.c15:focus::placeholder {
+.c12:focus::placeholder {
   color: transparent;
 }
 
-.c11 {
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding-bottom: 0.4rem;
+  font-weight: 600;
+  font-size: 1.4rem;
+  font-family: "Open Sans",sans-serif;
+  font-style: normal;
+  line-height: 2;
+  cursor: pointer;
+}
+
+.c7 {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -1111,7 +720,7 @@ exports[`<AbsencePeriods /> should render 1`] = `
   text-align: center;
 }
 
-.c13 {
+.c10 {
   position: absolute;
   top: 1.6rem;
   right: 1.6rem;
@@ -1121,7 +730,7 @@ exports[`<AbsencePeriods /> should render 1`] = `
   pointer-events: none;
 }
 
-.c12 {
+.c9 {
   width: 100%;
   height: 5.4rem;
   padding: 0 2rem 0;
@@ -1142,25 +751,25 @@ exports[`<AbsencePeriods /> should render 1`] = `
   appearance: none;
 }
 
-.c12::-ms-expand {
+.c9::-ms-expand {
   background-color: transparent;
   border: 0 transparent;
 }
 
-.c12 *::-ms-backdrop,
-.c12 {
+.c9 *::-ms-backdrop,
+.c9 {
   padding-right: 1.6rem;
 }
 
-.c12:invalid {
+.c9:invalid {
   border-color: #eb5757;
 }
 
-.c12:disabled {
+.c9:disabled {
   background-color: #e4e8ef;
 }
 
-.c17 {
+.c14 {
   -webkit-align-self: flex-start;
   -ms-flex-item-align: start;
   align-self: flex-start;
@@ -1168,20 +777,56 @@ exports[`<AbsencePeriods /> should render 1`] = `
   padding-left: 0;
 }
 
-.c9 {
-  margin-left: 1rem;
-}
-
-.c10 {
-  width: 2rem;
-  margin-left: 0.4rem;
-  color: #f66663;
-}
-
-.c18 {
+.c15 {
   width: 2rem;
   margin-right: 0.4rem;
   color: #f66663;
+}
+
+.c4 {
+  display: -ms-grid;
+  -ms-grid-rows: auto auto;
+  -ms-grid-columns: 2fr 1fr 13rem;
+  display: grid;
+  grid-template-rows: auto auto;
+  grid-template-columns: 2fr 1fr 13rem;
+  margin-top: 1.6rem;
+  margin-bottom: 1.6rem;
+}
+
+.c4 > *:nth-child(1) {
+  -ms-grid-row: 1;
+  -ms-grid-column: 1;
+  grid-row: 1;
+  grid-column: 1;
+}
+
+.c4 > *:nth-child(2) {
+  -ms-grid-row: 2;
+  -ms-grid-column: 1;
+  grid-row: 2;
+  grid-column: 1;
+}
+
+.c4 > *:nth-child(3) {
+  -ms-grid-row: 1;
+  -ms-grid-column: 2;
+  grid-row: 1;
+  grid-column: 2;
+}
+
+.c4 > *:nth-child(4) {
+  -ms-grid-row: 2;
+  -ms-grid-column: 2;
+  grid-row: 2;
+  grid-column: 2;
+}
+
+.c4 > *:nth-child(5) {
+  -ms-grid-row: 2;
+  -ms-grid-column: 3;
+  grid-row: 2;
+  grid-column: 3;
 }
 
 .c0 {
@@ -1193,62 +838,29 @@ exports[`<AbsencePeriods /> should render 1`] = `
   cursor: default;
 }
 
+.c1 {
+  position: relative;
+}
+
 .c2 {
+  margin-bottom: 1.6rem;
+  padding-top: 1rem;
+}
+
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  margin-bottom: 1rem;
 }
 
 .c6 {
-  display: none;
-}
-
-.c4 {
-  padding-top: 1rem;
-  padding-bottom: 0.4rem;
-  font-weight: 700;
-  font-size: 1.4rem;
-}
-
-.c3 {
-  -webkit-flex: 0 1 35rem;
-  -ms-flex: 0 1 35rem;
-  flex: 0 1 35rem;
-  margin-right: 2rem;
-}
-
-.c5 {
-  margin-right: 2rem;
+  margin-right: 1.6rem;
 }
 
 @media (max-width:600px) {
-  .c8 {
+  .c13 {
     font-size: 1.4rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c16 {
-    font-size: 1.4rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c14 {
-    width: 100%;
-  }
-}
-
-@media (max-width:600px) {
-  .c15 {
-    padding: 0 1rem;
-    padding-right: 2rem;
   }
 }
 
@@ -1259,58 +871,35 @@ exports[`<AbsencePeriods /> should render 1`] = `
 }
 
 @media (max-width:600px) {
+  .c12 {
+    padding: 0 1rem;
+    padding-right: 2rem;
+  }
+}
+
+@media (max-width:600px) {
+  .c7 {
+    width: 100%;
+  }
+}
+
+@media (max-width:600px) {
+  .c4 {
+    display: block;
+    margin-bottom: 3.2rem;
+  }
+}
+
+@media (max-width:600px) {
   .c0 {
     font-size: 1.6rem;
   }
 }
 
 @media (max-width:600px) {
-  .c2 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-    margin-bottom: 3.2rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c1 {
-    display: none;
-  }
-}
-
-@media (max-width:600px) {
   .c6 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-align-items: center;
-    -webkit-box-align: center;
-    -ms-flex-align: center;
-    align-items: center;
-    -webkit-box-pack: justify;
-    -webkit-justify-content: space-between;
-    -ms-flex-pack: justify;
-    justify-content: space-between;
-  }
-}
-
-@media (max-width:600px) {
-  .c3 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
     margin-right: 0;
-  }
-}
-
-@media (max-width:600px) {
-  .c5 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    margin-right: 0;
+    margin-bottom: 1.6rem;
   }
 }
 
@@ -1324,178 +913,128 @@ exports[`<AbsencePeriods /> should render 1`] = `
     Quels sont le motif et la durée de ces absences prolongées ?
   </p>
   <div
-    class="c1 c2"
+    class="c1"
   >
     <div
-      class="c3 c4"
-    >
-      Motif
-    </div>
-    <div
-      class="c5 c4"
-    >
-      Durée (en mois)
-    </div>
-  </div>
-  <div
-    class="c2"
-  >
-    <div
-      class="c6"
+      class="c2"
     >
       <span
-        class="c7"
+        class="c3"
         font-size="hsmall"
         font-weight="400"
       >
-        Période 
+        Absence 
         1
       </span>
-      <button
-        class="c8 c9"
-        type="button"
-      >
-        Supprimer
-        <svg
-          aria-hidden="true"
-          class="c10"
-          fill="none"
-          viewBox="0 0 32 32"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M14.752 16.5L7.258 8.591A.957.957 0 017 7.932c0-.247.093-.484.259-.659A.858.858 0 017.883 7a.86.86 0 01.625.273L16 15.183l7.492-7.91A.859.859 0 0124.117 7c.234 0 .459.098.624.273a.957.957 0 01.259.659.957.957 0 01-.259.66L17.249 16.5l7.492 7.909a.958.958 0 01.259.659.957.957 0 01-.259.659.859.859 0 01-.624.273.86.86 0 01-.625-.273L16 17.817l-7.492 7.91a.859.859 0 01-.625.273.859.859 0 01-.624-.273.957.957 0 01-.259-.659.96.96 0 01.259-.66l7.492-7.908z"
-            fill="currentColor"
-            fill-rule="evenodd"
-          />
-        </svg>
-      </button>
     </div>
     <div
-      class="c3"
+      class="c4"
     >
-      <div
-        class="c6 c4"
+      <label
+        class="c5"
+        for="absences[0].type"
       >
         Motif
-      </div>
+      </label>
       <div
-        class="c11"
+        class="c6"
       >
-        <select
-          class="c12"
-        >
-          <option>
-            Absence pour maladie non professionnelle
-          </option>
-          <option>
-            Arrêt maladie lié à un accident de trajet
-          </option>
-          <option>
-            Congé sabbatique
-          </option>
-          <option>
-            Congé pour création d'entreprise
-          </option>
-          <option>
-            Congé parental d'éducation
-          </option>
-          <option>
-            Congés sans solde
-          </option>
-          <option>
-            Grève
-          </option>
-          <option>
-            Mise à pied
-          </option>
-          <option>
-            Maladie d'origine non professionnelle
-          </option>
-          <option>
-            Congé de paternité
-          </option>
-        </select>
         <div
-          aria-hidden="true"
-          class="c13"
+          class="c7 c8"
         >
-          <svg
-            fill="none"
-            viewBox="0 0 16 16"
+          <select
+            class="c9"
+            id="absences[0].type"
           >
-            <g
-              clip-path="url(#arrow-down_svg__clip0)"
+            <option>
+              Absence pour maladie non professionnelle
+            </option>
+            <option>
+              Arrêt maladie lié à un accident de trajet
+            </option>
+            <option>
+              Congé sabbatique
+            </option>
+            <option>
+              Congé pour création d'entreprise
+            </option>
+            <option>
+              Congé parental d'éducation
+            </option>
+            <option>
+              Congés sans solde
+            </option>
+            <option>
+              Grève
+            </option>
+            <option>
+              Mise à pied
+            </option>
+            <option>
+              Maladie d'origine non professionnelle
+            </option>
+            <option>
+              Congé de paternité
+            </option>
+          </select>
+          <div
+            aria-hidden="true"
+            class="c10"
+          >
+            <svg
+              fill="none"
+              viewBox="0 0 16 16"
             >
-              <path
-                d="M8.425 11.573l7.11-6.072a.709.709 0 00.26-.537.709.709 0 00-.26-.537.973.973 0 00-.629-.223.973.973 0 00-.63.223l-6.48 5.536-6.481-5.536a.973.973 0 00-.63-.223.973.973 0 00-.628.223.708.708 0 00-.261.537c0 .202.094.395.26.537l7.11 6.072a.91.91 0 00.29.165 1.021 1.021 0 00.68 0 .91.91 0 00.29-.165z"
-                fill="currentColor"
-              />
-            </g>
-            <defs>
-              <clippath
-                id="arrow-down_svg__clip0"
+              <g
+                clip-path="url(#arrow-down_svg__clip0)"
               >
                 <path
-                  d="M0 0h16v16H0z"
+                  d="M8.425 11.573l7.11-6.072a.709.709 0 00.26-.537.709.709 0 00-.26-.537.973.973 0 00-.629-.223.973.973 0 00-.63.223l-6.48 5.536-6.481-5.536a.973.973 0 00-.63-.223.973.973 0 00-.628.223.708.708 0 00-.261.537c0 .202.094.395.26.537l7.11 6.072a.91.91 0 00.29.165 1.021 1.021 0 00.68 0 .91.91 0 00.29-.165z"
                   fill="currentColor"
                 />
-              </clippath>
-            </defs>
-          </svg>
+              </g>
+              <defs>
+                <clippath
+                  id="arrow-down_svg__clip0"
+                >
+                  <path
+                    d="M0 0h16v16H0z"
+                    fill="currentColor"
+                  />
+                </clippath>
+              </defs>
+            </svg>
+          </div>
         </div>
       </div>
-    </div>
-    <div
-      class="c5"
-    >
-      <div
-        class="c6 c4"
+      <label
+        class="c5"
+        for="absences[0].duration"
       >
         Durée (en mois)
-      </div>
-      <span
-        class="c14"
-      >
-        <input
-          class="c15"
-          name="absences[0].duration"
-          type="number"
-          value="3"
-        />
-      </span>
-    </div>
-    <div
-      class="c1"
-    >
-      <button
-        class="c16 c9"
-        type="button"
-      >
-        Supprimer
-        <svg
-          aria-hidden="true"
-          class="c10"
-          fill="none"
-          viewBox="0 0 32 32"
+      </label>
+      <div>
+        <span
+          class="c11"
         >
-          <path
-            clip-rule="evenodd"
-            d="M14.752 16.5L7.258 8.591A.957.957 0 017 7.932c0-.247.093-.484.259-.659A.858.858 0 017.883 7a.86.86 0 01.625.273L16 15.183l7.492-7.91A.859.859 0 0124.117 7c.234 0 .459.098.624.273a.957.957 0 01.259.659.957.957 0 01-.259.66L17.249 16.5l7.492 7.909a.958.958 0 01.259.659.957.957 0 01-.259.659.859.859 0 01-.624.273.86.86 0 01-.625-.273L16 17.817l-7.492 7.91a.859.859 0 01-.625.273.859.859 0 01-.624-.273.957.957 0 01-.259-.659.96.96 0 01.259-.66l7.492-7.908z"
-            fill="currentColor"
-            fill-rule="evenodd"
+          <input
+            class="c12"
+            id="absences[0].duration"
+            name="absences[0].duration"
+            type="number"
+            value="3"
           />
-        </svg>
-      </button>
+        </span>
+      </div>
     </div>
   </div>
   <button
-    class="c8 c17"
+    class="c13 c14"
     type="button"
   >
     <svg
       aria-hidden="true"
-      class="c18"
+      class="c15"
       fill="none"
       viewBox="0 0 16 16"
     >
@@ -1506,7 +1045,7 @@ exports[`<AbsencePeriods /> should render 1`] = `
         fill-rule="evenodd"
       />
     </svg>
-    Ajouter une période
+    Ajouter une absence
   </button>
 </div>
 `;

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/components/__tests__/__snapshots__/IndemniteConventionnelle.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/components/__tests__/__snapshots__/IndemniteConventionnelle.test.js.snap
@@ -61,11 +61,6 @@ exports[`<IndemniteCCn /> should render results with highlight on indemnité con
   white-space: pre-line;
 }
 
-.c8 {
-  display: block;
-  margin-bottom: 1.6rem;
-}
-
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -93,6 +88,11 @@ exports[`<IndemniteCCn /> should render results with highlight on indemnité con
   margin-left: 1.6rem;
   color: #4d73b8;
   font-size: 1.8rem;
+}
+
+.c8 {
+  display: block;
+  margin-bottom: 1.6rem;
 }
 
 .c7 {
@@ -381,11 +381,6 @@ exports[`<IndemniteCCn /> should render results with highlight on indemnité leg
   white-space: pre-line;
 }
 
-.c8 {
-  display: block;
-  margin-bottom: 1.6rem;
-}
-
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -413,6 +408,11 @@ exports[`<IndemniteCCn /> should render results with highlight on indemnité leg
   margin-left: 1.6rem;
   color: #4d73b8;
   font-size: 1.8rem;
+}
+
+.c8 {
+  display: block;
+  margin-bottom: 1.6rem;
 }
 
 .c7 {

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/components/__tests__/__snapshots__/IndemniteLegale.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/components/__tests__/__snapshots__/IndemniteLegale.test.js.snap
@@ -1,22 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<IndemniteLegale /> should render 1`] = `
-.c0 {
-  margin-top: 3.2rem;
-  margin-bottom: 2rem;
-  color: #4d73b8;
-  font-weight: 600;
-  font-size: 1.8rem;
-  font-family: "Open Sans",sans-serif;
-}
-
-.c1 {
-  color: #f66663;
-  font-weight: 700;
-  font-size: 1.8rem;
-  white-space: pre-line;
-}
-
 .c3 {
   display: block;
   margin-bottom: 1.6rem;
@@ -41,6 +25,22 @@ exports[`<IndemniteLegale /> should render 1`] = `
 
 .c7 {
   margin: 1.6rem 0;
+}
+
+.c0 {
+  margin-top: 3.2rem;
+  margin-bottom: 2rem;
+  color: #4d73b8;
+  font-weight: 600;
+  font-size: 1.8rem;
+  font-family: "Open Sans",sans-serif;
+}
+
+.c1 {
+  color: #f66663;
+  font-weight: 700;
+  font-size: 1.8rem;
+  white-space: pre-line;
 }
 
 @media (max-width:600px) {

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/components/__tests__/__snapshots__/Primes.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/components/__tests__/__snapshots__/Primes.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Primes /> should add a prime 1`] = `
-.c7 {
+.c4 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -29,102 +29,39 @@ exports[`<Primes /> should add a prime 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  padding: 0;
-  color: #f66663;
-  font-weight: 600;
-  font-size: 1.6rem;
-  line-height: 1.625;
-  vertical-align: baseline;
-  text-align: left;
-  background: none;
-  border: none;
-  border-radius: 0;
-  overflow: visible;
-}
-
-.c7:focus,
-.c7:hover,
-.c7:active {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c5 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: content-box;
-  font-weight: 500;
-  font-size: 1.6rem;
-  line-height: 1.125em;
-  text-align: center;
-  vertical-align: middle;
-  border: 1px solid;
-  border-radius: 0.6rem;
-  cursor: pointer;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,-webkit-transform 100ms linear;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  height: 5.2rem;
-  padding: 0 4.4rem;
+  height: 4rem;
+  padding: 0 1rem;
   color: #3e486e;
-  background: #fff;
-  border-color: #bbcadf;
+  background: transparent;
+  border-color: transparent;
   box-shadow: none;
   opacity: 1;
 }
 
-.c5:link,
-.c5:visited {
+.c4:link,
+.c4:visited {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #3e486e;
 }
 
-.c5:not([disabled]):hover,
-.c5:not([disabled]):active,
-.c5:not([disabled]):focus {
-  opacity: 1;
+.c4:not([disabled]):hover,
+.c4:not([disabled]):active,
+.c4:not([disabled]):focus {
+  opacity: 0.6;
   -webkit-transform: translateY(-2px);
   -ms-transform: translateY(-2px);
   transform: translateY(-2px);
-  background: #fff;
-  border-color: #dee5ef;
+  background: transparent;
+  border-color: transparent;
 }
 
-.c5[disabled] {
+.c4[disabled] {
   background-color: #e4e8ef;
   border-color: #e4e8ef;
   color: #9298af;
   box-shadow: none;
   cursor: not-allowed;
-}
-
-.c9 {
-  width: 2.6rem;
-  height: 1.4rem;
-  margin: 0 0.4rem 0 1rem;
-  -webkit-transition: -webkit-transform 250ms linear;
-  -webkit-transition: transform 250ms linear;
-  transition: transform 250ms linear;
-}
-
-.c4:hover .c9 {
-  -webkit-transform: translateX(4px);
-  -ms-transform: translateX(4px);
-  transform: translateX(4px);
 }
 
 .c1 {
@@ -226,15 +163,35 @@ exports[`<Primes /> should add a prime 1`] = `
   color: #9298af;
 }
 
+.c7 {
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
+  margin: 1rem 0;
+  padding-left: 0;
+}
+
+.c6 {
+  width: 2rem;
+  margin-left: 0.4rem;
+  color: #f66663;
+}
+
+.c8 {
+  width: 2rem;
+  margin-right: 0.4rem;
+  color: #f66663;
+}
+
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -242,29 +199,13 @@ exports[`<Primes /> should add a prime 1`] = `
   margin-bottom: 0.4rem;
 }
 
-.c6 {
-  margin-left: 2rem;
-}
-
-.c8 {
-  margin: 2rem 0;
+.c5 {
+  margin-left: 1.6rem;
 }
 
 @media (max-width:600px) {
-  .c7 {
+  .c4 {
     font-size: 1.4rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c5 {
-    font-size: 1.4rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c5 {
-    padding: 0 3rem;
   }
 }
 
@@ -314,33 +255,49 @@ exports[`<Primes /> should add a prime 1`] = `
       </span>
     </div>
     <button
-      class="c4 c5 c6"
+      class="c4 c5"
       type="button"
     >
       Supprimer
+      <svg
+        aria-hidden="true"
+        class="c6"
+        fill="none"
+        viewBox="0 0 32 32"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M14.752 16.5L7.258 8.591A.957.957 0 017 7.932c0-.247.093-.484.259-.659A.858.858 0 017.883 7a.86.86 0 01.625.273L16 15.183l7.492-7.91A.859.859 0 0124.117 7c.234 0 .459.098.624.273a.957.957 0 01.259.659.957.957 0 01-.259.66L17.249 16.5l7.492 7.909a.958.958 0 01.259.659.957.957 0 01-.259.659.859.859 0 01-.624.273.86.86 0 01-.625-.273L16 17.817l-7.492 7.91a.859.859 0 01-.625.273.859.859 0 01-.624-.273.957.957 0 01-.259-.659.96.96 0 01.259-.66l7.492-7.908z"
+          fill="currentColor"
+          fill-rule="evenodd"
+        />
+      </svg>
     </button>
   </div>
   <button
-    class="c4 c7 c8"
+    class="c4 c7"
     type="button"
   >
-    Ajouter une prime
     <svg
-      class="c9"
+      aria-hidden="true"
+      class="c8"
       fill="none"
-      viewBox="0 0 28 15"
+      viewBox="0 0 16 16"
     >
       <path
-        d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
+        clip-rule="evenodd"
+        d="M8 2a1 1 0 00-1 1v4H3a1 1 0 000 2h4v4a1 1 0 102 0V9h4a1 1 0 100-2H9V3a1 1 0 00-1-1z"
         fill="currentColor"
+        fill-rule="evenodd"
       />
     </svg>
+    Ajouter une prime
   </button>
 </div>
 `;
 
 exports[`<Primes /> should delete a primes 1`] = `
-.c1 {
+.c0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -368,55 +325,57 @@ exports[`<Primes /> should delete a primes 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  padding: 0;
-  color: #f66663;
-  font-weight: 600;
-  font-size: 1.6rem;
-  line-height: 1.625;
-  vertical-align: baseline;
-  text-align: left;
-  background: none;
-  border: none;
-  border-radius: 0;
-  overflow: visible;
+  height: 4rem;
+  padding: 0 1rem;
+  color: #3e486e;
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  opacity: 1;
 }
 
-.c1:focus,
-.c1:hover,
-.c1:active {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
+.c0:link,
+.c0:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #3e486e;
 }
 
-.c3 {
-  width: 2.6rem;
-  height: 1.4rem;
-  margin: 0 0.4rem 0 1rem;
-  -webkit-transition: -webkit-transform 250ms linear;
-  -webkit-transition: transform 250ms linear;
-  transition: transform 250ms linear;
+.c0:not([disabled]):hover,
+.c0:not([disabled]):active,
+.c0:not([disabled]):focus {
+  opacity: 0.6;
+  -webkit-transform: translateY(-2px);
+  -ms-transform: translateY(-2px);
+  transform: translateY(-2px);
+  background: transparent;
+  border-color: transparent;
 }
 
-.c0:hover .c3 {
-  -webkit-transform: translateX(4px);
-  -ms-transform: translateX(4px);
-  transform: translateX(4px);
+.c0[disabled] {
+  background-color: #e4e8ef;
+  border-color: #e4e8ef;
+  color: #9298af;
+  box-shadow: none;
+  cursor: not-allowed;
+}
+
+.c1 {
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
+  margin: 1rem 0;
+  padding-left: 0;
 }
 
 .c2 {
-  margin: 2rem 0;
+  width: 2rem;
+  margin-right: 0.4rem;
+  color: #f66663;
 }
 
 @media (max-width:600px) {
-
-}
-
-@media (max-width:600px) {
-
-}
-
-@media (max-width:600px) {
-  .c1 {
+  .c0 {
     font-size: 1.4rem;
   }
 }
@@ -434,26 +393,29 @@ exports[`<Primes /> should delete a primes 1`] = `
     Primes annuelles ou exceptionnelles perçues au cours des 3 derniers mois
   </p>
   <button
-    class="c0 c1 c2"
+    class="c0 c1"
     type="button"
   >
-    Ajouter une prime
     <svg
-      class="c3"
+      aria-hidden="true"
+      class="c2"
       fill="none"
-      viewBox="0 0 28 15"
+      viewBox="0 0 16 16"
     >
       <path
-        d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
+        clip-rule="evenodd"
+        d="M8 2a1 1 0 00-1 1v4H3a1 1 0 000 2h4v4a1 1 0 102 0V9h4a1 1 0 100-2H9V3a1 1 0 00-1-1z"
         fill="currentColor"
+        fill-rule="evenodd"
       />
     </svg>
+    Ajouter une prime
   </button>
 </div>
 `;
 
 exports[`<Primes /> should render 1`] = `
-.c5 {
+.c4 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -481,102 +443,39 @@ exports[`<Primes /> should render 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  height: 5.2rem;
-  padding: 0 4.4rem;
+  height: 4rem;
+  padding: 0 1rem;
   color: #3e486e;
-  background: #fff;
-  border-color: #bbcadf;
+  background: transparent;
+  border-color: transparent;
   box-shadow: none;
   opacity: 1;
 }
 
-.c5:link,
-.c5:visited {
+.c4:link,
+.c4:visited {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #3e486e;
 }
 
-.c5:not([disabled]):hover,
-.c5:not([disabled]):active,
-.c5:not([disabled]):focus {
-  opacity: 1;
+.c4:not([disabled]):hover,
+.c4:not([disabled]):active,
+.c4:not([disabled]):focus {
+  opacity: 0.6;
   -webkit-transform: translateY(-2px);
   -ms-transform: translateY(-2px);
   transform: translateY(-2px);
-  background: #fff;
-  border-color: #dee5ef;
+  background: transparent;
+  border-color: transparent;
 }
 
-.c5[disabled] {
+.c4[disabled] {
   background-color: #e4e8ef;
   border-color: #e4e8ef;
   color: #9298af;
   box-shadow: none;
   cursor: not-allowed;
-}
-
-.c7 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: content-box;
-  font-weight: 500;
-  font-size: 1.6rem;
-  line-height: 1.125em;
-  text-align: center;
-  vertical-align: middle;
-  border: 1px solid;
-  border-radius: 0.6rem;
-  cursor: pointer;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,-webkit-transform 100ms linear;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  padding: 0;
-  color: #f66663;
-  font-weight: 600;
-  font-size: 1.6rem;
-  line-height: 1.625;
-  vertical-align: baseline;
-  text-align: left;
-  background: none;
-  border: none;
-  border-radius: 0;
-  overflow: visible;
-}
-
-.c7:focus,
-.c7:hover,
-.c7:active {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c9 {
-  width: 2.6rem;
-  height: 1.4rem;
-  margin: 0 0.4rem 0 1rem;
-  -webkit-transition: -webkit-transform 250ms linear;
-  -webkit-transition: transform 250ms linear;
-  transition: transform 250ms linear;
-}
-
-.c4:hover .c9 {
-  -webkit-transform: translateX(4px);
-  -ms-transform: translateX(4px);
-  transform: translateX(4px);
 }
 
 .c1 {
@@ -678,15 +577,35 @@ exports[`<Primes /> should render 1`] = `
   color: #9298af;
 }
 
+.c7 {
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
+  margin: 1rem 0;
+  padding-left: 0;
+}
+
+.c6 {
+  width: 2rem;
+  margin-left: 0.4rem;
+  color: #f66663;
+}
+
+.c8 {
+  width: 2rem;
+  margin-right: 0.4rem;
+  color: #f66663;
+}
+
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -694,28 +613,12 @@ exports[`<Primes /> should render 1`] = `
   margin-bottom: 0.4rem;
 }
 
-.c6 {
-  margin-left: 2rem;
-}
-
-.c8 {
-  margin: 2rem 0;
+.c5 {
+  margin-left: 1.6rem;
 }
 
 @media (max-width:600px) {
-  .c5 {
-    font-size: 1.4rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c5 {
-    padding: 0 3rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c7 {
+  .c4 {
     font-size: 1.4rem;
   }
 }
@@ -766,27 +669,43 @@ exports[`<Primes /> should render 1`] = `
       </span>
     </div>
     <button
-      class="c4 c5 c6"
+      class="c4 c5"
       type="button"
     >
       Supprimer
+      <svg
+        aria-hidden="true"
+        class="c6"
+        fill="none"
+        viewBox="0 0 32 32"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M14.752 16.5L7.258 8.591A.957.957 0 017 7.932c0-.247.093-.484.259-.659A.858.858 0 017.883 7a.86.86 0 01.625.273L16 15.183l7.492-7.91A.859.859 0 0124.117 7c.234 0 .459.098.624.273a.957.957 0 01.259.659.957.957 0 01-.259.66L17.249 16.5l7.492 7.909a.958.958 0 01.259.659.957.957 0 01-.259.659.859.859 0 01-.624.273.86.86 0 01-.625-.273L16 17.817l-7.492 7.91a.859.859 0 01-.625.273.859.859 0 01-.624-.273.957.957 0 01-.259-.659.96.96 0 01.259-.66l7.492-7.908z"
+          fill="currentColor"
+          fill-rule="evenodd"
+        />
+      </svg>
     </button>
   </div>
   <button
-    class="c4 c7 c8"
+    class="c4 c7"
     type="button"
   >
-    Ajouter une prime
     <svg
-      class="c9"
+      aria-hidden="true"
+      class="c8"
       fill="none"
-      viewBox="0 0 28 15"
+      viewBox="0 0 16 16"
     >
       <path
-        d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
+        clip-rule="evenodd"
+        d="M8 2a1 1 0 00-1 1v4H3a1 1 0 000 2h4v4a1 1 0 102 0V9h4a1 1 0 100-2H9V3a1 1 0 00-1-1z"
         fill="currentColor"
+        fill-rule="evenodd"
       />
     </svg>
+    Ajouter une prime
   </button>
 </div>
 `;

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/components/__tests__/__snapshots__/SalaireTempsPartiel.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/components/__tests__/__snapshots__/SalaireTempsPartiel.test.js.snap
@@ -1,778 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<SalaireTempsPartiel /> should add a period 1`] = `
-.c8 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: content-box;
-  font-weight: 500;
-  font-size: 1.6rem;
-  line-height: 1.125em;
-  text-align: center;
-  vertical-align: middle;
-  border: 1px solid;
-  border-radius: 0.6rem;
-  cursor: pointer;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,-webkit-transform 100ms linear;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  height: 4rem;
-  padding: 0 1rem;
-  color: #3e486e;
-  background: transparent;
-  border-color: transparent;
-  box-shadow: none;
-  opacity: 1;
-}
-
-.c8:link,
-.c8:visited {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #3e486e;
-}
-
-.c8:not([disabled]):hover,
-.c8:not([disabled]):active,
-.c8:not([disabled]):focus {
-  opacity: 0.6;
-  -webkit-transform: translateY(-2px);
-  -ms-transform: translateY(-2px);
-  transform: translateY(-2px);
-  background: transparent;
-  border-color: transparent;
-}
-
-.c8[disabled] {
-  background-color: #e4e8ef;
-  border-color: #e4e8ef;
-  color: #9298af;
-  box-shadow: none;
-  cursor: not-allowed;
-}
-
-.c19 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: content-box;
-  font-weight: 500;
-  font-size: 1.6rem;
-  line-height: 1.125em;
-  text-align: center;
-  vertical-align: middle;
-  border: 1px solid;
-  border-radius: 0.6rem;
-  cursor: pointer;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,-webkit-transform 100ms linear;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  height: 5.2rem;
-  padding: 0 1.9rem;
-  color: #3e486e;
-  background: transparent;
-  border-color: transparent;
-  box-shadow: none;
-  opacity: 1;
-}
-
-.c19:link,
-.c19:visited {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #3e486e;
-}
-
-.c19:not([disabled]):hover,
-.c19:not([disabled]):active,
-.c19:not([disabled]):focus {
-  opacity: 0.6;
-  -webkit-transform: translateY(-2px);
-  -ms-transform: translateY(-2px);
-  transform: translateY(-2px);
-  background: transparent;
-  border-color: transparent;
-}
-
-.c19[disabled] {
-  background-color: #e4e8ef;
-  border-color: #e4e8ef;
-  color: #9298af;
-  box-shadow: none;
-  cursor: not-allowed;
-}
-
-.c7 {
-  color: #7994d4;
-  line-height: 1.25;
-  font-size: 1.8rem;
-  font-weight: 400;
-}
-
-.c14 {
-  position: relative;
-  display: inline-block;
-}
-
-.c15 {
-  width: 100%;
-  height: 5.4rem;
-  padding: 0 2rem;
-  padding-right: 2rem;
-  color: #3e486e;
-  font-weight: normal;
-  font-size: 1.6rem;
-  font-family: "Open Sans",sans-serif;
-  font-style: normal;
-  line-height: inherit;
-  text-align: right;
-  background: #fff;
-  border: 1px solid transparent;
-  border-color: transparent;
-  border-radius: 0.6rem;
-  box-shadow: 0 1rem 2rem rgba(121,148,212,0.2);
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
-.c15::-webkit-outer-spin-button,
-.c15::-webkit-inner-spin-button {
-  margin: 0;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
-.c15::-webkit-calendar-picker-indicator {
-  display: block;
-  width: 3.2rem;
-  height: 3.2rem;
-  margin-right: -2rem;
-  color: rgba(0,0,0,0);
-  background-color: #9298af;
-  cursor: pointer;
-  opacity: 1;
-  -webkit-mask-image: url("data:image/svg+xml;,%3Csvg%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M20.947%207.601h1.601c1.472%200%202.521%201.198%202.521%202.669v2.306l-.001%2010.392c0%201.472-1.049%202.669-2.521%202.669H8.669A2.672%202.672%200%20016%2022.967l.001-12.697a2.672%202.672%200%20012.67-2.669h1.331V6h.999v1.601H20V6h.947v1.601zm1.6%2017.036c.883%200%201.454-.786%201.454-1.67v-10.33h-17L7%2022.967c0%20.884.785%201.67%201.668%201.67h13.879zm-15.548-13h17.002l.001-1.367c0-.883-.57-1.601-1.453-1.601h-1.6v1.068H20V8.669h-9v1.068h-1V8.669H8.669C7.786%208.669%207%209.387%207%2010.27v1.367zm9.677%206.277h-2.135a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203h-2.135v2.135h2.136v-2.135zm3.203%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068H19.88a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135H19.88v-2.135zm-8.54%208.541H9.204a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H9.204v2.135h2.136l-.001-2.135zm3.202%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068h-2.135a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135h-2.136v-2.135zm7.473%203.203H19.88a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H19.88v2.135h2.136v-2.135z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E");
-  mask-image: url("data:image/svg+xml;,%3Csvg%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M20.947%207.601h1.601c1.472%200%202.521%201.198%202.521%202.669v2.306l-.001%2010.392c0%201.472-1.049%202.669-2.521%202.669H8.669A2.672%202.672%200%20016%2022.967l.001-12.697a2.672%202.672%200%20012.67-2.669h1.331V6h.999v1.601H20V6h.947v1.601zm1.6%2017.036c.883%200%201.454-.786%201.454-1.67v-10.33h-17L7%2022.967c0%20.884.785%201.67%201.668%201.67h13.879zm-15.548-13h17.002l.001-1.367c0-.883-.57-1.601-1.453-1.601h-1.6v1.068H20V8.669h-9v1.068h-1V8.669H8.669C7.786%208.669%207%209.387%207%2010.27v1.367zm9.677%206.277h-2.135a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203h-2.135v2.135h2.136v-2.135zm3.203%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068H19.88a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135H19.88v-2.135zm-8.54%208.541H9.204a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H9.204v2.135h2.136l-.001-2.135zm3.202%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068h-2.135a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135h-2.136v-2.135zm7.473%203.203H19.88a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H19.88v2.135h2.136v-2.135z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E");
-}
-
-.c15:invalid {
-  border-color: #eb5757;
-}
-
-.c15::-webkit-input-placeholder {
-  color: #9298af;
-}
-
-.c15::-moz-placeholder {
-  color: #9298af;
-}
-
-.c15:-ms-input-placeholder {
-  color: #9298af;
-}
-
-.c15::placeholder {
-  color: #9298af;
-}
-
-.c15:focus {
-  border-color: #7994d4;
-}
-
-.c15:focus::-webkit-input-placeholder {
-  color: transparent;
-}
-
-.c15:focus::-moz-placeholder {
-  color: transparent;
-}
-
-.c15:focus:-ms-input-placeholder {
-  color: transparent;
-}
-
-.c15:focus::placeholder {
-  color: transparent;
-}
-
-.c17 {
-  width: 100%;
-  height: 5.4rem;
-  padding: 0 2rem;
-  padding-right: 5rem;
-  color: #3e486e;
-  font-weight: normal;
-  font-size: 1.6rem;
-  font-family: "Open Sans",sans-serif;
-  font-style: normal;
-  line-height: inherit;
-  text-align: right;
-  background: #fff;
-  border: 1px solid transparent;
-  border-color: transparent;
-  border-radius: 0.6rem;
-  box-shadow: 0 1rem 2rem rgba(121,148,212,0.2);
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
-.c17::-webkit-outer-spin-button,
-.c17::-webkit-inner-spin-button {
-  margin: 0;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
-.c17::-webkit-calendar-picker-indicator {
-  display: block;
-  width: 3.2rem;
-  height: 3.2rem;
-  margin-right: -2rem;
-  color: rgba(0,0,0,0);
-  background-color: #9298af;
-  cursor: pointer;
-  opacity: 1;
-  -webkit-mask-image: url("data:image/svg+xml;,%3Csvg%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M20.947%207.601h1.601c1.472%200%202.521%201.198%202.521%202.669v2.306l-.001%2010.392c0%201.472-1.049%202.669-2.521%202.669H8.669A2.672%202.672%200%20016%2022.967l.001-12.697a2.672%202.672%200%20012.67-2.669h1.331V6h.999v1.601H20V6h.947v1.601zm1.6%2017.036c.883%200%201.454-.786%201.454-1.67v-10.33h-17L7%2022.967c0%20.884.785%201.67%201.668%201.67h13.879zm-15.548-13h17.002l.001-1.367c0-.883-.57-1.601-1.453-1.601h-1.6v1.068H20V8.669h-9v1.068h-1V8.669H8.669C7.786%208.669%207%209.387%207%2010.27v1.367zm9.677%206.277h-2.135a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203h-2.135v2.135h2.136v-2.135zm3.203%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068H19.88a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135H19.88v-2.135zm-8.54%208.541H9.204a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H9.204v2.135h2.136l-.001-2.135zm3.202%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068h-2.135a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135h-2.136v-2.135zm7.473%203.203H19.88a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H19.88v2.135h2.136v-2.135z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E");
-  mask-image: url("data:image/svg+xml;,%3Csvg%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M20.947%207.601h1.601c1.472%200%202.521%201.198%202.521%202.669v2.306l-.001%2010.392c0%201.472-1.049%202.669-2.521%202.669H8.669A2.672%202.672%200%20016%2022.967l.001-12.697a2.672%202.672%200%20012.67-2.669h1.331V6h.999v1.601H20V6h.947v1.601zm1.6%2017.036c.883%200%201.454-.786%201.454-1.67v-10.33h-17L7%2022.967c0%20.884.785%201.67%201.668%201.67h13.879zm-15.548-13h17.002l.001-1.367c0-.883-.57-1.601-1.453-1.601h-1.6v1.068H20V8.669h-9v1.068h-1V8.669H8.669C7.786%208.669%207%209.387%207%2010.27v1.367zm9.677%206.277h-2.135a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203h-2.135v2.135h2.136v-2.135zm3.203%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068H19.88a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135H19.88v-2.135zm-8.54%208.541H9.204a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H9.204v2.135h2.136l-.001-2.135zm3.202%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068h-2.135a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135h-2.136v-2.135zm7.473%203.203H19.88a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H19.88v2.135h2.136v-2.135z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E");
-}
-
-.c17:invalid {
-  border-color: #eb5757;
-}
-
-.c17::-webkit-input-placeholder {
-  color: #9298af;
-}
-
-.c17::-moz-placeholder {
-  color: #9298af;
-}
-
-.c17:-ms-input-placeholder {
-  color: #9298af;
-}
-
-.c17::placeholder {
-  color: #9298af;
-}
-
-.c17:focus {
-  border-color: #7994d4;
-}
-
-.c17:focus::-webkit-input-placeholder {
-  color: transparent;
-}
-
-.c17:focus::-moz-placeholder {
-  color: transparent;
-}
-
-.c17:focus:-ms-input-placeholder {
-  color: transparent;
-}
-
-.c17:focus::placeholder {
-  color: transparent;
-}
-
-.c18 {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  width: 100%;
-  max-width: 3.2rem;
-  height: 100%;
-  max-height: 3.2rem;
-  color: #9298af;
-}
-
-.c11 {
-  position: relative;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  text-align: center;
-}
-
-.c13 {
-  position: absolute;
-  top: 1.6rem;
-  right: 1.6rem;
-  width: 1.6rem;
-  height: 1.6rem;
-  color: #f66663;
-  pointer-events: none;
-}
-
-.c12 {
-  width: 100%;
-  height: 5.4rem;
-  padding: 0 2rem 0;
-  padding-right: 5rem;
-  color: #3e486e;
-  font-size: 1.6rem;
-  font-family: "Open Sans",sans-serif;
-  vertical-align: middle;
-  background-color: #fff;
-  border: none;
-  border-radius: 0.6rem;
-  box-shadow: 0 1rem 2rem rgba(121,148,212,0.2);
-  cursor: pointer;
-  -webkit-transition: border-color 250ms ease;
-  transition: border-color 250ms ease;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
-.c12::-ms-expand {
-  background-color: transparent;
-  border: 0 transparent;
-}
-
-.c12 *::-ms-backdrop,
-.c12 {
-  padding-right: 1.6rem;
-}
-
-.c12:invalid {
-  border-color: #eb5757;
-}
-
-.c12:disabled {
-  background-color: #e4e8ef;
-}
-
-.c20 {
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: start;
-  align-self: flex-start;
-  margin: 1rem 0;
-  padding-left: 0;
-}
-
-.c9 {
-  margin-left: 1rem;
-}
-
-.c10 {
-  width: 2rem;
-  margin-left: 0.4rem;
-  color: #f66663;
-}
-
-.c21 {
-  width: 2rem;
-  margin-right: 0.4rem;
-  color: #f66663;
-}
-
-.c0 {
-  display: block;
-  margin-top: 2rem;
-  margin-bottom: 1rem;
-  font-weight: 600;
-  font-size: 1.8rem;
-  cursor: pointer;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  margin-bottom: 1rem;
-}
-
-.c6 {
-  display: none;
-}
-
-.c4 {
-  padding-top: 1rem;
-  padding-bottom: 0.4rem;
-  font-weight: 700;
-  font-size: 1.4rem;
-}
-
-.c3 {
-  -webkit-flex-basis: 20rem;
-  -ms-flex-preferred-size: 20rem;
-  flex-basis: 20rem;
-  margin-right: 2rem;
-}
-
-.c5 {
-  -webkit-flex-basis: 15rem;
-  -ms-flex-preferred-size: 15rem;
-  flex-basis: 15rem;
-  margin-right: 2rem;
-}
-
-.c16 {
-  -webkit-flex-basis: 20rem;
-  -ms-flex-preferred-size: 20rem;
-  flex-basis: 20rem;
-}
-
-@media (max-width:600px) {
-  .c8 {
-    font-size: 1.4rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c19 {
-    font-size: 1.4rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c14 {
-    width: 100%;
-  }
-}
-
-@media (max-width:600px) {
-  .c15 {
-    padding: 0 1rem;
-    padding-right: 2rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c17 {
-    padding: 0 1rem;
-    padding-right: 5rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c11 {
-    width: 100%;
-  }
-}
-
-@media (max-width:600px) {
-  .c0 {
-    font-size: 1.6rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c2 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-    margin-bottom: 3.2rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c1 {
-    display: none;
-  }
-}
-
-@media (max-width:600px) {
-  .c6 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-align-items: center;
-    -webkit-box-align: center;
-    -ms-flex-align: center;
-    align-items: center;
-    -webkit-box-pack: justify;
-    -webkit-justify-content: space-between;
-    -ms-flex-pack: justify;
-    justify-content: space-between;
-  }
-}
-
-@media (max-width:600px) {
-  .c3 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    margin-right: 0;
-  }
-}
-
-@media (max-width:600px) {
-  .c5 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    margin-right: 0;
-  }
-}
-
-@media (max-width:600px) {
-  .c16 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-  }
-}
-
-<div>
-  <label
-    class="c0"
-  >
-    Quels ont été les durées et les salaires des périodes à temps plein et à temps partiel ?
-  </label>
-  <div
-    class="c1 c2"
-  >
-    <div
-      class="c3 c4"
-    >
-      Type de durée de travail
-    </div>
-    <div
-      class="c5 c4"
-    >
-      Durée (en mois)
-    </div>
-    <div
-      class="c4"
-    >
-      Rémunération
-    </div>
-  </div>
-  <div
-    class="c2"
-  >
-    <div
-      class="c6"
-    >
-      <span
-        class="c7"
-        font-size="hsmall"
-        font-weight="400"
-      >
-        Période 
-        1
-      </span>
-      <button
-        class="c8 c9"
-        type="button"
-      >
-        Supprimer
-        <svg
-          aria-hidden="true"
-          class="c10"
-          fill="none"
-          viewBox="0 0 32 32"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M14.752 16.5L7.258 8.591A.957.957 0 017 7.932c0-.247.093-.484.259-.659A.858.858 0 017.883 7a.86.86 0 01.625.273L16 15.183l7.492-7.91A.859.859 0 0124.117 7c.234 0 .459.098.624.273a.957.957 0 01.259.659.957.957 0 01-.259.66L17.249 16.5l7.492 7.909a.958.958 0 01.259.659.957.957 0 01-.259.659.859.859 0 01-.624.273.86.86 0 01-.625-.273L16 17.817l-7.492 7.91a.859.859 0 01-.625.273.859.859 0 01-.624-.273.957.957 0 01-.259-.659.96.96 0 01.259-.66l7.492-7.908z"
-            fill="currentColor"
-            fill-rule="evenodd"
-          />
-        </svg>
-      </button>
-    </div>
-    <div
-      class="c3"
-    >
-      <div
-        class="c6 c4"
-      >
-        Type de durée de travail
-      </div>
-      <div
-        class="c11"
-      >
-        <select
-          class="c12"
-          name="periods[0].type"
-        >
-          <option>
-            Temps partiel
-          </option>
-          <option>
-            Temps plein
-          </option>
-        </select>
-        <div
-          aria-hidden="true"
-          class="c13"
-        >
-          <svg
-            fill="none"
-            viewBox="0 0 16 16"
-          >
-            <g
-              clip-path="url(#arrow-down_svg__clip0)"
-            >
-              <path
-                d="M8.425 11.573l7.11-6.072a.709.709 0 00.26-.537.709.709 0 00-.26-.537.973.973 0 00-.629-.223.973.973 0 00-.63.223l-6.48 5.536-6.481-5.536a.973.973 0 00-.63-.223.973.973 0 00-.628.223.708.708 0 00-.261.537c0 .202.094.395.26.537l7.11 6.072a.91.91 0 00.29.165 1.021 1.021 0 00.68 0 .91.91 0 00.29-.165z"
-                fill="currentColor"
-              />
-            </g>
-            <defs>
-              <clippath
-                id="arrow-down_svg__clip0"
-              >
-                <path
-                  d="M0 0h16v16H0z"
-                  fill="currentColor"
-                />
-              </clippath>
-            </defs>
-          </svg>
-        </div>
-      </div>
-    </div>
-    <div
-      class="c5"
-    >
-      <div
-        class="c6 c4"
-      >
-        Durée (en mois)
-      </div>
-      <span
-        class="c14"
-      >
-        <input
-          class="c15"
-          name="periods[0].duration"
-          type="number"
-          value=""
-        />
-      </span>
-    </div>
-    <div
-      class="c16"
-    >
-      <div
-        class="c6 c4"
-      >
-        Rémunération
-      </div>
-      <span
-        class="c14"
-      >
-        <input
-          class="c17"
-          name="periods[0].salary"
-          type="number"
-          value=""
-        />
-        <div
-          class="c18"
-        >
-          <svg
-            fill="none"
-            viewBox="0 0 32 32"
-          >
-            <path
-              d="M17.632 12.392c-.78 0-1.42.232-1.917.697-.493.465-.822 1.168-.988 2.108h3.785v1.279h-3.91l-.016.373v.457l.016.323h3.387v1.27h-3.245c.354 1.727 1.361 2.59 3.021 2.59.791 0 1.602-.171 2.432-.514v1.685c-.725.337-1.569.506-2.531.506-1.334 0-2.419-.365-3.254-1.096-.83-.73-1.373-1.787-1.627-3.17h-1.262v-1.27h1.129l-.017-.308v-.307l.017-.54h-1.13v-1.278h1.246c.21-1.389.739-2.479 1.585-3.27.847-.792 1.94-1.187 3.28-1.187 1.106 0 2.097.243 2.971.73l-.697 1.553c-.852-.421-1.61-.631-2.275-.631z"
-              fill="currentColor"
-            />
-          </svg>
-        </div>
-      </span>
-    </div>
-    <div
-      class="c1"
-    >
-      <button
-        class="c19 c9"
-        type="button"
-      >
-        Supprimer
-        <svg
-          aria-hidden="true"
-          class="c10"
-          fill="none"
-          viewBox="0 0 32 32"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M14.752 16.5L7.258 8.591A.957.957 0 017 7.932c0-.247.093-.484.259-.659A.858.858 0 017.883 7a.86.86 0 01.625.273L16 15.183l7.492-7.91A.859.859 0 0124.117 7c.234 0 .459.098.624.273a.957.957 0 01.259.659.957.957 0 01-.259.66L17.249 16.5l7.492 7.909a.958.958 0 01.259.659.957.957 0 01-.259.659.859.859 0 01-.624.273.86.86 0 01-.625-.273L16 17.817l-7.492 7.91a.859.859 0 01-.625.273.859.859 0 01-.624-.273.957.957 0 01-.259-.659.96.96 0 01.259-.66l7.492-7.908z"
-            fill="currentColor"
-            fill-rule="evenodd"
-          />
-        </svg>
-      </button>
-    </div>
-  </div>
-  <button
-    class="c8 c20"
-    type="button"
-  >
-    <svg
-      aria-hidden="true"
-      class="c21"
-      fill="none"
-      viewBox="0 0 16 16"
-    >
-      <path
-        clip-rule="evenodd"
-        d="M8 2a1 1 0 00-1 1v4H3a1 1 0 000 2h4v4a1 1 0 102 0V9h4a1 1 0 100-2H9V3a1 1 0 00-1-1z"
-        fill="currentColor"
-        fill-rule="evenodd"
-      />
-    </svg>
-    Ajouter une période
-  </button>
-</div>
-`;
-
 exports[`<SalaireTempsPartiel /> should delete a period 1`] = `
-.c8 {
+.c15 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -809,16 +38,16 @@ exports[`<SalaireTempsPartiel /> should delete a period 1`] = `
   opacity: 1;
 }
 
-.c8:link,
-.c8:visited {
+.c15:link,
+.c15:visited {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #3e486e;
 }
 
-.c8:not([disabled]):hover,
-.c8:not([disabled]):active,
-.c8:not([disabled]):focus {
+.c15:not([disabled]):hover,
+.c15:not([disabled]):active,
+.c15:not([disabled]):focus {
   opacity: 0.6;
   -webkit-transform: translateY(-2px);
   -ms-transform: translateY(-2px);
@@ -827,7 +56,7 @@ exports[`<SalaireTempsPartiel /> should delete a period 1`] = `
   border-color: transparent;
 }
 
-.c8[disabled] {
+.c15[disabled] {
   background-color: #e4e8ef;
   border-color: #e4e8ef;
   color: #9298af;
@@ -835,82 +64,19 @@ exports[`<SalaireTempsPartiel /> should delete a period 1`] = `
   cursor: not-allowed;
 }
 
-.c19 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: content-box;
-  font-weight: 500;
-  font-size: 1.6rem;
-  line-height: 1.125em;
-  text-align: center;
-  vertical-align: middle;
-  border: 1px solid;
-  border-radius: 0.6rem;
-  cursor: pointer;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,-webkit-transform 100ms linear;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  height: 5.2rem;
-  padding: 0 1.9rem;
-  color: #3e486e;
-  background: transparent;
-  border-color: transparent;
-  box-shadow: none;
-  opacity: 1;
-}
-
-.c19:link,
-.c19:visited {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #3e486e;
-}
-
-.c19:not([disabled]):hover,
-.c19:not([disabled]):active,
-.c19:not([disabled]):focus {
-  opacity: 0.6;
-  -webkit-transform: translateY(-2px);
-  -ms-transform: translateY(-2px);
-  transform: translateY(-2px);
-  background: transparent;
-  border-color: transparent;
-}
-
-.c19[disabled] {
-  background-color: #e4e8ef;
-  border-color: #e4e8ef;
-  color: #9298af;
-  box-shadow: none;
-  cursor: not-allowed;
-}
-
-.c7 {
+.c3 {
   color: #7994d4;
   line-height: 1.25;
   font-size: 1.8rem;
   font-weight: 400;
 }
 
-.c14 {
+.c11 {
   position: relative;
   display: inline-block;
 }
 
-.c15 {
+.c12 {
   width: 100%;
   height: 5.4rem;
   padding: 0 2rem;
@@ -932,15 +98,15 @@ exports[`<SalaireTempsPartiel /> should delete a period 1`] = `
   appearance: none;
 }
 
-.c15::-webkit-outer-spin-button,
-.c15::-webkit-inner-spin-button {
+.c12::-webkit-outer-spin-button,
+.c12::-webkit-inner-spin-button {
   margin: 0;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c15::-webkit-calendar-picker-indicator {
+.c12::-webkit-calendar-picker-indicator {
   display: block;
   width: 3.2rem;
   height: 3.2rem;
@@ -953,47 +119,47 @@ exports[`<SalaireTempsPartiel /> should delete a period 1`] = `
   mask-image: url("data:image/svg+xml;,%3Csvg%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M20.947%207.601h1.601c1.472%200%202.521%201.198%202.521%202.669v2.306l-.001%2010.392c0%201.472-1.049%202.669-2.521%202.669H8.669A2.672%202.672%200%20016%2022.967l.001-12.697a2.672%202.672%200%20012.67-2.669h1.331V6h.999v1.601H20V6h.947v1.601zm1.6%2017.036c.883%200%201.454-.786%201.454-1.67v-10.33h-17L7%2022.967c0%20.884.785%201.67%201.668%201.67h13.879zm-15.548-13h17.002l.001-1.367c0-.883-.57-1.601-1.453-1.601h-1.6v1.068H20V8.669h-9v1.068h-1V8.669H8.669C7.786%208.669%207%209.387%207%2010.27v1.367zm9.677%206.277h-2.135a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203h-2.135v2.135h2.136v-2.135zm3.203%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068H19.88a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135H19.88v-2.135zm-8.54%208.541H9.204a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H9.204v2.135h2.136l-.001-2.135zm3.202%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068h-2.135a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135h-2.136v-2.135zm7.473%203.203H19.88a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H19.88v2.135h2.136v-2.135z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E");
 }
 
-.c15:invalid {
+.c12:invalid {
   border-color: #eb5757;
 }
 
-.c15::-webkit-input-placeholder {
+.c12::-webkit-input-placeholder {
   color: #9298af;
 }
 
-.c15::-moz-placeholder {
+.c12::-moz-placeholder {
   color: #9298af;
 }
 
-.c15:-ms-input-placeholder {
+.c12:-ms-input-placeholder {
   color: #9298af;
 }
 
-.c15::placeholder {
+.c12::placeholder {
   color: #9298af;
 }
 
-.c15:focus {
+.c12:focus {
   border-color: #7994d4;
 }
 
-.c15:focus::-webkit-input-placeholder {
+.c12:focus::-webkit-input-placeholder {
   color: transparent;
 }
 
-.c15:focus::-moz-placeholder {
+.c12:focus::-moz-placeholder {
   color: transparent;
 }
 
-.c15:focus:-ms-input-placeholder {
+.c12:focus:-ms-input-placeholder {
   color: transparent;
 }
 
-.c15:focus::placeholder {
+.c12:focus::placeholder {
   color: transparent;
 }
 
-.c17 {
+.c13 {
   width: 100%;
   height: 5.4rem;
   padding: 0 2rem;
@@ -1015,15 +181,15 @@ exports[`<SalaireTempsPartiel /> should delete a period 1`] = `
   appearance: none;
 }
 
-.c17::-webkit-outer-spin-button,
-.c17::-webkit-inner-spin-button {
+.c13::-webkit-outer-spin-button,
+.c13::-webkit-inner-spin-button {
   margin: 0;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c17::-webkit-calendar-picker-indicator {
+.c13::-webkit-calendar-picker-indicator {
   display: block;
   width: 3.2rem;
   height: 3.2rem;
@@ -1036,47 +202,47 @@ exports[`<SalaireTempsPartiel /> should delete a period 1`] = `
   mask-image: url("data:image/svg+xml;,%3Csvg%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M20.947%207.601h1.601c1.472%200%202.521%201.198%202.521%202.669v2.306l-.001%2010.392c0%201.472-1.049%202.669-2.521%202.669H8.669A2.672%202.672%200%20016%2022.967l.001-12.697a2.672%202.672%200%20012.67-2.669h1.331V6h.999v1.601H20V6h.947v1.601zm1.6%2017.036c.883%200%201.454-.786%201.454-1.67v-10.33h-17L7%2022.967c0%20.884.785%201.67%201.668%201.67h13.879zm-15.548-13h17.002l.001-1.367c0-.883-.57-1.601-1.453-1.601h-1.6v1.068H20V8.669h-9v1.068h-1V8.669H8.669C7.786%208.669%207%209.387%207%2010.27v1.367zm9.677%206.277h-2.135a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203h-2.135v2.135h2.136v-2.135zm3.203%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068H19.88a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135H19.88v-2.135zm-8.54%208.541H9.204a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H9.204v2.135h2.136l-.001-2.135zm3.202%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068h-2.135a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135h-2.136v-2.135zm7.473%203.203H19.88a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H19.88v2.135h2.136v-2.135z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E");
 }
 
-.c17:invalid {
+.c13:invalid {
   border-color: #eb5757;
 }
 
-.c17::-webkit-input-placeholder {
+.c13::-webkit-input-placeholder {
   color: #9298af;
 }
 
-.c17::-moz-placeholder {
+.c13::-moz-placeholder {
   color: #9298af;
 }
 
-.c17:-ms-input-placeholder {
+.c13:-ms-input-placeholder {
   color: #9298af;
 }
 
-.c17::placeholder {
+.c13::placeholder {
   color: #9298af;
 }
 
-.c17:focus {
+.c13:focus {
   border-color: #7994d4;
 }
 
-.c17:focus::-webkit-input-placeholder {
+.c13:focus::-webkit-input-placeholder {
   color: transparent;
 }
 
-.c17:focus::-moz-placeholder {
+.c13:focus::-moz-placeholder {
   color: transparent;
 }
 
-.c17:focus:-ms-input-placeholder {
+.c13:focus:-ms-input-placeholder {
   color: transparent;
 }
 
-.c17:focus::placeholder {
+.c13:focus::placeholder {
   color: transparent;
 }
 
-.c18 {
+.c14 {
   position: absolute;
   top: 1rem;
   right: 1rem;
@@ -1087,7 +253,21 @@ exports[`<SalaireTempsPartiel /> should delete a period 1`] = `
   color: #9298af;
 }
 
-.c11 {
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding-bottom: 0.4rem;
+  font-weight: 600;
+  font-size: 1.4rem;
+  font-family: "Open Sans",sans-serif;
+  font-style: normal;
+  line-height: 2;
+  cursor: pointer;
+}
+
+.c7 {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -1107,7 +287,7 @@ exports[`<SalaireTempsPartiel /> should delete a period 1`] = `
   text-align: center;
 }
 
-.c13 {
+.c10 {
   position: absolute;
   top: 1.6rem;
   right: 1.6rem;
@@ -1117,7 +297,7 @@ exports[`<SalaireTempsPartiel /> should delete a period 1`] = `
   pointer-events: none;
 }
 
-.c12 {
+.c9 {
   width: 100%;
   height: 5.4rem;
   padding: 0 2rem 0;
@@ -1138,25 +318,25 @@ exports[`<SalaireTempsPartiel /> should delete a period 1`] = `
   appearance: none;
 }
 
-.c12::-ms-expand {
+.c9::-ms-expand {
   background-color: transparent;
   border: 0 transparent;
 }
 
-.c12 *::-ms-backdrop,
-.c12 {
+.c9 *::-ms-backdrop,
+.c9 {
   padding-right: 1.6rem;
 }
 
-.c12:invalid {
+.c9:invalid {
   border-color: #eb5757;
 }
 
-.c12:disabled {
+.c9:disabled {
   background-color: #e4e8ef;
 }
 
-.c20 {
+.c16 {
   -webkit-align-self: flex-start;
   -ms-flex-item-align: start;
   align-self: flex-start;
@@ -1164,20 +344,70 @@ exports[`<SalaireTempsPartiel /> should delete a period 1`] = `
   padding-left: 0;
 }
 
-.c9 {
-  margin-left: 1rem;
-}
-
-.c10 {
-  width: 2rem;
-  margin-left: 0.4rem;
-  color: #f66663;
-}
-
-.c21 {
+.c17 {
   width: 2rem;
   margin-right: 0.4rem;
   color: #f66663;
+}
+
+.c4 {
+  display: -ms-grid;
+  -ms-grid-rows: auto auto;
+  -ms-grid-columns: 2fr 1fr 1fr 13rem;
+  display: grid;
+  grid-template-rows: auto auto;
+  grid-template-columns: 2fr 1fr 1fr 13rem;
+  margin-top: 1.6rem;
+  margin-bottom: 1.6rem;
+}
+
+.c4 > *:nth-child(1) {
+  -ms-grid-row: 1;
+  -ms-grid-column: 1;
+  grid-row: 1;
+  grid-column: 1;
+}
+
+.c4 > *:nth-child(2) {
+  -ms-grid-row: 2;
+  -ms-grid-column: 1;
+  grid-row: 2;
+  grid-column: 1;
+}
+
+.c4 > *:nth-child(3) {
+  -ms-grid-row: 1;
+  -ms-grid-column: 2;
+  grid-row: 1;
+  grid-column: 2;
+}
+
+.c4 > *:nth-child(4) {
+  -ms-grid-row: 2;
+  -ms-grid-column: 2;
+  grid-row: 2;
+  grid-column: 2;
+}
+
+.c4 > *:nth-child(5) {
+  -ms-grid-row: 1;
+  -ms-grid-column: 3;
+  grid-row: 1;
+  grid-column: 3;
+}
+
+.c4 > *:nth-child(6) {
+  -ms-grid-row: 2;
+  -ms-grid-column: 3;
+  grid-row: 2;
+  grid-column: 3;
+}
+
+.c4 > *:nth-child(7) {
+  -ms-grid-row: 2;
+  -ms-grid-column: 4;
+  grid-row: 2;
+  grid-column: 4;
 }
 
 .c0 {
@@ -1186,81 +416,32 @@ exports[`<SalaireTempsPartiel /> should delete a period 1`] = `
   margin-bottom: 1rem;
   font-weight: 600;
   font-size: 1.8rem;
-  cursor: pointer;
+  cursor: default;
+}
+
+.c1 {
+  position: relative;
 }
 
 .c2 {
+  margin-bottom: 1.6rem;
+  padding-top: 1rem;
+}
+
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  margin-bottom: 1rem;
 }
 
 .c6 {
-  display: none;
-}
-
-.c4 {
-  padding-top: 1rem;
-  padding-bottom: 0.4rem;
-  font-weight: 700;
-  font-size: 1.4rem;
-}
-
-.c3 {
-  -webkit-flex-basis: 20rem;
-  -ms-flex-preferred-size: 20rem;
-  flex-basis: 20rem;
-  margin-right: 2rem;
-}
-
-.c5 {
-  -webkit-flex-basis: 15rem;
-  -ms-flex-preferred-size: 15rem;
-  flex-basis: 15rem;
-  margin-right: 2rem;
-}
-
-.c16 {
-  -webkit-flex-basis: 20rem;
-  -ms-flex-preferred-size: 20rem;
-  flex-basis: 20rem;
-}
-
-@media (max-width:600px) {
-  .c8 {
-    font-size: 1.4rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c19 {
-    font-size: 1.4rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c14 {
-    width: 100%;
-  }
+  margin-right: 1.6rem;
 }
 
 @media (max-width:600px) {
   .c15 {
-    padding: 0 1rem;
-    padding-right: 2rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c17 {
-    padding: 0 1rem;
-    padding-right: 5rem;
+    font-size: 1.4rem;
   }
 }
 
@@ -1271,262 +452,188 @@ exports[`<SalaireTempsPartiel /> should delete a period 1`] = `
 }
 
 @media (max-width:600px) {
+  .c12 {
+    padding: 0 1rem;
+    padding-right: 2rem;
+  }
+}
+
+@media (max-width:600px) {
+  .c13 {
+    padding: 0 1rem;
+    padding-right: 5rem;
+  }
+}
+
+@media (max-width:600px) {
+  .c7 {
+    width: 100%;
+  }
+}
+
+@media (max-width:600px) {
+  .c4 {
+    display: block;
+    margin-bottom: 3.2rem;
+  }
+}
+
+@media (max-width:600px) {
   .c0 {
     font-size: 1.6rem;
   }
 }
 
 @media (max-width:600px) {
-  .c2 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-    margin-bottom: 3.2rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c1 {
-    display: none;
-  }
-}
-
-@media (max-width:600px) {
   .c6 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-align-items: center;
-    -webkit-box-align: center;
-    -ms-flex-align: center;
-    align-items: center;
-    -webkit-box-pack: justify;
-    -webkit-justify-content: space-between;
-    -ms-flex-pack: justify;
-    justify-content: space-between;
-  }
-}
-
-@media (max-width:600px) {
-  .c3 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
     margin-right: 0;
+    margin-bottom: 1.6rem;
   }
 }
 
 @media (max-width:600px) {
-  .c5 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    margin-right: 0;
-  }
-}
 
-@media (max-width:600px) {
-  .c16 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-  }
 }
 
 <div>
-  <label
+  <p
     class="c0"
   >
     Quels ont été les durées et les salaires des périodes à temps plein et à temps partiel ?
-  </label>
+  </p>
   <div
-    class="c1 c2"
+    class="c1"
   >
     <div
-      class="c3 c4"
-    >
-      Type de durée de travail
-    </div>
-    <div
-      class="c5 c4"
-    >
-      Durée (en mois)
-    </div>
-    <div
-      class="c4"
-    >
-      Rémunération
-    </div>
-  </div>
-  <div
-    class="c2"
-  >
-    <div
-      class="c6"
+      class="c2"
     >
       <span
-        class="c7"
+        class="c3"
         font-size="hsmall"
         font-weight="400"
       >
         Période 
         1
       </span>
-      <button
-        class="c8 c9"
-        type="button"
-      >
-        Supprimer
-        <svg
-          aria-hidden="true"
-          class="c10"
-          fill="none"
-          viewBox="0 0 32 32"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M14.752 16.5L7.258 8.591A.957.957 0 017 7.932c0-.247.093-.484.259-.659A.858.858 0 017.883 7a.86.86 0 01.625.273L16 15.183l7.492-7.91A.859.859 0 0124.117 7c.234 0 .459.098.624.273a.957.957 0 01.259.659.957.957 0 01-.259.66L17.249 16.5l7.492 7.909a.958.958 0 01.259.659.957.957 0 01-.259.659.859.859 0 01-.624.273.86.86 0 01-.625-.273L16 17.817l-7.492 7.91a.859.859 0 01-.625.273.859.859 0 01-.624-.273.957.957 0 01-.259-.659.96.96 0 01.259-.66l7.492-7.908z"
-            fill="currentColor"
-            fill-rule="evenodd"
-          />
-        </svg>
-      </button>
     </div>
     <div
-      class="c3"
+      class="c4"
     >
-      <div
-        class="c6 c4"
+      <label
+        class="c5"
+        for="periods[0].type"
       >
         Type de durée de travail
-      </div>
+      </label>
       <div
-        class="c11"
+        class="c6"
       >
-        <select
-          class="c12"
-          name="periods[0].type"
-        >
-          <option>
-            Temps partiel
-          </option>
-          <option>
-            Temps plein
-          </option>
-        </select>
         <div
-          aria-hidden="true"
-          class="c13"
+          class="c7 c8"
         >
-          <svg
-            fill="none"
-            viewBox="0 0 16 16"
+          <select
+            class="c9"
+            name="periods[0].type"
           >
-            <g
-              clip-path="url(#arrow-down_svg__clip0)"
+            <option>
+              Temps partiel
+            </option>
+            <option>
+              Temps plein
+            </option>
+          </select>
+          <div
+            aria-hidden="true"
+            class="c10"
+          >
+            <svg
+              fill="none"
+              viewBox="0 0 16 16"
             >
-              <path
-                d="M8.425 11.573l7.11-6.072a.709.709 0 00.26-.537.709.709 0 00-.26-.537.973.973 0 00-.629-.223.973.973 0 00-.63.223l-6.48 5.536-6.481-5.536a.973.973 0 00-.63-.223.973.973 0 00-.628.223.708.708 0 00-.261.537c0 .202.094.395.26.537l7.11 6.072a.91.91 0 00.29.165 1.021 1.021 0 00.68 0 .91.91 0 00.29-.165z"
-                fill="currentColor"
-              />
-            </g>
-            <defs>
-              <clippath
-                id="arrow-down_svg__clip0"
+              <g
+                clip-path="url(#arrow-down_svg__clip0)"
               >
                 <path
-                  d="M0 0h16v16H0z"
+                  d="M8.425 11.573l7.11-6.072a.709.709 0 00.26-.537.709.709 0 00-.26-.537.973.973 0 00-.629-.223.973.973 0 00-.63.223l-6.48 5.536-6.481-5.536a.973.973 0 00-.63-.223.973.973 0 00-.628.223.708.708 0 00-.261.537c0 .202.094.395.26.537l7.11 6.072a.91.91 0 00.29.165 1.021 1.021 0 00.68 0 .91.91 0 00.29-.165z"
                   fill="currentColor"
                 />
-              </clippath>
-            </defs>
-          </svg>
+              </g>
+              <defs>
+                <clippath
+                  id="arrow-down_svg__clip0"
+                >
+                  <path
+                    d="M0 0h16v16H0z"
+                    fill="currentColor"
+                  />
+                </clippath>
+              </defs>
+            </svg>
+          </div>
         </div>
       </div>
-    </div>
-    <div
-      class="c5"
-    >
-      <div
-        class="c6 c4"
+      <label
+        class="c5"
+        for="periods[0].duration"
       >
         Durée (en mois)
-      </div>
-      <span
-        class="c14"
-      >
-        <input
-          class="c15"
-          name="periods[0].duration"
-          type="number"
-          value="6"
-        />
-      </span>
-    </div>
-    <div
-      class="c16"
-    >
+      </label>
       <div
-        class="c6 c4"
+        class="c6"
+      >
+        <span
+          class="c11"
+        >
+          <input
+            class="c12"
+            id="periods[0].duration"
+            name="periods[0].duration"
+            type="number"
+            value="6"
+          />
+        </span>
+      </div>
+      <label
+        class="c5"
+        for="periods[0].salary"
       >
         Rémunération
-      </div>
-      <span
-        class="c14"
-      >
-        <input
-          class="c17"
-          name="periods[0].salary"
-          type="number"
-          value="1000"
-        />
-        <div
-          class="c18"
+      </label>
+      <div>
+        <span
+          class="c11"
         >
-          <svg
-            fill="none"
-            viewBox="0 0 32 32"
-          >
-            <path
-              d="M17.632 12.392c-.78 0-1.42.232-1.917.697-.493.465-.822 1.168-.988 2.108h3.785v1.279h-3.91l-.016.373v.457l.016.323h3.387v1.27h-3.245c.354 1.727 1.361 2.59 3.021 2.59.791 0 1.602-.171 2.432-.514v1.685c-.725.337-1.569.506-2.531.506-1.334 0-2.419-.365-3.254-1.096-.83-.73-1.373-1.787-1.627-3.17h-1.262v-1.27h1.129l-.017-.308v-.307l.017-.54h-1.13v-1.278h1.246c.21-1.389.739-2.479 1.585-3.27.847-.792 1.94-1.187 3.28-1.187 1.106 0 2.097.243 2.971.73l-.697 1.553c-.852-.421-1.61-.631-2.275-.631z"
-              fill="currentColor"
-            />
-          </svg>
-        </div>
-      </span>
-    </div>
-    <div
-      class="c1"
-    >
-      <button
-        class="c19 c9"
-        type="button"
-      >
-        Supprimer
-        <svg
-          aria-hidden="true"
-          class="c10"
-          fill="none"
-          viewBox="0 0 32 32"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M14.752 16.5L7.258 8.591A.957.957 0 017 7.932c0-.247.093-.484.259-.659A.858.858 0 017.883 7a.86.86 0 01.625.273L16 15.183l7.492-7.91A.859.859 0 0124.117 7c.234 0 .459.098.624.273a.957.957 0 01.259.659.957.957 0 01-.259.66L17.249 16.5l7.492 7.909a.958.958 0 01.259.659.957.957 0 01-.259.659.859.859 0 01-.624.273.86.86 0 01-.625-.273L16 17.817l-7.492 7.91a.859.859 0 01-.625.273.859.859 0 01-.624-.273.957.957 0 01-.259-.659.96.96 0 01.259-.66l7.492-7.908z"
-            fill="currentColor"
-            fill-rule="evenodd"
+          <input
+            class="c13"
+            id="periods[0].salary"
+            name="periods[0].salary"
+            type="number"
+            value="1000"
           />
-        </svg>
-      </button>
+          <div
+            class="c14"
+          >
+            <svg
+              fill="none"
+              viewBox="0 0 32 32"
+            >
+              <path
+                d="M17.632 12.392c-.78 0-1.42.232-1.917.697-.493.465-.822 1.168-.988 2.108h3.785v1.279h-3.91l-.016.373v.457l.016.323h3.387v1.27h-3.245c.354 1.727 1.361 2.59 3.021 2.59.791 0 1.602-.171 2.432-.514v1.685c-.725.337-1.569.506-2.531.506-1.334 0-2.419-.365-3.254-1.096-.83-.73-1.373-1.787-1.627-3.17h-1.262v-1.27h1.129l-.017-.308v-.307l.017-.54h-1.13v-1.278h1.246c.21-1.389.739-2.479 1.585-3.27.847-.792 1.94-1.187 3.28-1.187 1.106 0 2.097.243 2.971.73l-.697 1.553c-.852-.421-1.61-.631-2.275-.631z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+        </span>
+      </div>
     </div>
   </div>
   <button
-    class="c8 c20"
+    class="c15 c16"
     type="button"
   >
     <svg
       aria-hidden="true"
-      class="c21"
+      class="c17"
       fill="none"
       viewBox="0 0 16 16"
     >
@@ -1543,7 +650,7 @@ exports[`<SalaireTempsPartiel /> should delete a period 1`] = `
 `;
 
 exports[`<SalaireTempsPartiel /> should render 1`] = `
-.c8 {
+.c15 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1580,16 +687,16 @@ exports[`<SalaireTempsPartiel /> should render 1`] = `
   opacity: 1;
 }
 
-.c8:link,
-.c8:visited {
+.c15:link,
+.c15:visited {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #3e486e;
 }
 
-.c8:not([disabled]):hover,
-.c8:not([disabled]):active,
-.c8:not([disabled]):focus {
+.c15:not([disabled]):hover,
+.c15:not([disabled]):active,
+.c15:not([disabled]):focus {
   opacity: 0.6;
   -webkit-transform: translateY(-2px);
   -ms-transform: translateY(-2px);
@@ -1598,7 +705,7 @@ exports[`<SalaireTempsPartiel /> should render 1`] = `
   border-color: transparent;
 }
 
-.c8[disabled] {
+.c15[disabled] {
   background-color: #e4e8ef;
   border-color: #e4e8ef;
   color: #9298af;
@@ -1606,82 +713,19 @@ exports[`<SalaireTempsPartiel /> should render 1`] = `
   cursor: not-allowed;
 }
 
-.c19 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: content-box;
-  font-weight: 500;
-  font-size: 1.6rem;
-  line-height: 1.125em;
-  text-align: center;
-  vertical-align: middle;
-  border: 1px solid;
-  border-radius: 0.6rem;
-  cursor: pointer;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,-webkit-transform 100ms linear;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  height: 5.2rem;
-  padding: 0 1.9rem;
-  color: #3e486e;
-  background: transparent;
-  border-color: transparent;
-  box-shadow: none;
-  opacity: 1;
-}
-
-.c19:link,
-.c19:visited {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #3e486e;
-}
-
-.c19:not([disabled]):hover,
-.c19:not([disabled]):active,
-.c19:not([disabled]):focus {
-  opacity: 0.6;
-  -webkit-transform: translateY(-2px);
-  -ms-transform: translateY(-2px);
-  transform: translateY(-2px);
-  background: transparent;
-  border-color: transparent;
-}
-
-.c19[disabled] {
-  background-color: #e4e8ef;
-  border-color: #e4e8ef;
-  color: #9298af;
-  box-shadow: none;
-  cursor: not-allowed;
-}
-
-.c7 {
+.c3 {
   color: #7994d4;
   line-height: 1.25;
   font-size: 1.8rem;
   font-weight: 400;
 }
 
-.c14 {
+.c11 {
   position: relative;
   display: inline-block;
 }
 
-.c15 {
+.c12 {
   width: 100%;
   height: 5.4rem;
   padding: 0 2rem;
@@ -1703,15 +747,15 @@ exports[`<SalaireTempsPartiel /> should render 1`] = `
   appearance: none;
 }
 
-.c15::-webkit-outer-spin-button,
-.c15::-webkit-inner-spin-button {
+.c12::-webkit-outer-spin-button,
+.c12::-webkit-inner-spin-button {
   margin: 0;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c15::-webkit-calendar-picker-indicator {
+.c12::-webkit-calendar-picker-indicator {
   display: block;
   width: 3.2rem;
   height: 3.2rem;
@@ -1724,47 +768,47 @@ exports[`<SalaireTempsPartiel /> should render 1`] = `
   mask-image: url("data:image/svg+xml;,%3Csvg%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M20.947%207.601h1.601c1.472%200%202.521%201.198%202.521%202.669v2.306l-.001%2010.392c0%201.472-1.049%202.669-2.521%202.669H8.669A2.672%202.672%200%20016%2022.967l.001-12.697a2.672%202.672%200%20012.67-2.669h1.331V6h.999v1.601H20V6h.947v1.601zm1.6%2017.036c.883%200%201.454-.786%201.454-1.67v-10.33h-17L7%2022.967c0%20.884.785%201.67%201.668%201.67h13.879zm-15.548-13h17.002l.001-1.367c0-.883-.57-1.601-1.453-1.601h-1.6v1.068H20V8.669h-9v1.068h-1V8.669H8.669C7.786%208.669%207%209.387%207%2010.27v1.367zm9.677%206.277h-2.135a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203h-2.135v2.135h2.136v-2.135zm3.203%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068H19.88a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135H19.88v-2.135zm-8.54%208.541H9.204a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H9.204v2.135h2.136l-.001-2.135zm3.202%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068h-2.135a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135h-2.136v-2.135zm7.473%203.203H19.88a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H19.88v2.135h2.136v-2.135z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E");
 }
 
-.c15:invalid {
+.c12:invalid {
   border-color: #eb5757;
 }
 
-.c15::-webkit-input-placeholder {
+.c12::-webkit-input-placeholder {
   color: #9298af;
 }
 
-.c15::-moz-placeholder {
+.c12::-moz-placeholder {
   color: #9298af;
 }
 
-.c15:-ms-input-placeholder {
+.c12:-ms-input-placeholder {
   color: #9298af;
 }
 
-.c15::placeholder {
+.c12::placeholder {
   color: #9298af;
 }
 
-.c15:focus {
+.c12:focus {
   border-color: #7994d4;
 }
 
-.c15:focus::-webkit-input-placeholder {
+.c12:focus::-webkit-input-placeholder {
   color: transparent;
 }
 
-.c15:focus::-moz-placeholder {
+.c12:focus::-moz-placeholder {
   color: transparent;
 }
 
-.c15:focus:-ms-input-placeholder {
+.c12:focus:-ms-input-placeholder {
   color: transparent;
 }
 
-.c15:focus::placeholder {
+.c12:focus::placeholder {
   color: transparent;
 }
 
-.c17 {
+.c13 {
   width: 100%;
   height: 5.4rem;
   padding: 0 2rem;
@@ -1786,15 +830,15 @@ exports[`<SalaireTempsPartiel /> should render 1`] = `
   appearance: none;
 }
 
-.c17::-webkit-outer-spin-button,
-.c17::-webkit-inner-spin-button {
+.c13::-webkit-outer-spin-button,
+.c13::-webkit-inner-spin-button {
   margin: 0;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c17::-webkit-calendar-picker-indicator {
+.c13::-webkit-calendar-picker-indicator {
   display: block;
   width: 3.2rem;
   height: 3.2rem;
@@ -1807,47 +851,47 @@ exports[`<SalaireTempsPartiel /> should render 1`] = `
   mask-image: url("data:image/svg+xml;,%3Csvg%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M20.947%207.601h1.601c1.472%200%202.521%201.198%202.521%202.669v2.306l-.001%2010.392c0%201.472-1.049%202.669-2.521%202.669H8.669A2.672%202.672%200%20016%2022.967l.001-12.697a2.672%202.672%200%20012.67-2.669h1.331V6h.999v1.601H20V6h.947v1.601zm1.6%2017.036c.883%200%201.454-.786%201.454-1.67v-10.33h-17L7%2022.967c0%20.884.785%201.67%201.668%201.67h13.879zm-15.548-13h17.002l.001-1.367c0-.883-.57-1.601-1.453-1.601h-1.6v1.068H20V8.669h-9v1.068h-1V8.669H8.669C7.786%208.669%207%209.387%207%2010.27v1.367zm9.677%206.277h-2.135a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203h-2.135v2.135h2.136v-2.135zm3.203%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068H19.88a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135H19.88v-2.135zm-8.54%208.541H9.204a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H9.204v2.135h2.136l-.001-2.135zm3.202%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068h-2.135a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135h-2.136v-2.135zm7.473%203.203H19.88a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H19.88v2.135h2.136v-2.135z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E");
 }
 
-.c17:invalid {
+.c13:invalid {
   border-color: #eb5757;
 }
 
-.c17::-webkit-input-placeholder {
+.c13::-webkit-input-placeholder {
   color: #9298af;
 }
 
-.c17::-moz-placeholder {
+.c13::-moz-placeholder {
   color: #9298af;
 }
 
-.c17:-ms-input-placeholder {
+.c13:-ms-input-placeholder {
   color: #9298af;
 }
 
-.c17::placeholder {
+.c13::placeholder {
   color: #9298af;
 }
 
-.c17:focus {
+.c13:focus {
   border-color: #7994d4;
 }
 
-.c17:focus::-webkit-input-placeholder {
+.c13:focus::-webkit-input-placeholder {
   color: transparent;
 }
 
-.c17:focus::-moz-placeholder {
+.c13:focus::-moz-placeholder {
   color: transparent;
 }
 
-.c17:focus:-ms-input-placeholder {
+.c13:focus:-ms-input-placeholder {
   color: transparent;
 }
 
-.c17:focus::placeholder {
+.c13:focus::placeholder {
   color: transparent;
 }
 
-.c18 {
+.c14 {
   position: absolute;
   top: 1rem;
   right: 1rem;
@@ -1858,7 +902,21 @@ exports[`<SalaireTempsPartiel /> should render 1`] = `
   color: #9298af;
 }
 
-.c11 {
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding-bottom: 0.4rem;
+  font-weight: 600;
+  font-size: 1.4rem;
+  font-family: "Open Sans",sans-serif;
+  font-style: normal;
+  line-height: 2;
+  cursor: pointer;
+}
+
+.c7 {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -1878,7 +936,7 @@ exports[`<SalaireTempsPartiel /> should render 1`] = `
   text-align: center;
 }
 
-.c13 {
+.c10 {
   position: absolute;
   top: 1.6rem;
   right: 1.6rem;
@@ -1888,7 +946,7 @@ exports[`<SalaireTempsPartiel /> should render 1`] = `
   pointer-events: none;
 }
 
-.c12 {
+.c9 {
   width: 100%;
   height: 5.4rem;
   padding: 0 2rem 0;
@@ -1909,25 +967,25 @@ exports[`<SalaireTempsPartiel /> should render 1`] = `
   appearance: none;
 }
 
-.c12::-ms-expand {
+.c9::-ms-expand {
   background-color: transparent;
   border: 0 transparent;
 }
 
-.c12 *::-ms-backdrop,
-.c12 {
+.c9 *::-ms-backdrop,
+.c9 {
   padding-right: 1.6rem;
 }
 
-.c12:invalid {
+.c9:invalid {
   border-color: #eb5757;
 }
 
-.c12:disabled {
+.c9:disabled {
   background-color: #e4e8ef;
 }
 
-.c20 {
+.c18 {
   -webkit-align-self: flex-start;
   -ms-flex-item-align: start;
   align-self: flex-start;
@@ -1935,20 +993,76 @@ exports[`<SalaireTempsPartiel /> should render 1`] = `
   padding-left: 0;
 }
 
-.c9 {
-  margin-left: 1rem;
-}
-
-.c10 {
+.c17 {
   width: 2rem;
   margin-left: 0.4rem;
   color: #f66663;
 }
 
-.c21 {
+.c19 {
   width: 2rem;
   margin-right: 0.4rem;
   color: #f66663;
+}
+
+.c4 {
+  display: -ms-grid;
+  -ms-grid-rows: auto auto;
+  -ms-grid-columns: 2fr 1fr 1fr 13rem;
+  display: grid;
+  grid-template-rows: auto auto;
+  grid-template-columns: 2fr 1fr 1fr 13rem;
+  margin-top: 1.6rem;
+  margin-bottom: 1.6rem;
+}
+
+.c4 > *:nth-child(1) {
+  -ms-grid-row: 1;
+  -ms-grid-column: 1;
+  grid-row: 1;
+  grid-column: 1;
+}
+
+.c4 > *:nth-child(2) {
+  -ms-grid-row: 2;
+  -ms-grid-column: 1;
+  grid-row: 2;
+  grid-column: 1;
+}
+
+.c4 > *:nth-child(3) {
+  -ms-grid-row: 1;
+  -ms-grid-column: 2;
+  grid-row: 1;
+  grid-column: 2;
+}
+
+.c4 > *:nth-child(4) {
+  -ms-grid-row: 2;
+  -ms-grid-column: 2;
+  grid-row: 2;
+  grid-column: 2;
+}
+
+.c4 > *:nth-child(5) {
+  -ms-grid-row: 1;
+  -ms-grid-column: 3;
+  grid-row: 1;
+  grid-column: 3;
+}
+
+.c4 > *:nth-child(6) {
+  -ms-grid-row: 2;
+  -ms-grid-column: 3;
+  grid-row: 2;
+  grid-column: 3;
+}
+
+.c4 > *:nth-child(7) {
+  -ms-grid-row: 2;
+  -ms-grid-column: 4;
+  grid-row: 2;
+  grid-column: 4;
 }
 
 .c0 {
@@ -1957,81 +1071,36 @@ exports[`<SalaireTempsPartiel /> should render 1`] = `
   margin-bottom: 1rem;
   font-weight: 600;
   font-size: 1.8rem;
-  cursor: pointer;
+  cursor: default;
+}
+
+.c1 {
+  position: relative;
 }
 
 .c2 {
+  margin-bottom: 1.6rem;
+  padding-top: 1rem;
+}
+
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  margin-bottom: 1rem;
 }
 
 .c6 {
-  display: none;
-}
-
-.c4 {
-  padding-top: 1rem;
-  padding-bottom: 0.4rem;
-  font-weight: 700;
-  font-size: 1.4rem;
-}
-
-.c3 {
-  -webkit-flex-basis: 20rem;
-  -ms-flex-preferred-size: 20rem;
-  flex-basis: 20rem;
-  margin-right: 2rem;
-}
-
-.c5 {
-  -webkit-flex-basis: 15rem;
-  -ms-flex-preferred-size: 15rem;
-  flex-basis: 15rem;
-  margin-right: 2rem;
+  margin-right: 1.6rem;
 }
 
 .c16 {
-  -webkit-flex-basis: 20rem;
-  -ms-flex-preferred-size: 20rem;
-  flex-basis: 20rem;
-}
-
-@media (max-width:600px) {
-  .c8 {
-    font-size: 1.4rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c19 {
-    font-size: 1.4rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c14 {
-    width: 100%;
-  }
+  margin-top: 0.8rem;
 }
 
 @media (max-width:600px) {
   .c15 {
-    padding: 0 1rem;
-    padding-right: 2rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c17 {
-    padding: 0 1rem;
-    padding-right: 5rem;
+    font-size: 1.4rem;
   }
 }
 
@@ -2042,242 +1111,192 @@ exports[`<SalaireTempsPartiel /> should render 1`] = `
 }
 
 @media (max-width:600px) {
+  .c12 {
+    padding: 0 1rem;
+    padding-right: 2rem;
+  }
+}
+
+@media (max-width:600px) {
+  .c13 {
+    padding: 0 1rem;
+    padding-right: 5rem;
+  }
+}
+
+@media (max-width:600px) {
+  .c7 {
+    width: 100%;
+  }
+}
+
+@media (max-width:600px) {
+  .c4 {
+    display: block;
+    margin-bottom: 3.2rem;
+  }
+}
+
+@media (max-width:600px) {
   .c0 {
     font-size: 1.6rem;
   }
 }
 
 @media (max-width:600px) {
-  .c2 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-    margin-bottom: 3.2rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c1 {
-    display: none;
-  }
-}
-
-@media (max-width:600px) {
   .c6 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-align-items: center;
-    -webkit-box-align: center;
-    -ms-flex-align: center;
-    align-items: center;
-    -webkit-box-pack: justify;
-    -webkit-justify-content: space-between;
-    -ms-flex-pack: justify;
-    justify-content: space-between;
-  }
-}
-
-@media (max-width:600px) {
-  .c3 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
     margin-right: 0;
-  }
-}
-
-@media (max-width:600px) {
-  .c5 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    margin-right: 0;
+    margin-bottom: 1.6rem;
   }
 }
 
 @media (max-width:600px) {
   .c16 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin-top: 0;
   }
 }
 
 <div>
-  <label
+  <p
     class="c0"
   >
     Quels ont été les durées et les salaires des périodes à temps plein et à temps partiel ?
-  </label>
+  </p>
   <div
-    class="c1 c2"
+    class="c1"
   >
     <div
-      class="c3 c4"
-    >
-      Type de durée de travail
-    </div>
-    <div
-      class="c5 c4"
-    >
-      Durée (en mois)
-    </div>
-    <div
-      class="c4"
-    >
-      Rémunération
-    </div>
-  </div>
-  <div
-    class="c2"
-  >
-    <div
-      class="c6"
+      class="c2"
     >
       <span
-        class="c7"
+        class="c3"
         font-size="hsmall"
         font-weight="400"
       >
         Période 
         1
       </span>
-      <button
-        class="c8 c9"
-        type="button"
-      >
-        Supprimer
-        <svg
-          aria-hidden="true"
-          class="c10"
-          fill="none"
-          viewBox="0 0 32 32"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M14.752 16.5L7.258 8.591A.957.957 0 017 7.932c0-.247.093-.484.259-.659A.858.858 0 017.883 7a.86.86 0 01.625.273L16 15.183l7.492-7.91A.859.859 0 0124.117 7c.234 0 .459.098.624.273a.957.957 0 01.259.659.957.957 0 01-.259.66L17.249 16.5l7.492 7.909a.958.958 0 01.259.659.957.957 0 01-.259.659.859.859 0 01-.624.273.86.86 0 01-.625-.273L16 17.817l-7.492 7.91a.859.859 0 01-.625.273.859.859 0 01-.624-.273.957.957 0 01-.259-.659.96.96 0 01.259-.66l7.492-7.908z"
-            fill="currentColor"
-            fill-rule="evenodd"
-          />
-        </svg>
-      </button>
     </div>
     <div
-      class="c3"
+      class="c4"
     >
-      <div
-        class="c6 c4"
+      <label
+        class="c5"
+        for="periods[0].type"
       >
         Type de durée de travail
-      </div>
+      </label>
       <div
-        class="c11"
+        class="c6"
       >
-        <select
-          class="c12"
-          name="periods[0].type"
-        >
-          <option>
-            Temps partiel
-          </option>
-          <option>
-            Temps plein
-          </option>
-        </select>
         <div
-          aria-hidden="true"
-          class="c13"
+          class="c7 c8"
         >
-          <svg
-            fill="none"
-            viewBox="0 0 16 16"
+          <select
+            class="c9"
+            name="periods[0].type"
           >
-            <g
-              clip-path="url(#arrow-down_svg__clip0)"
+            <option>
+              Temps partiel
+            </option>
+            <option>
+              Temps plein
+            </option>
+          </select>
+          <div
+            aria-hidden="true"
+            class="c10"
+          >
+            <svg
+              fill="none"
+              viewBox="0 0 16 16"
             >
-              <path
-                d="M8.425 11.573l7.11-6.072a.709.709 0 00.26-.537.709.709 0 00-.26-.537.973.973 0 00-.629-.223.973.973 0 00-.63.223l-6.48 5.536-6.481-5.536a.973.973 0 00-.63-.223.973.973 0 00-.628.223.708.708 0 00-.261.537c0 .202.094.395.26.537l7.11 6.072a.91.91 0 00.29.165 1.021 1.021 0 00.68 0 .91.91 0 00.29-.165z"
-                fill="currentColor"
-              />
-            </g>
-            <defs>
-              <clippath
-                id="arrow-down_svg__clip0"
+              <g
+                clip-path="url(#arrow-down_svg__clip0)"
               >
                 <path
-                  d="M0 0h16v16H0z"
+                  d="M8.425 11.573l7.11-6.072a.709.709 0 00.26-.537.709.709 0 00-.26-.537.973.973 0 00-.629-.223.973.973 0 00-.63.223l-6.48 5.536-6.481-5.536a.973.973 0 00-.63-.223.973.973 0 00-.628.223.708.708 0 00-.261.537c0 .202.094.395.26.537l7.11 6.072a.91.91 0 00.29.165 1.021 1.021 0 00.68 0 .91.91 0 00.29-.165z"
                   fill="currentColor"
                 />
-              </clippath>
-            </defs>
-          </svg>
+              </g>
+              <defs>
+                <clippath
+                  id="arrow-down_svg__clip0"
+                >
+                  <path
+                    d="M0 0h16v16H0z"
+                    fill="currentColor"
+                  />
+                </clippath>
+              </defs>
+            </svg>
+          </div>
         </div>
       </div>
-    </div>
-    <div
-      class="c5"
-    >
-      <div
-        class="c6 c4"
+      <label
+        class="c5"
+        for="periods[0].duration"
       >
         Durée (en mois)
-      </div>
-      <span
-        class="c14"
-      >
-        <input
-          class="c15"
-          name="periods[0].duration"
-          type="number"
-          value="12"
-        />
-      </span>
-    </div>
-    <div
-      class="c16"
-    >
+      </label>
       <div
-        class="c6 c4"
+        class="c6"
+      >
+        <span
+          class="c11"
+        >
+          <input
+            class="c12"
+            id="periods[0].duration"
+            name="periods[0].duration"
+            type="number"
+            value="12"
+          />
+        </span>
+      </div>
+      <label
+        class="c5"
+        for="periods[0].salary"
       >
         Rémunération
-      </div>
-      <span
-        class="c14"
-      >
-        <input
-          class="c17"
-          name="periods[0].salary"
-          type="number"
-          value="2000"
-        />
-        <div
-          class="c18"
+      </label>
+      <div>
+        <span
+          class="c11"
         >
-          <svg
-            fill="none"
-            viewBox="0 0 32 32"
+          <input
+            class="c13"
+            id="periods[0].salary"
+            name="periods[0].salary"
+            type="number"
+            value="2000"
+          />
+          <div
+            class="c14"
           >
-            <path
-              d="M17.632 12.392c-.78 0-1.42.232-1.917.697-.493.465-.822 1.168-.988 2.108h3.785v1.279h-3.91l-.016.373v.457l.016.323h3.387v1.27h-3.245c.354 1.727 1.361 2.59 3.021 2.59.791 0 1.602-.171 2.432-.514v1.685c-.725.337-1.569.506-2.531.506-1.334 0-2.419-.365-3.254-1.096-.83-.73-1.373-1.787-1.627-3.17h-1.262v-1.27h1.129l-.017-.308v-.307l.017-.54h-1.13v-1.278h1.246c.21-1.389.739-2.479 1.585-3.27.847-.792 1.94-1.187 3.28-1.187 1.106 0 2.097.243 2.971.73l-.697 1.553c-.852-.421-1.61-.631-2.275-.631z"
-              fill="currentColor"
-            />
-          </svg>
-        </div>
-      </span>
-    </div>
-    <div
-      class="c1"
-    >
+            <svg
+              fill="none"
+              viewBox="0 0 32 32"
+            >
+              <path
+                d="M17.632 12.392c-.78 0-1.42.232-1.917.697-.493.465-.822 1.168-.988 2.108h3.785v1.279h-3.91l-.016.373v.457l.016.323h3.387v1.27h-3.245c.354 1.727 1.361 2.59 3.021 2.59.791 0 1.602-.171 2.432-.514v1.685c-.725.337-1.569.506-2.531.506-1.334 0-2.419-.365-3.254-1.096-.83-.73-1.373-1.787-1.627-3.17h-1.262v-1.27h1.129l-.017-.308v-.307l.017-.54h-1.13v-1.278h1.246c.21-1.389.739-2.479 1.585-3.27.847-.792 1.94-1.187 3.28-1.187 1.106 0 2.097.243 2.971.73l-.697 1.553c-.852-.421-1.61-.631-2.275-.631z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+        </span>
+      </div>
       <button
-        class="c19 c9"
+        class="c15 c16"
         type="button"
       >
         Supprimer
         <svg
           aria-hidden="true"
-          class="c10"
+          class="c17"
           fill="none"
           viewBox="0 0 32 32"
         >
@@ -2292,153 +1311,137 @@ exports[`<SalaireTempsPartiel /> should render 1`] = `
     </div>
   </div>
   <div
-    class="c2"
+    class="c1"
   >
     <div
-      class="c6"
+      class="c2"
     >
       <span
-        class="c7"
+        class="c3"
         font-size="hsmall"
         font-weight="400"
       >
         Période 
         2
       </span>
-      <button
-        class="c8 c9"
-        type="button"
-      >
-        Supprimer
-        <svg
-          aria-hidden="true"
-          class="c10"
-          fill="none"
-          viewBox="0 0 32 32"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M14.752 16.5L7.258 8.591A.957.957 0 017 7.932c0-.247.093-.484.259-.659A.858.858 0 017.883 7a.86.86 0 01.625.273L16 15.183l7.492-7.91A.859.859 0 0124.117 7c.234 0 .459.098.624.273a.957.957 0 01.259.659.957.957 0 01-.259.66L17.249 16.5l7.492 7.909a.958.958 0 01.259.659.957.957 0 01-.259.659.859.859 0 01-.624.273.86.86 0 01-.625-.273L16 17.817l-7.492 7.91a.859.859 0 01-.625.273.859.859 0 01-.624-.273.957.957 0 01-.259-.659.96.96 0 01.259-.66l7.492-7.908z"
-            fill="currentColor"
-            fill-rule="evenodd"
-          />
-        </svg>
-      </button>
     </div>
     <div
-      class="c3"
+      class="c4"
     >
-      <div
-        class="c6 c4"
+      <label
+        class="c5"
+        for="periods[1].type"
       >
         Type de durée de travail
-      </div>
+      </label>
       <div
-        class="c11"
+        class="c6"
       >
-        <select
-          class="c12"
-          name="periods[1].type"
-        >
-          <option>
-            Temps partiel
-          </option>
-          <option>
-            Temps plein
-          </option>
-        </select>
         <div
-          aria-hidden="true"
-          class="c13"
+          class="c7 c8"
         >
-          <svg
-            fill="none"
-            viewBox="0 0 16 16"
+          <select
+            class="c9"
+            name="periods[1].type"
           >
-            <g
-              clip-path="url(#arrow-down_svg__clip0)"
+            <option>
+              Temps partiel
+            </option>
+            <option>
+              Temps plein
+            </option>
+          </select>
+          <div
+            aria-hidden="true"
+            class="c10"
+          >
+            <svg
+              fill="none"
+              viewBox="0 0 16 16"
             >
-              <path
-                d="M8.425 11.573l7.11-6.072a.709.709 0 00.26-.537.709.709 0 00-.26-.537.973.973 0 00-.629-.223.973.973 0 00-.63.223l-6.48 5.536-6.481-5.536a.973.973 0 00-.63-.223.973.973 0 00-.628.223.708.708 0 00-.261.537c0 .202.094.395.26.537l7.11 6.072a.91.91 0 00.29.165 1.021 1.021 0 00.68 0 .91.91 0 00.29-.165z"
-                fill="currentColor"
-              />
-            </g>
-            <defs>
-              <clippath
-                id="arrow-down_svg__clip0"
+              <g
+                clip-path="url(#arrow-down_svg__clip0)"
               >
                 <path
-                  d="M0 0h16v16H0z"
+                  d="M8.425 11.573l7.11-6.072a.709.709 0 00.26-.537.709.709 0 00-.26-.537.973.973 0 00-.629-.223.973.973 0 00-.63.223l-6.48 5.536-6.481-5.536a.973.973 0 00-.63-.223.973.973 0 00-.628.223.708.708 0 00-.261.537c0 .202.094.395.26.537l7.11 6.072a.91.91 0 00.29.165 1.021 1.021 0 00.68 0 .91.91 0 00.29-.165z"
                   fill="currentColor"
                 />
-              </clippath>
-            </defs>
-          </svg>
+              </g>
+              <defs>
+                <clippath
+                  id="arrow-down_svg__clip0"
+                >
+                  <path
+                    d="M0 0h16v16H0z"
+                    fill="currentColor"
+                  />
+                </clippath>
+              </defs>
+            </svg>
+          </div>
         </div>
       </div>
-    </div>
-    <div
-      class="c5"
-    >
-      <div
-        class="c6 c4"
+      <label
+        class="c5"
+        for="periods[1].duration"
       >
         Durée (en mois)
-      </div>
-      <span
-        class="c14"
-      >
-        <input
-          class="c15"
-          name="periods[1].duration"
-          type="number"
-          value="6"
-        />
-      </span>
-    </div>
-    <div
-      class="c16"
-    >
+      </label>
       <div
-        class="c6 c4"
+        class="c6"
+      >
+        <span
+          class="c11"
+        >
+          <input
+            class="c12"
+            id="periods[1].duration"
+            name="periods[1].duration"
+            type="number"
+            value="6"
+          />
+        </span>
+      </div>
+      <label
+        class="c5"
+        for="periods[1].salary"
       >
         Rémunération
-      </div>
-      <span
-        class="c14"
-      >
-        <input
-          class="c17"
-          name="periods[1].salary"
-          type="number"
-          value="1000"
-        />
-        <div
-          class="c18"
+      </label>
+      <div>
+        <span
+          class="c11"
         >
-          <svg
-            fill="none"
-            viewBox="0 0 32 32"
+          <input
+            class="c13"
+            id="periods[1].salary"
+            name="periods[1].salary"
+            type="number"
+            value="1000"
+          />
+          <div
+            class="c14"
           >
-            <path
-              d="M17.632 12.392c-.78 0-1.42.232-1.917.697-.493.465-.822 1.168-.988 2.108h3.785v1.279h-3.91l-.016.373v.457l.016.323h3.387v1.27h-3.245c.354 1.727 1.361 2.59 3.021 2.59.791 0 1.602-.171 2.432-.514v1.685c-.725.337-1.569.506-2.531.506-1.334 0-2.419-.365-3.254-1.096-.83-.73-1.373-1.787-1.627-3.17h-1.262v-1.27h1.129l-.017-.308v-.307l.017-.54h-1.13v-1.278h1.246c.21-1.389.739-2.479 1.585-3.27.847-.792 1.94-1.187 3.28-1.187 1.106 0 2.097.243 2.971.73l-.697 1.553c-.852-.421-1.61-.631-2.275-.631z"
-              fill="currentColor"
-            />
-          </svg>
-        </div>
-      </span>
-    </div>
-    <div
-      class="c1"
-    >
+            <svg
+              fill="none"
+              viewBox="0 0 32 32"
+            >
+              <path
+                d="M17.632 12.392c-.78 0-1.42.232-1.917.697-.493.465-.822 1.168-.988 2.108h3.785v1.279h-3.91l-.016.373v.457l.016.323h3.387v1.27h-3.245c.354 1.727 1.361 2.59 3.021 2.59.791 0 1.602-.171 2.432-.514v1.685c-.725.337-1.569.506-2.531.506-1.334 0-2.419-.365-3.254-1.096-.83-.73-1.373-1.787-1.627-3.17h-1.262v-1.27h1.129l-.017-.308v-.307l.017-.54h-1.13v-1.278h1.246c.21-1.389.739-2.479 1.585-3.27.847-.792 1.94-1.187 3.28-1.187 1.106 0 2.097.243 2.971.73l-.697 1.553c-.852-.421-1.61-.631-2.275-.631z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+        </span>
+      </div>
       <button
-        class="c19 c9"
+        class="c15 c16"
         type="button"
       >
         Supprimer
         <svg
           aria-hidden="true"
-          class="c10"
+          class="c17"
           fill="none"
           viewBox="0 0 32 32"
         >
@@ -2453,12 +1456,12 @@ exports[`<SalaireTempsPartiel /> should render 1`] = `
     </div>
   </div>
   <button
-    class="c8 c20"
+    class="c15 c18"
     type="button"
   >
     <svg
       aria-hidden="true"
-      class="c21"
+      class="c19"
       fill="none"
       viewBox="0 0 16 16"
     >

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/Anciennete.js
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/Anciennete.js
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Field } from "react-final-form";
 import createDecorator from "final-form-calculate";
 import { isAfter, differenceInMonths, format } from "date-fns";
 
@@ -10,7 +9,7 @@ import { parse } from "../../common/date";
 import { YesNoQuestion } from "../../common/YesNoQuestion";
 import { TextQuestion } from "../../common/TextQuestion";
 import { ErrorComputedField } from "../../common/ErrorField";
-import { AbsencePeriods, motifs } from "../components/AbsencePeriods";
+import { AbsencePeriods, MOTIFS } from "../components/AbsencePeriods";
 
 function validate({
   dateEntree,
@@ -36,7 +35,7 @@ function validate({
     (absencePeriods || [])
       .filter((period) => Boolean(period.duration))
       .reduce((total, item) => {
-        const motif = motifs.find((motif) => motif.label === item.type);
+        const motif = MOTIFS.find((motif) => motif.label === item.type);
         return total + item.duration * motif.value;
       }, 0) / 12;
 
@@ -102,19 +101,7 @@ function StepAnciennete({ form }) {
             : form.change("absencePeriods", []);
         }}
       />
-      <Field name="hasAbsenceProlonge">
-        {({ input }) => (
-          <AbsencePeriods
-            visible={input.value}
-            name="absencePeriods"
-            onChange={(absencePeriods) => {
-              if (absencePeriods.length === 0) {
-                form.change("hasAbsenceProlonge", false);
-              }
-            }}
-          />
-        )}
-      </Field>
+      <AbsencePeriods name="absencePeriods" />
     </>
   );
 }
@@ -147,7 +134,7 @@ function computeAnciennete({ dateEntree, dateSortie, absencePeriods = [] }) {
     (absencePeriods || [])
       .filter((period) => Boolean(period.duration))
       .reduce((total, item) => {
-        const motif = motifs.find((motif) => motif.label === item.type);
+        const motif = MOTIFS.find((motif) => motif.label === item.type);
         return total + item.duration * motif.value;
       }, 0) / 12;
   return differenceInMonths(dSortie, dEntree) / 12 - totalAbsence;

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/Salaires.js
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/Salaires.js
@@ -16,7 +16,7 @@ import {
   TEMPS_PLEIN,
 } from "../components/SalaireTempsPartiel";
 import { SalaireTempsPlein } from "../components/SalaireTempsPlein";
-import { motifs } from "../components/AbsencePeriods";
+import { MOTIFS } from "../components/AbsencePeriods";
 import { Question } from "../../common/Question";
 
 function StepSalaires({ form }) {
@@ -41,19 +41,10 @@ function StepSalaires({ form }) {
           }
         }}
       />
+      <SalaireTempsPartiel name="salairePeriods" />
       <Field name="hasTempsPartiel">
         {({ input }) => (
           <>
-            <SalaireTempsPartiel
-              name="salairePeriods"
-              visible={input.value}
-              onChange={(salairePeriods) => {
-                if (salairePeriods.length === 0) {
-                  form.change("hasTempsPartiel", false);
-                }
-              }}
-            />
-
             {input.value === false && (
               <>
                 <YesNoQuestion
@@ -132,7 +123,7 @@ function getSalairesPeriods({ dateEntree, dateSortie, absencePeriods }) {
   const totalAbsence = (absencePeriods || [])
     .filter((period) => Boolean(period.duration))
     .reduce((total, item) => {
-      const motif = motifs.find((motif) => motif.label === item.type);
+      const motif = MOTIFS.find((motif) => motif.label === item.type);
       return total + item.duration * motif.value;
     }, 0);
 

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/__tests__/__snapshots__/Anciennete.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/__tests__/__snapshots__/Anciennete.test.js.snap
@@ -379,8 +379,6 @@ exports[`<Anciennete /> should render 1`] = `
         Non
       </label>
     </div>
-    
-    
     <button
       data-testid="nextBt"
     >

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/__tests__/__snapshots__/Indemnite.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/__tests__/__snapshots__/Indemnite.test.js.snap
@@ -35,22 +35,6 @@ exports[`<StepIndemnite /> should render 1`] = `
   text-align: left;
 }
 
-.c0 {
-  margin-top: 3.2rem;
-  margin-bottom: 2rem;
-  color: #4d73b8;
-  font-weight: 600;
-  font-size: 1.8rem;
-  font-family: "Open Sans",sans-serif;
-}
-
-.c1 {
-  color: #f66663;
-  font-weight: 700;
-  font-size: 1.8rem;
-  white-space: pre-line;
-}
-
 .c3 {
   display: block;
   margin-bottom: 1.6rem;
@@ -75,6 +59,22 @@ exports[`<StepIndemnite /> should render 1`] = `
 
 .c7 {
   margin: 1.6rem 0;
+}
+
+.c0 {
+  margin-top: 3.2rem;
+  margin-bottom: 2rem;
+  color: #4d73b8;
+  font-weight: 600;
+  font-size: 1.8rem;
+  font-family: "Open Sans",sans-serif;
+}
+
+.c1 {
+  color: #f66663;
+  font-weight: 700;
+  font-size: 1.8rem;
+  white-space: pre-line;
 }
 
 @media print {

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/__tests__/__snapshots__/Primes.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/__tests__/__snapshots__/Primes.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<StepPrimes /> should render 1`] = `
-.c10 {
+.c9 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -29,102 +29,39 @@ exports[`<StepPrimes /> should render 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  height: 5.2rem;
-  padding: 0 4.4rem;
+  height: 4rem;
+  padding: 0 1rem;
   color: #3e486e;
-  background: #fff;
-  border-color: #bbcadf;
+  background: transparent;
+  border-color: transparent;
   box-shadow: none;
   opacity: 1;
 }
 
-.c10:link,
-.c10:visited {
+.c9:link,
+.c9:visited {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #3e486e;
 }
 
-.c10:not([disabled]):hover,
-.c10:not([disabled]):active,
-.c10:not([disabled]):focus {
-  opacity: 1;
+.c9:not([disabled]):hover,
+.c9:not([disabled]):active,
+.c9:not([disabled]):focus {
+  opacity: 0.6;
   -webkit-transform: translateY(-2px);
   -ms-transform: translateY(-2px);
   transform: translateY(-2px);
-  background: #fff;
-  border-color: #dee5ef;
+  background: transparent;
+  border-color: transparent;
 }
 
-.c10[disabled] {
+.c9[disabled] {
   background-color: #e4e8ef;
   border-color: #e4e8ef;
   color: #9298af;
   box-shadow: none;
   cursor: not-allowed;
-}
-
-.c12 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: content-box;
-  font-weight: 500;
-  font-size: 1.6rem;
-  line-height: 1.125em;
-  text-align: center;
-  vertical-align: middle;
-  border: 1px solid;
-  border-radius: 0.6rem;
-  cursor: pointer;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,-webkit-transform 100ms linear;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  padding: 0;
-  color: #f66663;
-  font-weight: 600;
-  font-size: 1.6rem;
-  line-height: 1.625;
-  vertical-align: baseline;
-  text-align: left;
-  background: none;
-  border: none;
-  border-radius: 0;
-  overflow: visible;
-}
-
-.c12:focus,
-.c12:hover,
-.c12:active {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c14 {
-  width: 2.6rem;
-  height: 1.4rem;
-  margin: 0 0.4rem 0 1rem;
-  -webkit-transition: -webkit-transform 250ms linear;
-  -webkit-transition: transform 250ms linear;
-  transition: transform 250ms linear;
-}
-
-.c9:hover .c14 {
-  -webkit-transform: translateX(4px);
-  -ms-transform: translateX(4px);
-  transform: translateX(4px);
 }
 
 .c6 {
@@ -314,15 +251,35 @@ exports[`<StepPrimes /> should render 1`] = `
   color: #eb5757;
 }
 
+.c12 {
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
+  margin: 1rem 0;
+  padding-left: 0;
+}
+
+.c11 {
+  width: 2rem;
+  margin-left: 0.4rem;
+  color: #f66663;
+}
+
+.c13 {
+  width: 2rem;
+  margin-right: 0.4rem;
+  color: #f66663;
+}
+
 .c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -330,28 +287,12 @@ exports[`<StepPrimes /> should render 1`] = `
   margin-bottom: 0.4rem;
 }
 
-.c11 {
-  margin-left: 2rem;
-}
-
-.c13 {
-  margin: 2rem 0;
+.c10 {
+  margin-left: 1.6rem;
 }
 
 @media (max-width:600px) {
-  .c10 {
-    font-size: 1.4rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c10 {
-    padding: 0 3rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c12 {
+  .c9 {
     font-size: 1.4rem;
   }
 }
@@ -452,27 +393,43 @@ exports[`<StepPrimes /> should render 1`] = `
       </span>
     </div>
     <button
-      class="c9 c10 c11"
+      class="c9 c10"
       type="button"
     >
       Supprimer
+      <svg
+        aria-hidden="true"
+        class="c11"
+        fill="none"
+        viewBox="0 0 32 32"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M14.752 16.5L7.258 8.591A.957.957 0 017 7.932c0-.247.093-.484.259-.659A.858.858 0 017.883 7a.86.86 0 01.625.273L16 15.183l7.492-7.91A.859.859 0 0124.117 7c.234 0 .459.098.624.273a.957.957 0 01.259.659.957.957 0 01-.259.66L17.249 16.5l7.492 7.909a.958.958 0 01.259.659.957.957 0 01-.259.659.859.859 0 01-.624.273.86.86 0 01-.625-.273L16 17.817l-7.492 7.91a.859.859 0 01-.625.273.859.859 0 01-.624-.273.957.957 0 01-.259-.659.96.96 0 01.259-.66l7.492-7.908z"
+          fill="currentColor"
+          fill-rule="evenodd"
+        />
+      </svg>
     </button>
   </div>
   <button
-    class="c9 c12 c13"
+    class="c9 c12"
     type="button"
   >
-    Ajouter une prime
     <svg
-      class="c14"
+      aria-hidden="true"
+      class="c13"
       fill="none"
-      viewBox="0 0 28 15"
+      viewBox="0 0 16 16"
     >
       <path
-        d="M27.875 7.153l-6-6.284a.526.526 0 00-.711-.023.496.496 0 00-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 00.024.687.52.52 0 00.711-.023l6-6.284a.506.506 0 000-.665z"
+        clip-rule="evenodd"
+        d="M8 2a1 1 0 00-1 1v4H3a1 1 0 000 2h4v4a1 1 0 102 0V9h4a1 1 0 100-2H9V3a1 1 0 00-1-1z"
         fill="currentColor"
+        fill-rule="evenodd"
       />
     </svg>
+    Ajouter une prime
   </button>
 </div>
 `;

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/__tests__/__snapshots__/Salaires.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/__tests__/__snapshots__/Salaires.test.js.snap
@@ -1164,7 +1164,7 @@ exports[`<StepSalaires /> should render same salaire 1`] = `
 `;
 
 exports[`<StepSalaires /> should render tempsPartiel 1`] = `
-.c13 {
+.c19 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1201,16 +1201,16 @@ exports[`<StepSalaires /> should render tempsPartiel 1`] = `
   opacity: 1;
 }
 
-.c13:link,
-.c13:visited {
+.c19:link,
+.c19:visited {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #3e486e;
 }
 
-.c13:not([disabled]):hover,
-.c13:not([disabled]):active,
-.c13:not([disabled]):focus {
+.c19:not([disabled]):hover,
+.c19:not([disabled]):active,
+.c19:not([disabled]):focus {
   opacity: 0.6;
   -webkit-transform: translateY(-2px);
   -ms-transform: translateY(-2px);
@@ -1219,7 +1219,7 @@ exports[`<StepSalaires /> should render tempsPartiel 1`] = `
   border-color: transparent;
 }
 
-.c13[disabled] {
+.c19[disabled] {
   background-color: #e4e8ef;
   border-color: #e4e8ef;
   color: #9298af;
@@ -1227,82 +1227,19 @@ exports[`<StepSalaires /> should render tempsPartiel 1`] = `
   cursor: not-allowed;
 }
 
-.c24 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: content-box;
-  font-weight: 500;
-  font-size: 1.6rem;
-  line-height: 1.125em;
-  text-align: center;
-  vertical-align: middle;
-  border: 1px solid;
-  border-radius: 0.6rem;
-  cursor: pointer;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,-webkit-transform 100ms linear;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  height: 5.2rem;
-  padding: 0 1.9rem;
-  color: #3e486e;
-  background: transparent;
-  border-color: transparent;
-  box-shadow: none;
-  opacity: 1;
-}
-
-.c24:link,
-.c24:visited {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #3e486e;
-}
-
-.c24:not([disabled]):hover,
-.c24:not([disabled]):active,
-.c24:not([disabled]):focus {
-  opacity: 0.6;
-  -webkit-transform: translateY(-2px);
-  -ms-transform: translateY(-2px);
-  transform: translateY(-2px);
-  background: transparent;
-  border-color: transparent;
-}
-
-.c24[disabled] {
-  background-color: #e4e8ef;
-  border-color: #e4e8ef;
-  color: #9298af;
-  box-shadow: none;
-  cursor: not-allowed;
-}
-
-.c12 {
+.c7 {
   color: #7994d4;
   line-height: 1.25;
   font-size: 1.8rem;
   font-weight: 400;
 }
 
-.c19 {
+.c15 {
   position: relative;
   display: inline-block;
 }
 
-.c20 {
+.c16 {
   width: 100%;
   height: 5.4rem;
   padding: 0 2rem;
@@ -1324,15 +1261,15 @@ exports[`<StepSalaires /> should render tempsPartiel 1`] = `
   appearance: none;
 }
 
-.c20::-webkit-outer-spin-button,
-.c20::-webkit-inner-spin-button {
+.c16::-webkit-outer-spin-button,
+.c16::-webkit-inner-spin-button {
   margin: 0;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c20::-webkit-calendar-picker-indicator {
+.c16::-webkit-calendar-picker-indicator {
   display: block;
   width: 3.2rem;
   height: 3.2rem;
@@ -1345,47 +1282,47 @@ exports[`<StepSalaires /> should render tempsPartiel 1`] = `
   mask-image: url("data:image/svg+xml;,%3Csvg%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M20.947%207.601h1.601c1.472%200%202.521%201.198%202.521%202.669v2.306l-.001%2010.392c0%201.472-1.049%202.669-2.521%202.669H8.669A2.672%202.672%200%20016%2022.967l.001-12.697a2.672%202.672%200%20012.67-2.669h1.331V6h.999v1.601H20V6h.947v1.601zm1.6%2017.036c.883%200%201.454-.786%201.454-1.67v-10.33h-17L7%2022.967c0%20.884.785%201.67%201.668%201.67h13.879zm-15.548-13h17.002l.001-1.367c0-.883-.57-1.601-1.453-1.601h-1.6v1.068H20V8.669h-9v1.068h-1V8.669H8.669C7.786%208.669%207%209.387%207%2010.27v1.367zm9.677%206.277h-2.135a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203h-2.135v2.135h2.136v-2.135zm3.203%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068H19.88a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135H19.88v-2.135zm-8.54%208.541H9.204a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H9.204v2.135h2.136l-.001-2.135zm3.202%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068h-2.135a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135h-2.136v-2.135zm7.473%203.203H19.88a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H19.88v2.135h2.136v-2.135z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E");
 }
 
-.c20:invalid {
+.c16:invalid {
   border-color: #eb5757;
 }
 
-.c20::-webkit-input-placeholder {
+.c16::-webkit-input-placeholder {
   color: #9298af;
 }
 
-.c20::-moz-placeholder {
+.c16::-moz-placeholder {
   color: #9298af;
 }
 
-.c20:-ms-input-placeholder {
+.c16:-ms-input-placeholder {
   color: #9298af;
 }
 
-.c20::placeholder {
+.c16::placeholder {
   color: #9298af;
 }
 
-.c20:focus {
+.c16:focus {
   border-color: #7994d4;
 }
 
-.c20:focus::-webkit-input-placeholder {
+.c16:focus::-webkit-input-placeholder {
   color: transparent;
 }
 
-.c20:focus::-moz-placeholder {
+.c16:focus::-moz-placeholder {
   color: transparent;
 }
 
-.c20:focus:-ms-input-placeholder {
+.c16:focus:-ms-input-placeholder {
   color: transparent;
 }
 
-.c20:focus::placeholder {
+.c16:focus::placeholder {
   color: transparent;
 }
 
-.c22 {
+.c17 {
   width: 100%;
   height: 5.4rem;
   padding: 0 2rem;
@@ -1407,15 +1344,15 @@ exports[`<StepSalaires /> should render tempsPartiel 1`] = `
   appearance: none;
 }
 
-.c22::-webkit-outer-spin-button,
-.c22::-webkit-inner-spin-button {
+.c17::-webkit-outer-spin-button,
+.c17::-webkit-inner-spin-button {
   margin: 0;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c22::-webkit-calendar-picker-indicator {
+.c17::-webkit-calendar-picker-indicator {
   display: block;
   width: 3.2rem;
   height: 3.2rem;
@@ -1428,47 +1365,47 @@ exports[`<StepSalaires /> should render tempsPartiel 1`] = `
   mask-image: url("data:image/svg+xml;,%3Csvg%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M20.947%207.601h1.601c1.472%200%202.521%201.198%202.521%202.669v2.306l-.001%2010.392c0%201.472-1.049%202.669-2.521%202.669H8.669A2.672%202.672%200%20016%2022.967l.001-12.697a2.672%202.672%200%20012.67-2.669h1.331V6h.999v1.601H20V6h.947v1.601zm1.6%2017.036c.883%200%201.454-.786%201.454-1.67v-10.33h-17L7%2022.967c0%20.884.785%201.67%201.668%201.67h13.879zm-15.548-13h17.002l.001-1.367c0-.883-.57-1.601-1.453-1.601h-1.6v1.068H20V8.669h-9v1.068h-1V8.669H8.669C7.786%208.669%207%209.387%207%2010.27v1.367zm9.677%206.277h-2.135a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203h-2.135v2.135h2.136v-2.135zm3.203%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068H19.88a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135H19.88v-2.135zm-8.54%208.541H9.204a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H9.204v2.135h2.136l-.001-2.135zm3.202%203.203h2.135a1.07%201.07%200%20001.068-1.068v-2.135a1.07%201.07%200%2000-1.068-1.068h-2.135a1.07%201.07%200%2000-1.068%201.068v2.135a1.07%201.07%200%20001.068%201.068zm0-3.203h2.135l.001%202.135h-2.136v-2.135zm7.473%203.203H19.88a1.07%201.07%200%2001-1.068-1.068v-2.135a1.07%201.07%200%20011.068-1.068h2.135a1.07%201.07%200%20011.068%201.068v2.135a1.07%201.07%200%2001-1.068%201.068zm0-3.203H19.88v2.135h2.136v-2.135z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E");
 }
 
-.c22:invalid {
+.c17:invalid {
   border-color: #eb5757;
 }
 
-.c22::-webkit-input-placeholder {
+.c17::-webkit-input-placeholder {
   color: #9298af;
 }
 
-.c22::-moz-placeholder {
+.c17::-moz-placeholder {
   color: #9298af;
 }
 
-.c22:-ms-input-placeholder {
+.c17:-ms-input-placeholder {
   color: #9298af;
 }
 
-.c22::placeholder {
+.c17::placeholder {
   color: #9298af;
 }
 
-.c22:focus {
+.c17:focus {
   border-color: #7994d4;
 }
 
-.c22:focus::-webkit-input-placeholder {
+.c17:focus::-webkit-input-placeholder {
   color: transparent;
 }
 
-.c22:focus::-moz-placeholder {
+.c17:focus::-moz-placeholder {
   color: transparent;
 }
 
-.c22:focus:-ms-input-placeholder {
+.c17:focus:-ms-input-placeholder {
   color: transparent;
 }
 
-.c22:focus::placeholder {
+.c17:focus::placeholder {
   color: transparent;
 }
 
-.c23 {
+.c18 {
   position: absolute;
   top: 1rem;
   right: 1rem;
@@ -1533,7 +1470,21 @@ exports[`<StepSalaires /> should render tempsPartiel 1`] = `
   display: block;
 }
 
-.c16 {
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding-bottom: 0.4rem;
+  font-weight: 600;
+  font-size: 1.4rem;
+  font-family: "Open Sans",sans-serif;
+  font-style: normal;
+  line-height: 2;
+  cursor: pointer;
+}
+
+.c11 {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -1553,7 +1504,7 @@ exports[`<StepSalaires /> should render tempsPartiel 1`] = `
   text-align: center;
 }
 
-.c18 {
+.c14 {
   position: absolute;
   top: 1.6rem;
   right: 1.6rem;
@@ -1563,7 +1514,7 @@ exports[`<StepSalaires /> should render tempsPartiel 1`] = `
   pointer-events: none;
 }
 
-.c17 {
+.c13 {
   width: 100%;
   height: 5.4rem;
   padding: 0 2rem 0;
@@ -1584,21 +1535,21 @@ exports[`<StepSalaires /> should render tempsPartiel 1`] = `
   appearance: none;
 }
 
-.c17::-ms-expand {
+.c13::-ms-expand {
   background-color: transparent;
   border: 0 transparent;
 }
 
-.c17 *::-ms-backdrop,
-.c17 {
+.c13 *::-ms-backdrop,
+.c13 {
   padding-right: 1.6rem;
 }
 
-.c17:invalid {
+.c13:invalid {
   border-color: #eb5757;
 }
 
-.c17:disabled {
+.c13:disabled {
   background-color: #e4e8ef;
 }
 
@@ -1621,29 +1572,6 @@ exports[`<StepSalaires /> should render tempsPartiel 1`] = `
   margin-bottom: 2rem;
 }
 
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  margin-bottom: 1rem;
-}
-
-.c11 {
-  display: none;
-}
-
-.c9 {
-  padding-top: 1rem;
-  padding-bottom: 0.4rem;
-  font-weight: 700;
-  font-size: 1.4rem;
-}
-
 .c0 {
   display: block;
   margin-top: 2rem;
@@ -1653,22 +1581,13 @@ exports[`<StepSalaires /> should render tempsPartiel 1`] = `
   cursor: default;
 }
 
-.c5 {
-  display: block;
-  margin-top: 2rem;
-  margin-bottom: 1rem;
-  font-weight: 600;
-  font-size: 1.8rem;
-  cursor: pointer;
-}
-
 .c1 {
   display: inline-block;
   margin-left: 1rem;
   color: #eb5757;
 }
 
-.c25 {
+.c22 {
   -webkit-align-self: flex-start;
   -ms-flex-item-align: start;
   align-self: flex-start;
@@ -1676,109 +1595,131 @@ exports[`<StepSalaires /> should render tempsPartiel 1`] = `
   padding-left: 0;
 }
 
-.c14 {
-  margin-left: 1rem;
-}
-
-.c15 {
+.c21 {
   width: 2rem;
   margin-left: 0.4rem;
   color: #f66663;
 }
 
-.c26 {
+.c23 {
   width: 2rem;
   margin-right: 0.4rem;
   color: #f66663;
 }
 
 .c8 {
-  -webkit-flex-basis: 20rem;
-  -ms-flex-preferred-size: 20rem;
-  flex-basis: 20rem;
-  margin-right: 2rem;
+  display: -ms-grid;
+  -ms-grid-rows: auto auto;
+  -ms-grid-columns: 2fr 1fr 1fr 13rem;
+  display: grid;
+  grid-template-rows: auto auto;
+  grid-template-columns: 2fr 1fr 1fr 13rem;
+  margin-top: 1.6rem;
+  margin-bottom: 1.6rem;
+}
+
+.c8 > *:nth-child(1) {
+  -ms-grid-row: 1;
+  -ms-grid-column: 1;
+  grid-row: 1;
+  grid-column: 1;
+}
+
+.c8 > *:nth-child(2) {
+  -ms-grid-row: 2;
+  -ms-grid-column: 1;
+  grid-row: 2;
+  grid-column: 1;
+}
+
+.c8 > *:nth-child(3) {
+  -ms-grid-row: 1;
+  -ms-grid-column: 2;
+  grid-row: 1;
+  grid-column: 2;
+}
+
+.c8 > *:nth-child(4) {
+  -ms-grid-row: 2;
+  -ms-grid-column: 2;
+  grid-row: 2;
+  grid-column: 2;
+}
+
+.c8 > *:nth-child(5) {
+  -ms-grid-row: 1;
+  -ms-grid-column: 3;
+  grid-row: 1;
+  grid-column: 3;
+}
+
+.c8 > *:nth-child(6) {
+  -ms-grid-row: 2;
+  -ms-grid-column: 3;
+  grid-row: 2;
+  grid-column: 3;
+}
+
+.c8 > *:nth-child(7) {
+  -ms-grid-row: 2;
+  -ms-grid-column: 4;
+  grid-row: 2;
+  grid-column: 4;
+}
+
+.c5 {
+  position: relative;
+}
+
+.c6 {
+  margin-bottom: 1.6rem;
+  padding-top: 1rem;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .c10 {
-  -webkit-flex-basis: 15rem;
-  -ms-flex-preferred-size: 15rem;
-  flex-basis: 15rem;
-  margin-right: 2rem;
+  margin-right: 1.6rem;
 }
 
-.c21 {
-  -webkit-flex-basis: 20rem;
-  -ms-flex-preferred-size: 20rem;
-  flex-basis: 20rem;
-}
-
-@media (max-width:600px) {
-  .c13 {
-    font-size: 1.4rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c24 {
-    font-size: 1.4rem;
-  }
+.c20 {
+  margin-top: 0.8rem;
 }
 
 @media (max-width:600px) {
   .c19 {
+    font-size: 1.4rem;
+  }
+}
+
+@media (max-width:600px) {
+  .c15 {
     width: 100%;
   }
 }
 
 @media (max-width:600px) {
-  .c20 {
+  .c16 {
     padding: 0 1rem;
     padding-right: 2rem;
   }
 }
 
 @media (max-width:600px) {
-  .c22 {
+  .c17 {
     padding: 0 1rem;
     padding-right: 5rem;
   }
 }
 
 @media (max-width:600px) {
-  .c16 {
-    width: 100%;
-  }
-}
-
-@media (max-width:600px) {
-  .c7 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-    margin-bottom: 3.2rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c6 {
-    display: none;
-  }
-}
-
-@media (max-width:600px) {
   .c11 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-align-items: center;
-    -webkit-box-align: center;
-    -ms-flex-align: center;
-    align-items: center;
-    -webkit-box-pack: justify;
-    -webkit-justify-content: space-between;
-    -ms-flex-pack: justify;
-    justify-content: space-between;
+    width: 100%;
   }
 }
 
@@ -1789,34 +1730,25 @@ exports[`<StepSalaires /> should render tempsPartiel 1`] = `
 }
 
 @media (max-width:600px) {
-  .c5 {
-    font-size: 1.6rem;
-  }
-}
-
-@media (max-width:600px) {
   .c8 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    margin-right: 0;
+    display: block;
+    margin-bottom: 3.2rem;
   }
 }
 
 @media (max-width:600px) {
   .c10 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
     margin-right: 0;
+    margin-bottom: 1.6rem;
   }
 }
 
 @media (max-width:600px) {
-  .c21 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
+  .c20 {
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin-top: 0;
   }
 }
 
@@ -1863,178 +1795,143 @@ exports[`<StepSalaires /> should render tempsPartiel 1`] = `
       Non
     </label>
   </div>
-  <label
-    class="c5"
+  <p
+    class="c0"
   >
     Quels ont été les durées et les salaires des périodes à temps plein et à temps partiel ?
-  </label>
+  </p>
   <div
-    class="c6 c7"
+    class="c5"
   >
     <div
-      class="c8 c9"
-    >
-      Type de durée de travail
-    </div>
-    <div
-      class="c10 c9"
-    >
-      Durée (en mois)
-    </div>
-    <div
-      class="c9"
-    >
-      Rémunération
-    </div>
-  </div>
-  <div
-    class="c7"
-  >
-    <div
-      class="c11"
+      class="c6"
     >
       <span
-        class="c12"
+        class="c7"
         font-size="hsmall"
         font-weight="400"
       >
         Période 
         1
       </span>
-      <button
-        class="c13 c14"
-        type="button"
-      >
-        Supprimer
-        <svg
-          aria-hidden="true"
-          class="c15"
-          fill="none"
-          viewBox="0 0 32 32"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M14.752 16.5L7.258 8.591A.957.957 0 017 7.932c0-.247.093-.484.259-.659A.858.858 0 017.883 7a.86.86 0 01.625.273L16 15.183l7.492-7.91A.859.859 0 0124.117 7c.234 0 .459.098.624.273a.957.957 0 01.259.659.957.957 0 01-.259.66L17.249 16.5l7.492 7.909a.958.958 0 01.259.659.957.957 0 01-.259.659.859.859 0 01-.624.273.86.86 0 01-.625-.273L16 17.817l-7.492 7.91a.859.859 0 01-.625.273.859.859 0 01-.624-.273.957.957 0 01-.259-.659.96.96 0 01.259-.66l7.492-7.908z"
-            fill="currentColor"
-            fill-rule="evenodd"
-          />
-        </svg>
-      </button>
     </div>
     <div
       class="c8"
     >
-      <div
-        class="c11 c9"
+      <label
+        class="c9"
+        for="salairePeriods[0].type"
       >
         Type de durée de travail
-      </div>
+      </label>
       <div
-        class="c16"
+        class="c10"
       >
-        <select
-          class="c17"
-          name="salairePeriods[0].type"
-        >
-          <option>
-            Temps partiel
-          </option>
-          <option>
-            Temps plein
-          </option>
-        </select>
         <div
-          aria-hidden="true"
-          class="c18"
+          class="c11 c12"
         >
-          <svg
-            fill="none"
-            viewBox="0 0 16 16"
+          <select
+            class="c13"
+            name="salairePeriods[0].type"
           >
-            <g
-              clip-path="url(#arrow-down_svg__clip0)"
+            <option>
+              Temps partiel
+            </option>
+            <option>
+              Temps plein
+            </option>
+          </select>
+          <div
+            aria-hidden="true"
+            class="c14"
+          >
+            <svg
+              fill="none"
+              viewBox="0 0 16 16"
             >
-              <path
-                d="M8.425 11.573l7.11-6.072a.709.709 0 00.26-.537.709.709 0 00-.26-.537.973.973 0 00-.629-.223.973.973 0 00-.63.223l-6.48 5.536-6.481-5.536a.973.973 0 00-.63-.223.973.973 0 00-.628.223.708.708 0 00-.261.537c0 .202.094.395.26.537l7.11 6.072a.91.91 0 00.29.165 1.021 1.021 0 00.68 0 .91.91 0 00.29-.165z"
-                fill="currentColor"
-              />
-            </g>
-            <defs>
-              <clippath
-                id="arrow-down_svg__clip0"
+              <g
+                clip-path="url(#arrow-down_svg__clip0)"
               >
                 <path
-                  d="M0 0h16v16H0z"
+                  d="M8.425 11.573l7.11-6.072a.709.709 0 00.26-.537.709.709 0 00-.26-.537.973.973 0 00-.629-.223.973.973 0 00-.63.223l-6.48 5.536-6.481-5.536a.973.973 0 00-.63-.223.973.973 0 00-.628.223.708.708 0 00-.261.537c0 .202.094.395.26.537l7.11 6.072a.91.91 0 00.29.165 1.021 1.021 0 00.68 0 .91.91 0 00.29-.165z"
                   fill="currentColor"
                 />
-              </clippath>
-            </defs>
-          </svg>
+              </g>
+              <defs>
+                <clippath
+                  id="arrow-down_svg__clip0"
+                >
+                  <path
+                    d="M0 0h16v16H0z"
+                    fill="currentColor"
+                  />
+                </clippath>
+              </defs>
+            </svg>
+          </div>
         </div>
       </div>
-    </div>
-    <div
-      class="c10"
-    >
-      <div
-        class="c11 c9"
+      <label
+        class="c9"
+        for="salairePeriods[0].duration"
       >
         Durée (en mois)
-      </div>
-      <span
-        class="c19"
-      >
-        <input
-          class="c20"
-          name="salairePeriods[0].duration"
-          type="number"
-          value="24"
-        />
-      </span>
-    </div>
-    <div
-      class="c21"
-    >
+      </label>
       <div
-        class="c11 c9"
+        class="c10"
+      >
+        <span
+          class="c15"
+        >
+          <input
+            class="c16"
+            id="salairePeriods[0].duration"
+            name="salairePeriods[0].duration"
+            type="number"
+            value="24"
+          />
+        </span>
+      </div>
+      <label
+        class="c9"
+        for="salairePeriods[0].salary"
       >
         Rémunération
-      </div>
-      <span
-        class="c19"
-      >
-        <input
-          class="c22"
-          name="salairePeriods[0].salary"
-          type="number"
-          value="2000"
-        />
-        <div
-          class="c23"
+      </label>
+      <div>
+        <span
+          class="c15"
         >
-          <svg
-            fill="none"
-            viewBox="0 0 32 32"
+          <input
+            class="c17"
+            id="salairePeriods[0].salary"
+            name="salairePeriods[0].salary"
+            type="number"
+            value="2000"
+          />
+          <div
+            class="c18"
           >
-            <path
-              d="M17.632 12.392c-.78 0-1.42.232-1.917.697-.493.465-.822 1.168-.988 2.108h3.785v1.279h-3.91l-.016.373v.457l.016.323h3.387v1.27h-3.245c.354 1.727 1.361 2.59 3.021 2.59.791 0 1.602-.171 2.432-.514v1.685c-.725.337-1.569.506-2.531.506-1.334 0-2.419-.365-3.254-1.096-.83-.73-1.373-1.787-1.627-3.17h-1.262v-1.27h1.129l-.017-.308v-.307l.017-.54h-1.13v-1.278h1.246c.21-1.389.739-2.479 1.585-3.27.847-.792 1.94-1.187 3.28-1.187 1.106 0 2.097.243 2.971.73l-.697 1.553c-.852-.421-1.61-.631-2.275-.631z"
-              fill="currentColor"
-            />
-          </svg>
-        </div>
-      </span>
-    </div>
-    <div
-      class="c6"
-    >
+            <svg
+              fill="none"
+              viewBox="0 0 32 32"
+            >
+              <path
+                d="M17.632 12.392c-.78 0-1.42.232-1.917.697-.493.465-.822 1.168-.988 2.108h3.785v1.279h-3.91l-.016.373v.457l.016.323h3.387v1.27h-3.245c.354 1.727 1.361 2.59 3.021 2.59.791 0 1.602-.171 2.432-.514v1.685c-.725.337-1.569.506-2.531.506-1.334 0-2.419-.365-3.254-1.096-.83-.73-1.373-1.787-1.627-3.17h-1.262v-1.27h1.129l-.017-.308v-.307l.017-.54h-1.13v-1.278h1.246c.21-1.389.739-2.479 1.585-3.27.847-.792 1.94-1.187 3.28-1.187 1.106 0 2.097.243 2.971.73l-.697 1.553c-.852-.421-1.61-.631-2.275-.631z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+        </span>
+      </div>
       <button
-        class="c24 c14"
+        class="c19 c20"
         type="button"
       >
         Supprimer
         <svg
           aria-hidden="true"
-          class="c15"
+          class="c21"
           fill="none"
           viewBox="0 0 32 32"
         >
@@ -2049,153 +1946,137 @@ exports[`<StepSalaires /> should render tempsPartiel 1`] = `
     </div>
   </div>
   <div
-    class="c7"
+    class="c5"
   >
     <div
-      class="c11"
+      class="c6"
     >
       <span
-        class="c12"
+        class="c7"
         font-size="hsmall"
         font-weight="400"
       >
         Période 
         2
       </span>
-      <button
-        class="c13 c14"
-        type="button"
-      >
-        Supprimer
-        <svg
-          aria-hidden="true"
-          class="c15"
-          fill="none"
-          viewBox="0 0 32 32"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M14.752 16.5L7.258 8.591A.957.957 0 017 7.932c0-.247.093-.484.259-.659A.858.858 0 017.883 7a.86.86 0 01.625.273L16 15.183l7.492-7.91A.859.859 0 0124.117 7c.234 0 .459.098.624.273a.957.957 0 01.259.659.957.957 0 01-.259.66L17.249 16.5l7.492 7.909a.958.958 0 01.259.659.957.957 0 01-.259.659.859.859 0 01-.624.273.86.86 0 01-.625-.273L16 17.817l-7.492 7.91a.859.859 0 01-.625.273.859.859 0 01-.624-.273.957.957 0 01-.259-.659.96.96 0 01.259-.66l7.492-7.908z"
-            fill="currentColor"
-            fill-rule="evenodd"
-          />
-        </svg>
-      </button>
     </div>
     <div
       class="c8"
     >
-      <div
-        class="c11 c9"
+      <label
+        class="c9"
+        for="salairePeriods[1].type"
       >
         Type de durée de travail
-      </div>
+      </label>
       <div
-        class="c16"
+        class="c10"
       >
-        <select
-          class="c17"
-          name="salairePeriods[1].type"
-        >
-          <option>
-            Temps partiel
-          </option>
-          <option>
-            Temps plein
-          </option>
-        </select>
         <div
-          aria-hidden="true"
-          class="c18"
+          class="c11 c12"
         >
-          <svg
-            fill="none"
-            viewBox="0 0 16 16"
+          <select
+            class="c13"
+            name="salairePeriods[1].type"
           >
-            <g
-              clip-path="url(#arrow-down_svg__clip0)"
+            <option>
+              Temps partiel
+            </option>
+            <option>
+              Temps plein
+            </option>
+          </select>
+          <div
+            aria-hidden="true"
+            class="c14"
+          >
+            <svg
+              fill="none"
+              viewBox="0 0 16 16"
             >
-              <path
-                d="M8.425 11.573l7.11-6.072a.709.709 0 00.26-.537.709.709 0 00-.26-.537.973.973 0 00-.629-.223.973.973 0 00-.63.223l-6.48 5.536-6.481-5.536a.973.973 0 00-.63-.223.973.973 0 00-.628.223.708.708 0 00-.261.537c0 .202.094.395.26.537l7.11 6.072a.91.91 0 00.29.165 1.021 1.021 0 00.68 0 .91.91 0 00.29-.165z"
-                fill="currentColor"
-              />
-            </g>
-            <defs>
-              <clippath
-                id="arrow-down_svg__clip0"
+              <g
+                clip-path="url(#arrow-down_svg__clip0)"
               >
                 <path
-                  d="M0 0h16v16H0z"
+                  d="M8.425 11.573l7.11-6.072a.709.709 0 00.26-.537.709.709 0 00-.26-.537.973.973 0 00-.629-.223.973.973 0 00-.63.223l-6.48 5.536-6.481-5.536a.973.973 0 00-.63-.223.973.973 0 00-.628.223.708.708 0 00-.261.537c0 .202.094.395.26.537l7.11 6.072a.91.91 0 00.29.165 1.021 1.021 0 00.68 0 .91.91 0 00.29-.165z"
                   fill="currentColor"
                 />
-              </clippath>
-            </defs>
-          </svg>
+              </g>
+              <defs>
+                <clippath
+                  id="arrow-down_svg__clip0"
+                >
+                  <path
+                    d="M0 0h16v16H0z"
+                    fill="currentColor"
+                  />
+                </clippath>
+              </defs>
+            </svg>
+          </div>
         </div>
       </div>
-    </div>
-    <div
-      class="c10"
-    >
-      <div
-        class="c11 c9"
+      <label
+        class="c9"
+        for="salairePeriods[1].duration"
       >
         Durée (en mois)
-      </div>
-      <span
-        class="c19"
-      >
-        <input
-          class="c20"
-          name="salairePeriods[1].duration"
-          type="number"
-          value="12"
-        />
-      </span>
-    </div>
-    <div
-      class="c21"
-    >
+      </label>
       <div
-        class="c11 c9"
+        class="c10"
+      >
+        <span
+          class="c15"
+        >
+          <input
+            class="c16"
+            id="salairePeriods[1].duration"
+            name="salairePeriods[1].duration"
+            type="number"
+            value="12"
+          />
+        </span>
+      </div>
+      <label
+        class="c9"
+        for="salairePeriods[1].salary"
       >
         Rémunération
-      </div>
-      <span
-        class="c19"
-      >
-        <input
-          class="c22"
-          name="salairePeriods[1].salary"
-          type="number"
-          value="1000"
-        />
-        <div
-          class="c23"
+      </label>
+      <div>
+        <span
+          class="c15"
         >
-          <svg
-            fill="none"
-            viewBox="0 0 32 32"
+          <input
+            class="c17"
+            id="salairePeriods[1].salary"
+            name="salairePeriods[1].salary"
+            type="number"
+            value="1000"
+          />
+          <div
+            class="c18"
           >
-            <path
-              d="M17.632 12.392c-.78 0-1.42.232-1.917.697-.493.465-.822 1.168-.988 2.108h3.785v1.279h-3.91l-.016.373v.457l.016.323h3.387v1.27h-3.245c.354 1.727 1.361 2.59 3.021 2.59.791 0 1.602-.171 2.432-.514v1.685c-.725.337-1.569.506-2.531.506-1.334 0-2.419-.365-3.254-1.096-.83-.73-1.373-1.787-1.627-3.17h-1.262v-1.27h1.129l-.017-.308v-.307l.017-.54h-1.13v-1.278h1.246c.21-1.389.739-2.479 1.585-3.27.847-.792 1.94-1.187 3.28-1.187 1.106 0 2.097.243 2.971.73l-.697 1.553c-.852-.421-1.61-.631-2.275-.631z"
-              fill="currentColor"
-            />
-          </svg>
-        </div>
-      </span>
-    </div>
-    <div
-      class="c6"
-    >
+            <svg
+              fill="none"
+              viewBox="0 0 32 32"
+            >
+              <path
+                d="M17.632 12.392c-.78 0-1.42.232-1.917.697-.493.465-.822 1.168-.988 2.108h3.785v1.279h-3.91l-.016.373v.457l.016.323h3.387v1.27h-3.245c.354 1.727 1.361 2.59 3.021 2.59.791 0 1.602-.171 2.432-.514v1.685c-.725.337-1.569.506-2.531.506-1.334 0-2.419-.365-3.254-1.096-.83-.73-1.373-1.787-1.627-3.17h-1.262v-1.27h1.129l-.017-.308v-.307l.017-.54h-1.13v-1.278h1.246c.21-1.389.739-2.479 1.585-3.27.847-.792 1.94-1.187 3.28-1.187 1.106 0 2.097.243 2.971.73l-.697 1.553c-.852-.421-1.61-.631-2.275-.631z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+        </span>
+      </div>
       <button
-        class="c24 c14"
+        class="c19 c20"
         type="button"
       >
         Supprimer
         <svg
           aria-hidden="true"
-          class="c15"
+          class="c21"
           fill="none"
           viewBox="0 0 32 32"
         >
@@ -2210,12 +2091,12 @@ exports[`<StepSalaires /> should render tempsPartiel 1`] = `
     </div>
   </div>
   <button
-    class="c13 c25"
+    class="c19 c22"
     type="button"
   >
     <svg
       aria-hidden="true"
-      class="c26"
+      class="c23"
       fill="none"
       viewBox="0 0 16 16"
     >

--- a/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/components/__tests__/__snapshots__/Salaires.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/components/__tests__/__snapshots__/Salaires.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Salaires /> should add a salaire 1`] = `
-.c12 {
+.c8 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -31,69 +31,6 @@ exports[`<Salaires /> should add a salaire 1`] = `
   appearance: none;
   height: 4rem;
   padding: 0 1rem;
-  color: #3e486e;
-  background: transparent;
-  border-color: transparent;
-  box-shadow: none;
-  opacity: 1;
-}
-
-.c12:link,
-.c12:visited {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #3e486e;
-}
-
-.c12:not([disabled]):hover,
-.c12:not([disabled]):active,
-.c12:not([disabled]):focus {
-  opacity: 0.6;
-  -webkit-transform: translateY(-2px);
-  -ms-transform: translateY(-2px);
-  transform: translateY(-2px);
-  background: transparent;
-  border-color: transparent;
-}
-
-.c12[disabled] {
-  background-color: #e4e8ef;
-  border-color: #e4e8ef;
-  color: #9298af;
-  box-shadow: none;
-  cursor: not-allowed;
-}
-
-.c8 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: content-box;
-  font-weight: 500;
-  font-size: 1.6rem;
-  line-height: 1.125em;
-  text-align: center;
-  vertical-align: middle;
-  border: 1px solid;
-  border-radius: 0.6rem;
-  cursor: pointer;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,-webkit-transform 100ms linear;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  height: 5.2rem;
-  padding: 0 1.9rem;
   color: #3e486e;
   background: transparent;
   border-color: transparent;
@@ -249,7 +186,7 @@ exports[`<Salaires /> should add a salaire 1`] = `
   max-width: 40rem;
 }
 
-.c13 {
+.c11 {
   -webkit-align-self: flex-start;
   -ms-flex-item-align: start;
   align-self: flex-start;
@@ -257,17 +194,13 @@ exports[`<Salaires /> should add a salaire 1`] = `
   padding-left: 0;
 }
 
-.c9 {
-  margin-left: 1rem;
-}
-
-.c11 {
+.c10 {
   width: 2rem;
   margin-left: 0.4rem;
   color: #f66663;
 }
 
-.c14 {
+.c12 {
   width: 2rem;
   margin-right: 0.4rem;
   color: #f66663;
@@ -295,12 +228,6 @@ exports[`<Salaires /> should add a salaire 1`] = `
   -ms-flex-pack: start;
   justify-content: flex-start;
   margin-bottom: 0.4rem;
-}
-
-@media (max-width:600px) {
-  .c12 {
-    font-size: 1.4rem;
-  }
 }
 
 @media (max-width:600px) {
@@ -341,7 +268,7 @@ exports[`<Salaires /> should add a salaire 1`] = `
 }
 
 @media (max-width:600px) {
-  .c10 {
+  .c9 {
     -webkit-align-self: center;
     -ms-flex-item-align: center;
     align-self: center;
@@ -410,13 +337,13 @@ exports[`<Salaires /> should add a salaire 1`] = `
       </span>
     </div>
     <button
-      class="c8 c9 c10"
+      class="c8 c9"
       type="button"
     >
       Supprimer
       <svg
         aria-hidden="true"
-        class="c11"
+        class="c10"
         fill="none"
         viewBox="0 0 32 32"
       >
@@ -430,12 +357,12 @@ exports[`<Salaires /> should add a salaire 1`] = `
     </button>
   </div>
   <button
-    class="c12 c13"
+    class="c8 c11"
     type="button"
   >
     <svg
       aria-hidden="true"
-      class="c14"
+      class="c12"
       fill="none"
       viewBox="0 0 16 16"
     >
@@ -545,10 +472,6 @@ exports[`<Salaires /> should delete a salaires 1`] = `
 }
 
 @media (max-width:600px) {
-
-}
-
-@media (max-width:600px) {
   .c2 {
     font-size: 1.4rem;
   }
@@ -643,8 +566,8 @@ exports[`<Salaires /> should render 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  height: 5.2rem;
-  padding: 0 1.9rem;
+  height: 4rem;
+  padding: 0 1rem;
   color: #3e486e;
   background: transparent;
   border-color: transparent;
@@ -671,69 +594,6 @@ exports[`<Salaires /> should render 1`] = `
 }
 
 .c8[disabled] {
-  background-color: #e4e8ef;
-  border-color: #e4e8ef;
-  color: #9298af;
-  box-shadow: none;
-  cursor: not-allowed;
-}
-
-.c12 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: content-box;
-  font-weight: 500;
-  font-size: 1.6rem;
-  line-height: 1.125em;
-  text-align: center;
-  vertical-align: middle;
-  border: 1px solid;
-  border-radius: 0.6rem;
-  cursor: pointer;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,-webkit-transform 100ms linear;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  height: 4rem;
-  padding: 0 1rem;
-  color: #3e486e;
-  background: transparent;
-  border-color: transparent;
-  box-shadow: none;
-  opacity: 1;
-}
-
-.c12:link,
-.c12:visited {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #3e486e;
-}
-
-.c12:not([disabled]):hover,
-.c12:not([disabled]):active,
-.c12:not([disabled]):focus {
-  opacity: 0.6;
-  -webkit-transform: translateY(-2px);
-  -ms-transform: translateY(-2px);
-  transform: translateY(-2px);
-  background: transparent;
-  border-color: transparent;
-}
-
-.c12[disabled] {
   background-color: #e4e8ef;
   border-color: #e4e8ef;
   color: #9298af;
@@ -863,7 +723,7 @@ exports[`<Salaires /> should render 1`] = `
   max-width: 40rem;
 }
 
-.c13 {
+.c11 {
   -webkit-align-self: flex-start;
   -ms-flex-item-align: start;
   align-self: flex-start;
@@ -871,17 +731,13 @@ exports[`<Salaires /> should render 1`] = `
   padding-left: 0;
 }
 
-.c9 {
-  margin-left: 1rem;
-}
-
-.c11 {
+.c10 {
   width: 2rem;
   margin-left: 0.4rem;
   color: #f66663;
 }
 
-.c14 {
+.c12 {
   width: 2rem;
   margin-right: 0.4rem;
   color: #f66663;
@@ -918,12 +774,6 @@ exports[`<Salaires /> should render 1`] = `
 }
 
 @media (max-width:600px) {
-  .c12 {
-    font-size: 1.4rem;
-  }
-}
-
-@media (max-width:600px) {
   .c5 {
     width: 100%;
   }
@@ -955,7 +805,7 @@ exports[`<Salaires /> should render 1`] = `
 }
 
 @media (max-width:600px) {
-  .c10 {
+  .c9 {
     -webkit-align-self: center;
     -ms-flex-item-align: center;
     align-self: center;
@@ -1024,13 +874,13 @@ exports[`<Salaires /> should render 1`] = `
       </span>
     </div>
     <button
-      class="c8 c9 c10"
+      class="c8 c9"
       type="button"
     >
       Supprimer
       <svg
         aria-hidden="true"
-        class="c11"
+        class="c10"
         fill="none"
         viewBox="0 0 32 32"
       >
@@ -1044,12 +894,12 @@ exports[`<Salaires /> should render 1`] = `
     </button>
   </div>
   <button
-    class="c12 c13"
+    class="c8 c11"
     type="button"
   >
     <svg
       aria-hidden="true"
-      class="c14"
+      class="c12"
       fill="none"
       viewBox="0 0 16 16"
     >

--- a/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/steps/__tests__/__snapshots__/Remuneration.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/steps/__tests__/__snapshots__/Remuneration.test.js.snap
@@ -29,8 +29,8 @@ exports[`<StepRemuneration /> should render multiple inputs 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  height: 5.2rem;
-  padding: 0 1.9rem;
+  height: 4rem;
+  padding: 0 1rem;
   color: #3e486e;
   background: transparent;
   border-color: transparent;
@@ -57,69 +57,6 @@ exports[`<StepRemuneration /> should render multiple inputs 1`] = `
 }
 
 .c11[disabled] {
-  background-color: #e4e8ef;
-  border-color: #e4e8ef;
-  color: #9298af;
-  box-shadow: none;
-  cursor: not-allowed;
-}
-
-.c15 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: content-box;
-  font-weight: 500;
-  font-size: 1.6rem;
-  line-height: 1.125em;
-  text-align: center;
-  vertical-align: middle;
-  border: 1px solid;
-  border-radius: 0.6rem;
-  cursor: pointer;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,-webkit-transform 100ms linear;
-  -webkit-transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  transition: background-color 250ms linear, border-color 250ms linear,transform 100ms linear;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  height: 4rem;
-  padding: 0 1rem;
-  color: #3e486e;
-  background: transparent;
-  border-color: transparent;
-  box-shadow: none;
-  opacity: 1;
-}
-
-.c15:link,
-.c15:visited {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #3e486e;
-}
-
-.c15:not([disabled]):hover,
-.c15:not([disabled]):active,
-.c15:not([disabled]):focus {
-  opacity: 0.6;
-  -webkit-transform: translateY(-2px);
-  -ms-transform: translateY(-2px);
-  transform: translateY(-2px);
-  background: transparent;
-  border-color: transparent;
-}
-
-.c15[disabled] {
   background-color: #e4e8ef;
   border-color: #e4e8ef;
   color: #9298af;
@@ -312,7 +249,7 @@ exports[`<StepRemuneration /> should render multiple inputs 1`] = `
   max-width: 40rem;
 }
 
-.c16 {
+.c14 {
   -webkit-align-self: flex-start;
   -ms-flex-item-align: start;
   align-self: flex-start;
@@ -320,17 +257,13 @@ exports[`<StepRemuneration /> should render multiple inputs 1`] = `
   padding-left: 0;
 }
 
-.c12 {
-  margin-left: 1rem;
-}
-
-.c14 {
+.c13 {
   width: 2rem;
   margin-left: 0.4rem;
   color: #f66663;
 }
 
-.c17 {
+.c15 {
   width: 2rem;
   margin-right: 0.4rem;
   color: #f66663;
@@ -360,7 +293,7 @@ exports[`<StepRemuneration /> should render multiple inputs 1`] = `
   margin-bottom: 0.4rem;
 }
 
-.c18 {
+.c16 {
   color: #3e486e;
   font-size: 1.4rem;
   font-style: italic;
@@ -368,12 +301,6 @@ exports[`<StepRemuneration /> should render multiple inputs 1`] = `
 
 @media (max-width:600px) {
   .c11 {
-    font-size: 1.4rem;
-  }
-}
-
-@media (max-width:600px) {
-  .c15 {
     font-size: 1.4rem;
   }
 }
@@ -416,7 +343,7 @@ exports[`<StepRemuneration /> should render multiple inputs 1`] = `
 }
 
 @media (max-width:600px) {
-  .c13 {
+  .c12 {
     -webkit-align-self: center;
     -ms-flex-item-align: center;
     align-self: center;
@@ -535,13 +462,13 @@ exports[`<StepRemuneration /> should render multiple inputs 1`] = `
       </span>
     </div>
     <button
-      class="c11 c12 c13"
+      class="c11 c12"
       type="button"
     >
       Supprimer
       <svg
         aria-hidden="true"
-        class="c14"
+        class="c13"
         fill="none"
         viewBox="0 0 32 32"
       >
@@ -592,13 +519,13 @@ exports[`<StepRemuneration /> should render multiple inputs 1`] = `
       </span>
     </div>
     <button
-      class="c11 c12 c13"
+      class="c11 c12"
       type="button"
     >
       Supprimer
       <svg
         aria-hidden="true"
-        class="c14"
+        class="c13"
         fill="none"
         viewBox="0 0 32 32"
       >
@@ -612,12 +539,12 @@ exports[`<StepRemuneration /> should render multiple inputs 1`] = `
     </button>
   </div>
   <button
-    class="c15 c16"
+    class="c11 c14"
     type="button"
   >
     <svg
       aria-hidden="true"
-      class="c17"
+      class="c15"
       fill="none"
       viewBox="0 0 16 16"
     >
@@ -631,7 +558,7 @@ exports[`<StepRemuneration /> should render multiple inputs 1`] = `
     Ajouter un salaire
   </button>
   <p
-    class="c18"
+    class="c16"
   >
     Majorations, indemnités, primes et accessoires compris sauf les remboursements de frais et l’indemnité de congés payés.
   </p>

--- a/packages/code-du-travail-frontend/src/outils/common/Buttons.js
+++ b/packages/code-du-travail-frontend/src/outils/common/Buttons.js
@@ -14,10 +14,10 @@ export function AddButton({ children, ...props }) {
 
 export function DelButton({ children, ...props }) {
   return (
-    <StyledDelButton narrow variant="naked" type="button" {...props}>
+    <Button narrow small variant="naked" type="button" {...props}>
       {children}
       <CloseIcon aria-hidden="true" />
-    </StyledDelButton>
+    </Button>
   );
 }
 const { spacings } = theme;
@@ -26,10 +26,6 @@ const StyledAddButton = styled(Button)`
   align-self: flex-start;
   margin: ${spacings.small} 0;
   padding-left: 0;
-`;
-
-const StyledDelButton = styled(Button)`
-  margin-left: ${spacings.small};
 `;
 
 const CloseIcon = styled(icons.Close)`

--- a/packages/code-du-travail-frontend/src/outils/common/MultiFieldRow.js
+++ b/packages/code-du-travail-frontend/src/outils/common/MultiFieldRow.js
@@ -1,0 +1,60 @@
+import styled from "styled-components";
+import { theme } from "@socialgouv/react-ui";
+
+const { breakpoints, spacings } = theme;
+
+// prefixing is only needed for grid properties/values
+const prefixer = (css) =>
+  `${css.replace(/grid-template/g, "grid").replace(/grid/g, "-ms-grid")}${css}`;
+
+const getChildNumber = (index, emptyCells) => {
+  const matchNumber = [...Array(index)].reduce((accumulator, unused, i) => {
+    return emptyCells.includes(i + 1) ? accumulator + 1 : accumulator;
+  }, 0);
+  return index - matchNumber + 1;
+};
+
+/*
+  The empty cell numbers must correspond to the following count:
+
+  Imagine a 3 x 4 grid on desktop
+
+    1  |  4  |  7  |  10
+  ----------------------
+    2  |  5  |  8  |  11
+  ----------------------
+    3  |  6  |  9  |  12
+
+  On mobile, elements will be below each others, according to markup.
+*/
+
+export const MultiFieldRow = styled.div`
+  ${({ gridRows, gridColumns }) =>
+    prefixer(`
+    display: grid;
+    grid-template-rows: ${gridRows.join(" ")};
+    grid-template-columns: ${gridColumns.join(" ")};
+  `)}
+  margin-top: ${spacings.base};
+  margin-bottom: ${spacings.base};
+  ${({ emptyCells, gridColumns, gridRows }) =>
+    [...Array(gridColumns.length * gridRows.length)]
+      .map((unused, i) => {
+        if (emptyCells.includes(i + 1)) {
+          return "";
+        }
+        return `
+        & > *:nth-child(${getChildNumber(i, emptyCells)}) {
+          ${prefixer(`
+            grid-row: ${(i + 1) % gridRows.length ? 1 : 2};
+            grid-column: ${Math.floor(i / gridRows.length + 1)};
+          `)}
+        }
+      `;
+      })
+      .join("")}
+  @media (max-width: ${breakpoints.mobile}) {
+    display: block;
+    margin-bottom: ${spacings.large};
+  }
+`;

--- a/packages/code-du-travail-frontend/src/outils/common/Wizard.js
+++ b/packages/code-du-travail-frontend/src/outils/common/Wizard.js
@@ -142,7 +142,7 @@ function Wizard({
               />
               {stepIndex > 0 && stepIndex < steps.length && (
                 <Notice>
-                  <Mandatory>*</Mandatory> Champs obligatoire
+                  <Mandatory>*</Mandatory> Champs obligatoires
                 </Notice>
               )}
               {process.env.NODE_ENV !== "production" &&

--- a/packages/code-du-travail-frontend/src/outils/common/__tests__/__snapshots__/Wizard.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/common/__tests__/__snapshots__/Wizard.test.js.snap
@@ -1011,7 +1011,7 @@ exports[`<Wizard /> should handle initialState.stepIndex 1`] = `
       >
         *
       </span>
-       Champs obligatoire
+       Champs obligatoires
     </p>
   </form>
 </div>
@@ -2498,7 +2498,7 @@ exports[`<Wizard /> should navigate to the second step when click on Suivant 1`]
       >
         *
       </span>
-       Champs obligatoire
+       Champs obligatoires
     </p>
   </form>
 </div>

--- a/packages/code-du-travail-frontend/src/outils/common/stepStyles.js
+++ b/packages/code-du-travail-frontend/src/outils/common/stepStyles.js
@@ -3,17 +3,6 @@ import { theme } from "@socialgouv/react-ui";
 
 const { breakpoints, fonts, colors, spacings } = theme;
 
-export const Input = styled.input`
-  width: ${(props) => (props.type === "number" ? "10em" : "auto")};
-  text-align: ${(props) => (props.type === "number" ? "right" : "left")};
-  border-color: ${(props) => (props.invalid ? colors.error : colors.border)};
-  &::-webkit-outer-spin-button,
-  &::-webkit-inner-spin-button {
-    margin: 0;
-    appearance: none;
-  }
-`;
-
 export const Label = styled.label`
   display: flex;
   align-items: center;
@@ -27,12 +16,6 @@ export const RadioContainer = styled.div`
   align-items: flex-start;
   justify-content: flex-start;
   margin-bottom: ${spacings.medium};
-`;
-
-export const Header = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
 `;
 
 export const SectionTitle = styled.h2`
@@ -58,45 +41,4 @@ export const SmallText = styled.p`
   color: ${colors.paragraph};
   font-size: ${fonts.sizes.small};
   font-style: italic;
-`;
-
-export const Summary = styled.summary`
-  display: block;
-  margin-bottom: ${spacings.base};
-`;
-
-/**
- * use for table like form multi-row
- * on mobile each line become a block
- */
-export const Row = styled.div`
-  display: flex;
-  justify-content: flex-start;
-  margin-bottom: ${spacings.small};
-  @media (max-width: ${theme.breakpoints.mobile}) {
-    flex-direction: column;
-    margin-bottom: ${spacings.large};
-  }
-`;
-
-export const DesktopOnly = styled.div`
-  @media (max-width: ${theme.breakpoints.mobile}) {
-    display: none;
-  }
-`;
-
-export const MobileOnlyCell = styled.div`
-  display: none;
-  @media (max-width: ${theme.breakpoints.mobile}) {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-  }
-`;
-
-export const CellHeader = styled.div`
-  padding-top: ${spacings.small};
-  padding-bottom: ${spacings.tiny};
-  font-weight: 700;
-  font-size: ${fonts.sizes.small};
 `;


### PR DESCRIPTION
Pour ne pas vous polluer la relecture avec les snaps, regardez le diff de ce commit uniquement: https://github.com/SocialGouv/code-du-travail-numerique/pull/2563/commits/bb0612b9fbd12c1c4f259689f3917bdd9732657d

Motivations:

1) Dupliquer le markup html ce n'est jamais une très bonne chose, et j'avais quelques soucis avec les doubles boutons (supprimer) pour les tests e2e (qui ne detectent pas si ils sont en `display: none` ou pas). Avec des grid, vu qu'on peut placer n'importe quoi n'importe ou, pas besoin de dupliquer le contenu pour assurer les version desktop / mobile, même si là, pour des raisons simplicité, j'utilise un positionement absolu du bouton supprimer sur mobile (mais je pourrais utiliser une grid)

2) l'alignement des éléments (bouton supprimer, labels, erreurs etc) était un peu chaotique sans les grids

3) Je voulais voir ce qu'il y a moyen de faire avec les grid et IE: ça fonctionne si on n'utilise pas les gaps et qu'on s'en tient à des positionnement définis (pas de positionnement automatique), avec des préfixes.

n.b. Il y a aussi un peu de cleanup

Rendu sur IE: 

<img width="540" alt="Screenshot 2020-04-03 at 11 00 02" src="https://user-images.githubusercontent.com/705453/78347879-68ffcb00-75a1-11ea-8230-b6270b4a4bc4.png">
<img width="941" alt="Screenshot 2020-04-03 at 10 58 05" src="https://user-images.githubusercontent.com/705453/78347883-6ac98e80-75a1-11ea-9ba7-68878b12b2af.png">
<img width="389" alt="Screenshot 2020-04-03 at 10 58 24" src="https://user-images.githubusercontent.com/705453/78347884-6bfabb80-75a1-11ea-8cc3-91ee7ccd594a.png">