### PR TITLE
fix(tools): bug

### DIFF
--- a/packages/code-du-travail-frontend/src/outils/common/Wizard.js
+++ b/packages/code-du-travail-frontend/src/outils/common/Wizard.js
@@ -47,7 +47,7 @@ function Wizard({
       "trackEvent",
       "outil",
       `click_previous_${title}`,
-      initialState.steps[nextStepIndex].name,
+      state.steps[nextStepIndex].name,
     ]);
   };
   const nextStep = (values) => {
@@ -58,12 +58,11 @@ function Wizard({
       skipFn = steps[nextStepIndex].skip || (() => false);
     }
     setStepIndex(nextStepIndex);
-
     matopush([
       "trackEvent",
       "outil",
       `view_step_${title}`,
-      initialState.steps[nextStepIndex].name,
+      state.steps[nextStepIndex].name,
     ]);
   };
 

--- a/packages/code-du-travail-frontend/src/outils/common/__tests__/__snapshots__/Wizard.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/common/__tests__/__snapshots__/Wizard.test.js.snap
@@ -983,11 +983,19 @@ exports[`<Wizard /> should handle initialState.stepIndex 1`] = `
       </ul>
     </div>
     <p>
-      Deuxieme Etape 
-      <button>
-        Submit
-      </button>
+      Deuxieme Etape
     </p>
+    <label
+      for="cb"
+    >
+      etape facultative
+      <input
+        id="cb"
+        name="fooStep"
+        type="checkbox"
+        value=""
+      />
+    </label>
     <div
       class="c12"
     >
@@ -1458,7 +1466,7 @@ exports[`<Wizard /> should handle initialValues 1`] = `
           >
             3
           </span>
-          Name
+          Optional Step
         </li>
       </ul>
     </div>
@@ -2470,11 +2478,19 @@ exports[`<Wizard /> should navigate to the second step when click on Suivant 1`]
       </ul>
     </div>
     <p>
-      Deuxieme Etape 
-      <button>
-        Submit
-      </button>
+      Deuxieme Etape
     </p>
+    <label
+      for="cb"
+    >
+      etape facultative
+      <input
+        id="cb"
+        name="fooStep"
+        type="checkbox"
+        value=""
+      />
+    </label>
     <div
       class="c12"
     >


### PR DESCRIPTION

![source](https://user-images.githubusercontent.com/705453/79250278-b5d78180-7e7e-11ea-8c75-ecad7a717c4a.gif)


https://sentry.fabrique.social.gouv.fr/incubateur/code-du-travail-numerique/?query=is%3Aunresolved+name

On utilisait le state initial pour fournir le nom de l'étape dans matomo, manque de bol ce state est dynamique et parfois il arrivait qu'on ait des steps en plus et lorsqu'on cherchait à faire un matopush sur un indice qui n'existait pas, kaput !

Je vais finir le test e2e qui check cet outil soon. 

Le résultat s'affichait (ouf) mais on ne pouvait plus rien faire après (js broken)