### PR TITLE
fix(frontend): sitemap

### DIFF
--- a/packages/code-du-travail-frontend/scripts/generate-sitemap.js
+++ b/packages/code-du-travail-frontend/scripts/generate-sitemap.js
@@ -16,11 +16,18 @@ const glossaryPages = [getRouteBySource(SOURCES.GLOSSARY)].concat(
     ({ title }) => `${getRouteBySource(SOURCES.GLOSSARY)}/${slugify(title)}`
   )
 );
-const staticPages = ["a-propos", "droit-du-travail", "mentions-legales"];
+const staticPages = [
+  "a-propos",
+  "droit-du-travail",
+  "mentions-legales",
+  "politique-confidentialite",
+  "integration",
+];
 const documentPages = require(DOCUMENT_PATH)
   .filter(
     ({ slug, source }) =>
-      Boolean(slug) && ![SOURCES.CCN_PAGE, SOURCES.SHEET_MT].includes(source)
+      Boolean(slug) &&
+      ![SOURCES.EXTERNALS, SOURCES.CDT, SOURCES.SHEET_MT].includes(source)
   )
   .map(({ source, slug }) =>
     source === SOURCES.SHEET_MT_PAGE


### PR DESCRIPTION
remove code du travail from sitemap since it is in noindex (this triggers a lot of error in the google console)
also adds a few missing pages and remove externals which are not valid and also trigger errors