### PR TITLE
ci(gitlab): deploy should not download artifacts by default

### DIFF
--- a/.gitlab-ci/stages/deploy.yml
+++ b/.gitlab-ci/stages/deploy.yml
@@ -92,6 +92,8 @@ Deploy @cdtn/api (dev):
   extends:
     - .deploy_api_stage
     - .dev_stage
+  dependencies:
+    - Register nlp image
   variables:
     HELM_RENDER_ARGS: >-
       --set autoscaling.enabled=false
@@ -126,6 +128,8 @@ Deploy @cdtn/frontend (dev):
   extends:
     - .deploy_frontend_stage
     - .dev_stage
+  dependencies:
+    - Register nlp image
   variables:
     HELM_RENDER_ARGS: >-
       --set autoscaling.enabled=false

--- a/.gitlab-ci/stages/deploy.yml
+++ b/.gitlab-ci/stages/deploy.yml
@@ -37,6 +37,7 @@ Create namespace:
 
 .deploy_stage: &deploy_stage
   stage: "Deploy"
+  dependencies: []
   except:
     variables:
       # Don't run when running e2e tests
@@ -209,6 +210,8 @@ Deploy @cdtn/nlp (dev):
   extends:
     - .deploy_nlp_stage
     - .dev_stage
+  dependencies:
+    - Register nlp image
   variables:
     HELM_RENDER_ARGS: >-
       --set deployment.resources.requests.memory=1Gi


### PR DESCRIPTION
<img src=https://media.giphy.com/media/icUEIrjnUuFCWDxFpU/giphy.gif width=693>

---

Get the `Register nlp image` artifact only on `Deploy @cdtn/nlp (dev)`