### PR TITLE
feat(front): add version check in /api

### DIFF
--- a/.gitlab-ci/stages/deploy.yml
+++ b/.gitlab-ci/stages/deploy.yml
@@ -142,8 +142,6 @@ Deploy @cdtn/frontend (dev):
   after_script:
     - |-
       source ./.gitlab-ci/env.sh
-      echo "Frontend url is : ${FRONTEND_URL}";
-      echo "Last commit is : ${COMMIT}";
       retry=60;
       while
         ! curl -sS "${FRONTEND_URL}/api/version" | grep "${COMMIT}" &&

--- a/.gitlab-ci/stages/deploy.yml
+++ b/.gitlab-ci/stages/deploy.yml
@@ -139,6 +139,17 @@ Deploy @cdtn/frontend (dev):
     expire_in: 30 mins
     paths:
       - packages/code-du-travail-nlp
+  after_script:
+    - |-
+      source ./.gitlab-ci/env.sh
+      echo "Frontend url is : ${FRONTEND_URL}";
+      echo "Last commit is : ${COMMIT}";
+      retry=60;
+      while
+        ! curl -sS "${FRONTEND_URL}/api/version" | grep "${COMMIT}" &&
+        [[ $(( retry-- )) -gt 0 ]];
+      do echo "Waiting for frontend to be ready" ; sleep 3 ; done ;
+      [ "$retry" -eq "-1" ] && exit 1
 
 Deploy @cdtn/frontend (prod):
   <<: *deploy_frontend_stage

--- a/.k8s/frontend.values.yml
+++ b/.k8s/frontend.values.yml
@@ -67,6 +67,8 @@ deployment:
           key: SENTRY_PUBLIC_DSN
     - name: VERSION
       value: "${VERSION}"
+    - name: COMMIT
+      value: "${COMMIT}"
 
   initContainers:
     - name: wait-for-api

--- a/packages/code-du-travail-frontend/next.config.js
+++ b/packages/code-du-travail-frontend/next.config.js
@@ -40,6 +40,7 @@ const nextConfig = {
       "https://entreprise.data.gouv.fr/api/sirene/v1",
     API_URL: process.env.API_URL || "http://127.0.0.1:1337/api/v1",
     PACKAGE_VERSION: process.env.VERSION || require("./package.json").version,
+    COMMIT: process.env.COMMIT,
     PIWIK_SITE_ID: process.env.PIWIK_SITE_ID,
     PIWIK_URL: process.env.PIWIK_URL,
     SENTRY_PUBLIC_DSN: process.env.SENTRY_PUBLIC_DSN,

--- a/packages/code-du-travail-frontend/pages/api/version.js
+++ b/packages/code-du-travail-frontend/pages/api/version.js
@@ -1,0 +1,11 @@
+import getConfig from "next/config";
+
+const {
+  publicRuntimeConfig: { COMMIT, PACKAGE_VERSION },
+} = getConfig();
+
+export default (req, res) => {
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify({ commit: COMMIT, version: PACKAGE_VERSION }));
+};


### PR DESCRIPTION
Ca permet à la CI de savoir si la branche a vraiment fini de deployer avant de continuer (Je compte m'en servir plus tard pour bien lancer les tests end2end quand on est ready)