### PR TITLE
fix: seo

### DIFF
--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/a-propos.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/a-propos.test.js.snap
@@ -1330,7 +1330,7 @@ exports[`<About /> should render 1`] = `
         >
           <a
             class="c16"
-            href="/recherche?q="
+            href="/recherche"
           >
             <svg
               fill="none"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/code-du-travail.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/code-du-travail.test.js.snap
@@ -1485,7 +1485,7 @@ exports[`<CodeDuTravail /> should render 1`] = `
         >
           <a
             class="c16"
-            href="/recherche?q="
+            href="/recherche"
           >
             <svg
               fill="none"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/contribution.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/contribution.test.js.snap
@@ -2101,7 +2101,7 @@ exports[`<FicheContribution /> should render with external content 1`] = `
           >
             <a
               class="c16"
-              href="/recherche?q="
+              href="/recherche"
             >
               <svg
                 fill="none"
@@ -5006,7 +5006,7 @@ exports[`<FicheContribution /> should render without external content 1`] = `
           >
             <a
               class="c16"
-              href="/recherche?q="
+              href="/recherche"
             >
               <svg
                 fill="none"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/droit-du-travail.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/droit-du-travail.test.js.snap
@@ -2486,7 +2486,7 @@ exports[`<DroitDuTravail /> should render 1`] = `
         >
           <a
             class="c17"
-            href="/recherche?q="
+            href="/recherche"
           >
             <svg
               fill="none"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/fiche-ministere-travail.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/fiche-ministere-travail.test.js.snap
@@ -1887,7 +1887,7 @@ exports[`<FicheMT /> should render 1`] = `
         >
           <a
             class="c16"
-            href="/recherche?q="
+            href="/recherche"
           >
             <svg
               fill="none"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/fiche-service-public.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/fiche-service-public.test.js.snap
@@ -1485,7 +1485,7 @@ exports[`<FicheSP /> should render 1`] = `
         >
           <a
             class="c16"
-            href="/recherche?q="
+            href="/recherche"
           >
             <svg
               fill="none"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire-[slug].test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire-[slug].test.js.snap
@@ -1341,7 +1341,7 @@ exports[`<Term /> should render 1`] = `
         >
           <a
             class="c16"
-            href="/recherche?q="
+            href="/recherche"
           >
             <svg
               fill="none"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire.test.js.snap
@@ -1333,7 +1333,7 @@ exports[`<Glossaire /> should render 1`] = `
         >
           <a
             class="c16"
-            href="/recherche?q="
+            href="/recherche"
           >
             <svg
               fill="none"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/mentions-legales.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/mentions-legales.test.js.snap
@@ -1353,7 +1353,7 @@ exports[`<MentionLegales /> should render 1`] = `
         >
           <a
             class="c16"
-            href="/recherche?q="
+            href="/recherche"
           >
             <svg
               fill="none"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers-[slug].test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers-[slug].test.js.snap
@@ -2063,7 +2063,7 @@ exports[`<ModelesDeCourrier /> should render 1`] = `
         >
           <a
             class="c16"
-            href="/recherche?q="
+            href="/recherche"
           >
             <svg
               fill="none"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers.test.js.snap
@@ -1439,7 +1439,7 @@ exports[`<ModelesDeCourriers /> should render 1`] = `
         >
           <a
             class="c16"
-            href="/recherche?q="
+            href="/recherche"
           >
             <svg
               fill="none"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/outils.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/outils.test.js.snap
@@ -1577,7 +1577,7 @@ exports[`<Outils /> should render 1`] = `
         >
           <a
             class="c17"
-            href="/recherche?q="
+            href="/recherche"
           >
             <svg
               fill="none"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/politique-confidentialite.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/politique-confidentialite.test.js.snap
@@ -1307,7 +1307,7 @@ exports[`<CookiePolicy /> should render 1`] = `
         >
           <a
             class="c16"
-            href="/recherche?q="
+            href="/recherche"
           >
             <svg
               fill="none"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/stats.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/stats.test.js.snap
@@ -1448,7 +1448,7 @@ exports[`<Stats /> should render 1`] = `
         >
           <a
             class="c16"
-            href="/recherche?q="
+            href="/recherche"
           >
             <svg
               fill="none"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/themes.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/themes.test.js.snap
@@ -127,7 +127,7 @@ exports[`<Theme /> should render 1`] = `
   color: #f66663;
 }
 
