### PR TITLE
feat(data): make possible to have same ref on different theme

### DIFF
--- a/packages/code-du-travail-data/indexing/breadcrumbs.js
+++ b/packages/code-du-travail-data/indexing/breadcrumbs.js
@@ -14,15 +14,16 @@ export function toBreadcrumbs({ label, position }) {
 
 export function createThemer(themes) {
   return function getTheme(slug) {
-    const referencedThemes = themes.filter((theme) =>
-      theme.refs.find((ref) => ref.url.match(new RegExp(slug, "i")))
-    );
-    const theme = referencedThemes.reduce((majorTheme, currentTheme) => {
-      if (!majorTheme || majorTheme.position > currentTheme) {
-        return currentTheme;
-      }
-      return majorTheme;
-    }, null);
+    // we only pick the most important theme
+    const theme = themes
+      .filter((theme) =>
+        theme.refs.find((ref) => ref.url.match(new RegExp(slug, "i")))
+      )
+      .sort((previous, next) => {
+        // currently position also take depth into account
+        // e.g. 7 has a depth of one and 71 a depth of 2 and so on
+        return previous.position - next.position;
+      })[0];
     let breadcrumbs = [];
     if (theme) {
       breadcrumbs = (theme.breadcrumbs || []).map(toBreadcrumbs).concat([

--- a/packages/code-du-travail-data/indexing/breadcrumbs.js
+++ b/packages/code-du-travail-data/indexing/breadcrumbs.js
@@ -14,9 +14,15 @@ export function toBreadcrumbs({ label, position }) {
 
 export function createThemer(themes) {
   return function getTheme(slug) {
-    const theme = themes.find((theme) =>
-      theme.refs.some((ref) => ref.url.match(new RegExp(slug, "i")))
+    const referencedThemes = themes.filter((theme) =>
+      theme.refs.find((ref) => ref.url.match(new RegExp(slug, "i")))
     );
+    const theme = referencedThemes.reduce((majorTheme, currentTheme) => {
+      if (!majorTheme || majorTheme.position > currentTheme) {
+        return currentTheme;
+      }
+      return majorTheme;
+    }, null);
     let breadcrumbs = [];
     if (theme) {
       breadcrumbs = (theme.breadcrumbs || []).map(toBreadcrumbs).concat([


### PR DESCRIPTION
@lionelB ça poserait problème de faire ça ? Je n'ai pas de vue holistique sur le sujet

Le but c'est de pouvoir référencer un contenu dans plusieurs themes sans casser le breadcrumb, en s'appuyant sur la position du theme pour prendre toujours le plus important. (comme vu avec virginie)