### PR TITLE
bugfix(search): set default vector / solve ES issue for semantic search

### DIFF
--- a/packages/code-du-travail-api/src/server/routes/search/index.js
+++ b/packages/code-du-travail-api/src/server/routes/search/index.js
@@ -209,7 +209,19 @@ async function msearch({ client, searches }) {
   }
 
   const results = keys.reduce((state, key, index) => {
-    state[key] = body.responses[index];
+    const resp = body.responses[index];
+
+    if (resp.error) {
+      logger.error(
+        `Elastic search error : index ${index}, search key ${key} : ${JSON.stringify(
+          resp.error,
+          null,
+          2
+        )}`
+      );
+    }
+
+    state[key] = resp;
     return state;
   }, {});
 

--- a/packages/code-du-travail-data/dump.js
+++ b/packages/code-du-travail-data/dump.js
@@ -20,6 +20,7 @@ const excludeSources = [
   SOURCES.HIGHLIGHTS,
   SOURCES.SHEET_MT_PAGE,
   SOURCES.CCN_PAGE,
+  SOURCES.VERSIONS,
 ];
 const nlpQueue = new PQueue({ concurrency: 3 });
 
@@ -36,7 +37,7 @@ const noIdSources = [
 
 async function fetchVector(data) {
   // ensure title_vector set, otherwise search will fail if any of the docs does not have title_vector
-  data.title_vector = [];
+  data.title_vector = Array(512).fill(0);
   return NLP_URL && data.title && data.text
     ? vectorizeDocument(data.title, data.text)
         .then((title_vector) => {

--- a/packages/code-du-travail-data/dump.js
+++ b/packages/code-du-travail-data/dump.js
@@ -37,27 +37,19 @@ const noIdSources = [
 
 async function fetchVector(data) {
   if (NLP_URL) {
-    if (data.title && data.text) {
-      await vectorizeDocument(data.title, data.text)
-        .then((title_vector) => {
-          if (title_vector.message) {
-            throw new Error(`error fetching ${data.title}`);
-          }
-          data.title_vector = title_vector;
-        })
-        .catch((err) => {
-          console.error(`error fetching ${data.title}`, err.message);
-        });
-    } else {
-      // create random title_vector : search will fail if any of the docs
-      // does not have title_vector set : 512 dimension vector, 9 digits between -1 and 1
-      const length = 512;
-      const maxDigits = 9;
-      data.title_vector = Array.from(
-        { length },
-        () => (Math.random() > 0.5 ? 1 : -1) * Math.random().toFixed(maxDigits)
-      );
-    }
+    if (!data.title)
+      console.error(`No title for document ${data.source} / ${data.slug}`);
+    const title = data.title || "sans titre";
+    await vectorizeDocument(title, data.text)
+      .then((title_vector) => {
+        if (title_vector.message) {
+          throw new Error(`error fetching ${data.title}`);
+        }
+        data.title_vector = title_vector;
+      })
+      .catch((err) => {
+        console.error(`error fetching ${data.title}`, err.message);
+      });
   }
 
   return data;

--- a/packages/code-du-travail-data/dump.js
+++ b/packages/code-du-travail-data/dump.js
@@ -35,6 +35,8 @@ const noIdSources = [
 ];
 
 async function fetchVector(data) {
+  // ensure title_vector set, otherwise search will fail if any of the docs does not have title_vector
+  data.title_vector = [];
   return NLP_URL && data.title && data.text
     ? vectorizeDocument(data.title, data.text)
         .then((title_vector) => {

--- a/packages/code-du-travail-data/dump.js
+++ b/packages/code-du-travail-data/dump.js
@@ -36,22 +36,31 @@ const noIdSources = [
 ];
 
 async function fetchVector(data) {
-  // ensure title_vector set, otherwise search will fail if any of the docs does not have title_vector
-  data.title_vector = Array(512).fill(0);
-  return NLP_URL && data.title && data.text
-    ? vectorizeDocument(data.title, data.text)
+  if (NLP_URL) {
+    if (data.title && data.text) {
+      await vectorizeDocument(data.title, data.text)
         .then((title_vector) => {
           if (title_vector.message) {
             throw new Error(`error fetching ${data.title}`);
           }
           data.title_vector = title_vector;
-          return data;
         })
         .catch((err) => {
           console.error(`error fetching ${data.title}`, err.message);
-          return data;
-        })
-    : data;
+        });
+    } else {
+      // create random title_vector : search will fail if any of the docs
+      // does not have title_vector set : 512 dimension vector, 9 digits between -1 and 1
+      const length = 512;
+      const maxDigits = 9;
+      data.title_vector = Array.from(
+        { length },
+        () => (Math.random() > 0.5 ? 1 : -1) * Math.random().toFixed(maxDigits)
+      );
+    }
+  }
+
+  return data;
 }
 
 const dump = async () => {

--- a/packages/code-du-travail-data/indexing/esClientUtils.js
+++ b/packages/code-du-travail-data/indexing/esClientUtils.js
@@ -43,7 +43,7 @@ async function version({ client }) {
 
 async function bulkIndexDocuments({ client, indexName, documents }) {
   try {
-    await client.bulk({
+    const resp = await client.bulk({
       body: documents.reduce(
         (state, doc, i) =>
           state.concat(
@@ -62,6 +62,12 @@ async function bulkIndexDocuments({ client, indexName, documents }) {
       ),
       index: indexName,
     });
+    if (resp.body.errors) {
+      const errorDocs = resp.body.items.filter(
+        (item) => item.index.status != 201
+      );
+      logger.error(`Errors during indexation : ${JSON.stringify(errorDocs)}`);
+    }
     logger.info(`Index ${documents.length} documents.`);
   } catch (error) {
     logger.error("index documents", error);


### PR DESCRIPTION
Petite session investigation aujourd'hui, car je ne trouvais plus de résultats sémantiques dans les résultats.
Après recherche cette PR résout le prob :
- certains documents n'ont pas de titre, et pour éviter les erreurs, on passait l'étape de vectorisation pour ceux-ci
- sauf que la recherche sémantique plante lorsque qu'il existe des documents sans vecteurs
- et on ne log pas toutes les erreurs retournées par Elastic 
- donc quand on met ça bout à bout, on se retrouve avec une version ou la recherche sémantique ne fonctionne plus du tout, à cause de quelques documents sans titre

Dans cette PR, je rajoute du log, et je set par défaut une valeur pour le vecteur de représentation sémantique.