-.c41 {
+.c42 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -164,16 +164,16 @@ exports[`<Theme /> should render 1`] = `
   opacity: 1;
 }
 
-.c41:link,
-.c41:visited {
+.c42:link,
+.c42:visited {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #fff;
 }
 
-.c41:not([disabled]):hover,
-.c41:not([disabled]):active,
-.c41:not([disabled]):focus {
+.c42:not([disabled]):hover,
+.c42:not([disabled]):active,
+.c42:not([disabled]):focus {
   opacity: 1;
   -webkit-transform: translateY(-2px);
   -ms-transform: translateY(-2px);
@@ -182,7 +182,7 @@ exports[`<Theme /> should render 1`] = `
   border-color: #a0b3e0;
 }
 
-.c41[disabled] {
+.c42[disabled] {
   background-color: #e4e8ef;
   border-color: #e4e8ef;
   color: #9298af;
@@ -849,7 +849,7 @@ exports[`<Theme /> should render 1`] = `
   justify-content: center;
 }
 
-.c42 {
+.c41 {
   margin: 1rem;
 }
 
@@ -897,19 +897,19 @@ exports[`<Theme /> should render 1`] = `
 }
 
 @media (max-width:600px) {
-  .c41 {
+  .c42 {
     font-size: 1.4rem;
   }
 }
 
 @media print {
-  .c41 {
+  .c42 {
     display: none;
   }
 }
 
 @media (max-width:600px) {
-  .c41 {
+  .c42 {
     padding: 0 3rem;
   }
 }
@@ -1279,7 +1279,7 @@ exports[`<Theme /> should render 1`] = `
 }
 
 @media (max-width:600px) {
-  .c42 {
+  .c41 {
     -webkit-flex: 1 1 auto;
     -ms-flex: 1 1 auto;
     flex: 1 1 auto;
@@ -1565,36 +1565,36 @@ exports[`<Theme /> should render 1`] = `
           <div
             class="c40"
           >
-            <button
+            <a
               class="c41 c42"
               href="/themes/121-cdi"
             >
               CDI
-            </button>
-            <button
+            </a>
+            <a
               class="c41 c42"
               href="/themes/122-cdd"
             >
               CDD
-            </button>
-            <button
+            </a>
+            <a
               class="c41 c42"
               href="/themes/123-interim"
             >
               Intérim
-            </button>
-            <button
+            </a>
+            <a
               class="c41 c42"
               href="/themes/124-contrat-dapprentissage"
             >
               Contrat d'apprentissage
-            </button>
-            <button
+            </a>
+            <a
               class="c41 c42"
               href="/themes/125-contrat-de-professionnalisation"
             >
               Contrat de professionnalisation
-            </button>
+            </a>
           </div>
         </div>
       </div>
@@ -1629,7 +1629,7 @@ exports[`<Theme /> should render 1`] = `
               Les services du ministère du Travail en région informent, conseillent et orientent les salariés et les employeurs du secteur privé sur leurs questions en droit du travail.
             </div>
             <button
-              class="c41"
+              class="c42"
             >
               Contacter nos services en région
               <svg

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/themes.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/themes.test.js.snap
@@ -1393,7 +1393,7 @@ exports[`<Theme /> should render 1`] = `
         >
           <a
             class="c16"
-            href="/recherche?q="
+            href="/recherche"
           >
             <svg
               fill="none"

--- a/packages/code-du-travail-frontend/pages/code-du-travail/[slug].js
+++ b/packages/code-du-travail-frontend/pages/code-du-travail/[slug].js
@@ -10,7 +10,7 @@ import Answer from "../../src/common/Answer";
 import Html from "../../src/common/Html";
 import Metas from "../../src/common/Metas";
 import { Layout } from "../../src/layout/Layout";
-import { replaceArticlesRefs } from "../../src/lib/replaceArticlesRefs";
+// import { replaceArticlesRefs } from "../../src/lib/replaceArticlesRefs";
 
 const {
   publicRuntimeConfig: { API_URL },

--- a/packages/code-du-travail-frontend/pages/code-du-travail/[slug].js
+++ b/packages/code-du-travail-frontend/pages/code-du-travail/[slug].js
@@ -39,7 +39,7 @@ class Fiche extends React.Component {
       },
     } = this.props;
 
-    const fixedHtml = replaceArticlesRefs(html);
+    // const fixedHtml = replaceArticlesRefs(html);
     return (
       <Layout>
         <Metas title={title} description={description} />
@@ -53,7 +53,7 @@ class Fiche extends React.Component {
             })
           }
           emptyMessage="Article introuvable"
-          html={fixedHtml}
+          html={html}
           source={{ name: "Code du travail", url }}
         >
           {notaHtml && (

--- a/packages/code-du-travail-frontend/pages/recherche.js
+++ b/packages/code-du-travail-frontend/pages/recherche.js
@@ -42,7 +42,7 @@ class SearchPage extends React.Component {
         initialTitle={`${query} - Code du travail numérique`}
       >
         <Head>
-          <meta name="robots" content="noindex, follow" />
+          <meta name="robots" content="noindex, nofollow" />
         </Head>
         <Metas
           title={`${query} - Code du travail numérique`}

--- a/packages/code-du-travail-frontend/pages/themes/[slug].js
+++ b/packages/code-du-travail-frontend/pages/themes/[slug].js
@@ -62,7 +62,7 @@ class Theme extends React.Component {
                     as={slug}
                     passHref
                   >
-                    <StyledLink as={Button}>{label}</StyledLink>
+                    <Button as={StyledLink}>{label}</Button>
                   </Link>
                 ))}
               </StyledContainer>

--- a/packages/code-du-travail-frontend/pages/themes/[slug].js
+++ b/packages/code-du-travail-frontend/pages/themes/[slug].js
@@ -72,7 +72,6 @@ class Theme extends React.Component {
         {theme.refs && theme.refs.length > 0 && (
           <Section>
             <SearchResults
-              query={theme.title}
               items={{ articles: [], documents: theme.refs, themes: [] }}
             />
           </Section>

--- a/packages/code-du-travail-frontend/server/__tests__/__snapshots__/routes.test.js.snap
+++ b/packages/code-du-travail-frontend/server/__tests__/__snapshots__/routes.test.js.snap
@@ -2,7 +2,8 @@
 
 exports[`/IS_PRODUCTION_DEPLOYMENT=false should return dev robots.txt 1`] = `
 "User-agent: *
-Disallow: /"
+Disallow: /
+Disallow: /code-du-travail/"
 `;
 
 exports[`/IS_PRODUCTION_DEPLOYMENT=true should return production robots.txt 1`] = `"Redirecting to <a href=\\"https://prod-test-hostname/robots.txt\\">https://prod-test-hostname/robots.txt</a>."`;

--- a/packages/code-du-travail-frontend/server/koaServer.js
+++ b/packages/code-du-travail-frontend/server/koaServer.js
@@ -30,11 +30,16 @@ function getSentryCspUrl() {
 
 const dev = process.env.NODE_ENV !== "production";
 
-const robotsDev = ["User-agent: *", "Disallow: /"].join("\n");
+const robotsDev = [
+  "User-agent: *",
+  "Disallow: /",
+  "Disallow: /code-du-travail/",
+].join("\n");
 const robotsProd = [
   "User-agent: *",
   "Disallow: /assets/",
   "Disallow: /images/",
+  "Disallow: /code-du-travail/",
   "",
   `Sitemap: https://${PROD_HOSTNAME}/sitemap.xml`,
 ].join("\n");

--- a/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/ReferenceList.js
+++ b/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/ReferenceList.js
@@ -15,7 +15,9 @@ const CodeDuTravailLink = ({ title, slug }) => (
     as={`/${getRouteBySource(SOURCES.CDT)}/${sanitizeCdtSlug(slug)}`}
     passHref
   >
-    <StyledArrowLink arrowPosition="left">{title}</StyledArrowLink>
+    <StyledArrowLink rel="nofollow" arrowPosition="left">
+      {title}
+    </StyledArrowLink>
   </Link>
 );
 
@@ -25,7 +27,10 @@ const ConventionLink = ({ title, slug }) => (
     as={`/${getRouteBySource(SOURCES.CCN)}/${slug}`}
     passHref
   >
-    <StyledArrowLink arrowPosition="left">{`Convention collective: ${title}`}</StyledArrowLink>
+    <StyledArrowLink
+      rel="nofollow"
+      arrowPosition="left"
+    >{`Convention collective: ${title}`}</StyledArrowLink>
   </Link>
 );
 
@@ -33,7 +38,7 @@ const OtherLink = ({ title, url }) =>
   url ? (
     <StyledArrowLink
       href={url}
-      rel="noopener noreferrer"
+      rel="noopener noreferrer nofollow"
       target="_blank"
       arrowPosition="left"
     >

--- a/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/__tests__/__snapshots__/ReferenceList.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/__tests__/__snapshots__/ReferenceList.test.js.snap
@@ -71,6 +71,7 @@ exports[`<ReferenceList /> should render 1`] = `
       <a
         class="c1 c2 c3"
         href="/code-du-travail/l2323-4"
+        rel="nofollow"
       >
         <svg
           class="c4"
@@ -98,6 +99,7 @@ exports[`<ReferenceList /> should render 1`] = `
       <a
         class="c1 c2 c3"
         href="/convention-collective/ma-convention-collective"
+        rel="nofollow"
       >
         <svg
           class="c4"
@@ -120,6 +122,7 @@ exports[`<ReferenceList /> should render 1`] = `
       <a
         class="c1 c2 c3"
         href="/code-du-travail/r3321-2"
+        rel="nofollow"
       >
         <svg
           class="c4"

--- a/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/__tests__/__snapshots__/ReferencesJuridiques.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/ReferencesJuridiques/__tests__/__snapshots__/ReferencesJuridiques.test.js.snap
@@ -269,6 +269,7 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
                   <a
                     class="c8 c9 c10"
                     href="/code-du-travail/l1244-3"
+                    rel="nofollow"
                   >
                     <svg
                       class="c11"
@@ -291,6 +292,7 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
                   <a
                     class="c8 c9 c10"
                     href="/code-du-travail/r1244-4"
+                    rel="nofollow"
                   >
                     <svg
                       class="c11"
@@ -323,6 +325,7 @@ exports[`<ReferencesJuridiques /> should render 1`] = `
                   <a
                     class="c8 c9 c10"
                     href="/convention-collective/ma-convention"
+                    rel="nofollow"
                   >
                     <svg
                       class="c11"

--- a/packages/code-du-travail-frontend/src/common/RelatedItems.js
+++ b/packages/code-du-travail-frontend/src/common/RelatedItems.js
@@ -50,6 +50,7 @@ export const RelatedItems = ({ items = [] }) => {
                   passHref
                 >
                   <CallToActionTile
+                    rel="nofollow"
                     action={action || "Consulter"}
                     custom
                     icon={
@@ -65,7 +66,7 @@ export const RelatedItems = ({ items = [] }) => {
                   custom={false}
                   href={url}
                   icon={icons[icon]}
-                  rel="noopener noreferrer"
+                  rel="noopener noreferrer nofollow"
                   subtitle={subtitle}
                   target="_blank"
                   title={title}
@@ -101,6 +102,7 @@ export const RelatedItems = ({ items = [] }) => {
                     passHref
                   >
                     <ArrowLink
+                      rel="nofollow"
                       arrowPosition="left"
                       onClick={() =>
                         matopush([

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/Answer.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/Answer.test.js.snap
@@ -3095,7 +3095,7 @@ exports[`<Answer /> should renders related content 1`] = `
             <a
               class="c27"
               href="url.extrenal/tool"
-              rel="noopener noreferrer"
+              rel="noopener noreferrer nofollow"
               target="_blank"
             >
               <div
@@ -3174,6 +3174,7 @@ exports[`<Answer /> should renders related content 1`] = `
             <a
               class="c27"
               href="/outils/TOOL_1"
+              rel="nofollow"
             >
               <div
                 class="c38"
@@ -3289,6 +3290,7 @@ exports[`<Answer /> should renders related content 1`] = `
             <a
               class="c43 c44"
               href="/fiche-service-public/LINK_1"
+              rel="nofollow"
             >
               <svg
                 class="c45"
@@ -3313,6 +3315,7 @@ exports[`<Answer /> should renders related content 1`] = `
             <a
               class="c43 c44"
               href="/fiche-ministere-travail/LINK_2"
+              rel="nofollow"
             >
               <svg
                 class="c45"
@@ -3337,6 +3340,7 @@ exports[`<Answer /> should renders related content 1`] = `
             <a
               class="c43 c44"
               href="/fiche-service-public/LINK_4"
+              rel="nofollow"
             >
               <svg
                 class="c45"

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/RelatedItems.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/RelatedItems.test.js.snap
@@ -402,7 +402,7 @@ exports[`<RelatedItems /> should render 1`] = `
         <a
           class="c4"
           href="external.tools"
-          rel="noopener noreferrer"
+          rel="noopener noreferrer nofollow"
           target="_blank"
         >
           <div
@@ -488,6 +488,7 @@ exports[`<RelatedItems /> should render 1`] = `
       >
         <button
           class="c4"
+          rel="nofollow"
         >
           <div
             class="c16"
@@ -594,6 +595,7 @@ exports[`<RelatedItems /> should render 1`] = `
       >
         <a
           class="c21 c22"
+          rel="nofollow"
         >
           <svg
             class="c23"
@@ -617,6 +619,7 @@ exports[`<RelatedItems /> should render 1`] = `
       >
         <a
           class="c21 c22"
+          rel="nofollow"
         >
           <svg
             class="c23"

--- a/packages/code-du-travail-frontend/src/contributions/Contribution.js
+++ b/packages/code-du-travail-frontend/src/contributions/Contribution.js
@@ -25,7 +25,7 @@ import rehypeToReact from "./rehypeToReact";
 
 const RefLink = ({ title, url }) =>
   url ? (
-    <a href={url} target="_blank" rel="noopener noreferrer">
+    <a href={url} target="_blank" rel="noopener noreferrer nofollow">
       {title}
     </a>
   ) : (
@@ -73,7 +73,7 @@ const References = ({ references = [] }) => {
                   }}
                   as={`/${getRouteBySource(SOURCES.CDT)}/${slugify(ref.title)}`}
                 >
-                  <a>{ref.title}</a>
+                  <a rel="nofollow">{ref.title}</a>
                 </Link>
               </li>
             ))}

--- a/packages/code-du-travail-frontend/src/conventions/Convention/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/code-du-travail-frontend/src/conventions/Convention/__tests__/__snapshots__/index.test.js.snap
@@ -1069,7 +1069,7 @@ exports[`<Convention /> renders 1`] = `
                             <a
                               class="c14 c15 c16"
                               href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                              rel="noopener noreferrer"
+                              rel="noopener noreferrer nofollow"
                               target="_blank"
                             >
                               <svg
@@ -1237,7 +1237,7 @@ exports[`<Convention /> renders 1`] = `
                             <a
                               class="c14 c15 c16"
                               href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                              rel="noopener noreferrer"
+                              rel="noopener noreferrer nofollow"
                               target="_blank"
                             >
                               <svg
@@ -1261,7 +1261,7 @@ exports[`<Convention /> renders 1`] = `
                             <a
                               class="c14 c15 c16"
                               href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                              rel="noopener noreferrer"
+                              rel="noopener noreferrer nofollow"
                               target="_blank"
                             >
                               <svg
@@ -1426,7 +1426,7 @@ exports[`<Convention /> renders 1`] = `
                             <a
                               class="c14 c15 c16"
                               href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                              rel="noopener noreferrer"
+                              rel="noopener noreferrer nofollow"
                               target="_blank"
                             >
                               <svg
@@ -1646,7 +1646,7 @@ exports[`<Convention /> renders 1`] = `
                             <a
                               class="c14 c15 c16"
                               href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                              rel="noopener noreferrer"
+                              rel="noopener noreferrer nofollow"
                               target="_blank"
                             >
                               <svg
@@ -1670,7 +1670,7 @@ exports[`<Convention /> renders 1`] = `
                             <a
                               class="c14 c15 c16"
                               href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                              rel="noopener noreferrer"
+                              rel="noopener noreferrer nofollow"
                               target="_blank"
                             >
                               <svg
@@ -1805,7 +1805,7 @@ exports[`<Convention /> renders 1`] = `
                             <a
                               class="c14 c15 c16"
                               href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                              rel="noopener noreferrer"
+                              rel="noopener noreferrer nofollow"
                               target="_blank"
                             >
                               <svg
@@ -1924,7 +1924,7 @@ exports[`<Convention /> renders 1`] = `
                             <a
                               class="c14 c15 c16"
                               href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                              rel="noopener noreferrer"
+                              rel="noopener noreferrer nofollow"
                               target="_blank"
                             >
                               <svg
@@ -1948,7 +1948,7 @@ exports[`<Convention /> renders 1`] = `
                             <a
                               class="c14 c15 c16"
                               href="https://www.legifrance.gouv.fr/affichIDCC.do;jsessionid=C6E78561AB60D1D67B3304C0EFE9B4DF.tplgfr30s_3?idSectionTA=KALISCTA000005706582&cidTexte=KALITEXT000005662348&idConvention=KALICONT000005635120"
-                              rel="noopener noreferrer"
+                              rel="noopener noreferrer nofollow"
                               target="_blank"
                             >
                               <svg
@@ -2067,7 +2067,7 @@ exports[`<Convention /> renders 1`] = `
                             <a
                               class="c14 c15 c16"
                               href="https://www.legifrance.gouv.fr/affichIDCC.do;jsessionid=C6E78561AB60D1D67B3304C0EFE9B4DF.tplgfr30s_3?idSectionTA=KALISCTA000005706582&cidTexte=KALITEXT000005662348&idConvention=KALICONT000005635120"
-                              rel="noopener noreferrer"
+                              rel="noopener noreferrer nofollow"
                               target="_blank"
                             >
                               <svg
@@ -2091,7 +2091,7 @@ exports[`<Convention /> renders 1`] = `
                             <a
                               class="c14 c15 c16"
                               href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                              rel="noopener noreferrer"
+                              rel="noopener noreferrer nofollow"
                               target="_blank"
                             >
                               <svg
@@ -2210,7 +2210,7 @@ exports[`<Convention /> renders 1`] = `
                             <a
                               class="c14 c15 c16"
                               href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                              rel="noopener noreferrer"
+                              rel="noopener noreferrer nofollow"
                               target="_blank"
                             >
                               <svg
@@ -2370,7 +2370,7 @@ exports[`<Convention /> renders 1`] = `
                             <a
                               class="c14 c15 c16"
                               href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                              rel="noopener noreferrer"
+                              rel="noopener noreferrer nofollow"
                               target="_blank"
                             >
                               <svg
@@ -2567,7 +2567,7 @@ exports[`<Convention /> renders 1`] = `
                             <a
                               class="c14 c15 c16"
                               href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                              rel="noopener noreferrer"
+                              rel="noopener noreferrer nofollow"
                               target="_blank"
                             >
                               <svg
@@ -2738,7 +2738,7 @@ exports[`<Convention /> renders 1`] = `
                             <a
                               class="c14 c15 c16"
                               href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                              rel="noopener noreferrer"
+                              rel="noopener noreferrer nofollow"
                               target="_blank"
                             >
                               <svg
@@ -2762,7 +2762,7 @@ exports[`<Convention /> renders 1`] = `
                             <a
                               class="c14 c15 c16"
                               href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                              rel="noopener noreferrer"
+                              rel="noopener noreferrer nofollow"
                               target="_blank"
                             >
                               <svg
@@ -2952,7 +2952,7 @@ exports[`<Convention /> renders 1`] = `
                             <a
                               class="c14 c15 c16"
                               href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                              rel="noopener noreferrer"
+                              rel="noopener noreferrer nofollow"
                               target="_blank"
                             >
                               <svg
@@ -3071,7 +3071,7 @@ exports[`<Convention /> renders 1`] = `
                             <a
                               class="c14 c15 c16"
                               href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                              rel="noopener noreferrer"
+                              rel="noopener noreferrer nofollow"
                               target="_blank"
                             >
                               <svg
@@ -3281,7 +3281,7 @@ exports[`<Convention /> renders 1`] = `
                             <a
                               class="c14 c15 c16"
                               href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                              rel="noopener noreferrer"
+                              rel="noopener noreferrer nofollow"
                               target="_blank"
                             >
                               <svg
@@ -3576,7 +3576,7 @@ exports[`<Convention /> renders 1`] = `
                             <a
                               class="c14 c15 c16"
                               href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                              rel="noopener noreferrer"
+                              rel="noopener noreferrer nofollow"
                               target="_blank"
                             >
                               <svg
@@ -3721,7 +3721,7 @@ exports[`<Convention /> renders 1`] = `
                             <a
                               class="c14 c15 c16"
                               href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                              rel="noopener noreferrer"
+                              rel="noopener noreferrer nofollow"
                               target="_blank"
                             >
                               <svg
@@ -4225,7 +4225,7 @@ exports[`<Convention /> renders 1`] = `
                                       <a
                                         class="c14 c15 c16"
                                         href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                                        rel="noopener noreferrer"
+                                        rel="noopener noreferrer nofollow"
                                         target="_blank"
                                       >
                                         <svg
@@ -4249,7 +4249,7 @@ exports[`<Convention /> renders 1`] = `
                                       <a
                                         class="c14 c15 c16"
                                         href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                                        rel="noopener noreferrer"
+                                        rel="noopener noreferrer nofollow"
                                         target="_blank"
                                       >
                                         <svg
@@ -4273,7 +4273,7 @@ exports[`<Convention /> renders 1`] = `
                                       <a
                                         class="c14 c15 c16"
                                         href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                                        rel="noopener noreferrer"
+                                        rel="noopener noreferrer nofollow"
                                         target="_blank"
                                       >
                                         <svg
@@ -4297,7 +4297,7 @@ exports[`<Convention /> renders 1`] = `
                                       <a
                                         class="c14 c15 c16"
                                         href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                                        rel="noopener noreferrer"
+                                        rel="noopener noreferrer nofollow"
                                         target="_blank"
                                       >
                                         <svg
@@ -4321,7 +4321,7 @@ exports[`<Convention /> renders 1`] = `
                                       <a
                                         class="c14 c15 c16"
                                         href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                                        rel="noopener noreferrer"
+                                        rel="noopener noreferrer nofollow"
                                         target="_blank"
                                       >
                                         <svg
@@ -4476,7 +4476,7 @@ exports[`<Convention /> renders 1`] = `
                             <a
                               class="c14 c15 c16"
                               href="https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635221"
-                              rel="noopener noreferrer"
+                              rel="noopener noreferrer nofollow"
                               target="_blank"
                             >
                               <svg

--- a/packages/code-du-travail-frontend/src/layout/Header/index.js
+++ b/packages/code-du-travail-frontend/src/layout/Header/index.js
@@ -57,7 +57,7 @@ export const Header = ({ currentPage = "" }) => {
         <RightSide>
           {isContentPage && !overThreshold && (
             <Link
-              href={{ pathname: "/recherche", query: router.query }}
+              href={{ pathname: "/recherche", query: { q: router.query.q } }}
               passHref
             >
               <StyledLink>

--- a/packages/code-du-travail-frontend/src/layout/Header/index.js
+++ b/packages/code-du-travail-frontend/src/layout/Header/index.js
@@ -22,6 +22,7 @@ export const Header = ({ currentPage = "" }) => {
     setDate(printDate());
   }, []);
   const router = useRouter();
+  const { q } = router.query;
   const scrollInfo = useWindowScrollPosition();
   const overThreshold = scrollInfo.y > 200;
   const floating = scrollInfo.direction === "up";
@@ -57,7 +58,10 @@ export const Header = ({ currentPage = "" }) => {
         <RightSide>
           {isContentPage && !overThreshold && (
             <Link
-              href={{ pathname: "/recherche", query: { q: router.query.q } }}
+              href={{
+                pathname: "/recherche",
+                ...(q && { query: { q } }),
+              }}
               passHref
             >
               <StyledLink>

--- a/packages/code-du-travail-frontend/src/layout/__tests__/__snapshots__/Header.test.js.snap
+++ b/packages/code-du-travail-frontend/src/layout/__tests__/__snapshots__/Header.test.js.snap
@@ -594,7 +594,7 @@ exports[`<Header /> should render 1`] = `
       >
         <a
           class="c14"
-          href="/recherche?q="
+          href="/recherche"
         >
           <svg
             fill="none"

--- a/packages/code-du-travail-frontend/src/layout/__tests__/__snapshots__/Layout.test.js.snap
+++ b/packages/code-du-travail-frontend/src/layout/__tests__/__snapshots__/Layout.test.js.snap
@@ -1156,7 +1156,7 @@ exports[`<Layout /> should render 1`] = `
         >
           <a
             class="c16"
-            href="/recherche?q="
+            href="/recherche"
           >
             <svg
               fill="none"


### PR DESCRIPTION
- theme button › a
- nofollow sur ref juridique et lien annexe
- suppression du preprocess des liens dans `/code-du-travail/`  
- suppression des liens avec ?recherche?slug (mobile)
- passage de la page `/recherche` en nofollow