### PR TITLE
fix wrong route for convention-collectives tool

### DIFF
--- a/packages/code-du-travail-api/src/server/routes/search/search.getSavedResult.js
+++ b/packages/code-du-travail-api/src/server/routes/search/search.getSavedResult.js
@@ -25,7 +25,7 @@ const preprocess = (q) => {
 
 async function _getPrequalified() {
   const body = getPrequalifiedBody();
-  const response = await elasticsearchClient.search({ index, body });
+  const response = await elasticsearchClient.search({ body, index });
   if (response.body.hits.total.value === 0) {
     return null;
   }
@@ -41,22 +41,22 @@ async function _getPrequalified() {
   }, {});
 
   return {
-    knownQueriesSet,
     allVariants: Object.keys(knownQueriesSet),
+    knownQueriesSet,
   };
 }
 
 const getPrequalified = memoizee(_getPrequalified, {
-  promise: true,
   maxAge: 1000 * 5 * 60,
   preFetch: true,
+  promise: true,
 });
 
 const fuzzOptions = {
-  scorer: fuzz.ratio,
   full_process: false,
-  unsorted: false,
   limit: 2,
+  scorer: fuzz.ratio,
+  unsorted: false,
 };
 
 const testFuzzyAllowed = (query, match) => {
@@ -101,7 +101,7 @@ const getSavedResult = async (query) => {
   const { knownQueriesSet, allVariants } = await getPrequalified();
 
   const knownQuery =
-    query.length > 3 && testMatch({ query, knownQueriesSet, allVariants });
+    query.length > 3 && testMatch({ allVariants, knownQueriesSet, query });
 
   if (knownQuery && knownQuery.refs) {
     // get ES results for a known query

--- a/packages/code-du-travail-frontend/pages/outils/convention-collective.js
+++ b/packages/code-du-travail-frontend/pages/outils/convention-collective.js
@@ -1,0 +1,3 @@
+import SearchConvention from "../convention-collective";
+
+export default SearchConvention;

--- a/packages/code-du-travail-frontend/src/search/SearchResults/Results.js
+++ b/packages/code-du-travail-frontend/src/search/SearchResults/Results.js
@@ -135,7 +135,7 @@ export const Results = ({ id, isSearch, items, query }) => {
         query={query}
       >
         {items.map((item) => (
-          <StyledListItem key={item.slug}>
+          <StyledListItem key={`${item.source}-${item.slug}`}>
             <ListLink item={item} showTheme={Boolean(isSearch)} query={query} />
           </StyledListItem>
         ))}


### PR DESCRIPTION
Dans la recherche, lorsque l'outil de recherche de convention collective remonte, son url est: `/outils/convention-collective` alors qu'il s'agit techniquement parlant d'une page et non d'un outil. Résultat, le site crash