### PR TITLE
feat(ccns): synonymes convention collectives #3063

### DIFF
--- a/packages/code-du-travail-api/src/server/routes/idcc/idcc.elastic.js
+++ b/packages/code-du-travail-api/src/server/routes/idcc/idcc.elastic.js
@@ -37,6 +37,13 @@ function getIdccBody({ query }) {
               },
               {
                 match_phrase_prefix: {
+                  "synonyms.french": {
+                    query: `${query}`,
+                  },
+                },
+              },
+              {
+                match_phrase_prefix: {
                   "title.french": {
                     query: `${query}`,
                   },

--- a/packages/code-du-travail-api/src/server/routes/idcc/idcc.elastic.js
+++ b/packages/code-du-travail-api/src/server/routes/idcc/idcc.elastic.js
@@ -37,7 +37,7 @@ function getIdccBody({ query }) {
               },
               {
                 match_phrase_prefix: {
-                  "synonyms.french": {
+                  "synonymes.french": {
                     query: `${query}`,
                   },
                 },

--- a/packages/code-du-travail-api/src/server/routes/idcc/index.js
+++ b/packages/code-du-travail-api/src/server/routes/idcc/index.js
@@ -25,7 +25,7 @@ const router = new Router({ prefix: API_BASE_URL });
 router.get("/idcc", async (ctx) => {
   const body = getIdccBody({ query: ctx.request.query.q });
 
-  const response = await elasticsearchClient.search({ index, body });
+  const response = await elasticsearchClient.search({ body, index });
   ctx.body = { ...response.body };
 });
 

--- a/packages/code-du-travail-data/dataset/suggestions.txt
+++ b/packages/code-du-travail-data/dataset/suggestions.txt
@@ -11,7 +11,7 @@
 {"entity": "risque s\u00e9rieux atteinte \u00e0 la sant\u00e9 \u00e0 la s\u00e9curit\u00e9 ou \u00e0 int\u00e9grit\u00e9 physique ou morale de l'apprenti", "value": 2.0}
 {"entity": "directe", "value": 2.0}
 {"entity": "dur\u00e9e cdd", "value": 28.88}
-{"entity": "\u00e0 combien ai-je droit d'heures pour recherche d'emploi?", "value": 2.0}
+{"entity": "\u00e0 combien ai-je droit d'heures pour recherche d'emploi?", "value": 2.5}
 {"entity": "discrimination", "value": 61.55}
 {"entity": "comment est calcul\u00e9 mon pr\u00e9avis de d\u00e9mission ?", "value": 2.0}
 {"entity": "p\u00e9nibilit\u00e9", "value": 54.9}

--- a/packages/code-du-travail-data/indexing/document.mapping.js
+++ b/packages/code-du-travail-data/indexing/document.mapping.js
@@ -153,6 +153,18 @@ export const documentMapping = {
       type: "keyword",
     },
 
+    // used for CC search
+    synonyms: {
+      fields: {
+        french: {
+          analyzer: "french_indexing",
+          search_analyzer: "french",
+          type: "text",
+        },
+      },
+      type: "text",
+    },
+
     // Currently only available for `Fiches service public`.
     tags: {
       analyzer: "french",

--- a/packages/code-du-travail-data/indexing/document.mapping.js
+++ b/packages/code-du-travail-data/indexing/document.mapping.js
@@ -154,7 +154,7 @@ export const documentMapping = {
     },
 
     // used for CC search
-    synonyms: {
+    synonymes: {
       fields: {
         french: {
           analyzer: "french_indexing",

--- a/packages/code-du-travail-frontend/src/conventions/Search/api/getQueryType.js
+++ b/packages/code-du-travail-frontend/src/conventions/Search/api/getQueryType.js
@@ -1,5 +1,6 @@
 // detect query type (IA level+++)
 const getQueryType = (str) => {
+  // search for "digit" queries : search by number
   if (str.match(/^[\d .-]+$/) && str.length >= 2) {
     const strClean = str.replace(/[\s .-]/g, "");
     if (strClean.length <= 4) {
@@ -11,7 +12,7 @@ const getQueryType = (str) => {
     }
     return;
   }
-  if (str.length > 2) {
+  if (str.length >= 2) {
     // search nom CC + APi entreprise
     return "text";
   }


### PR DESCRIPTION
3 changes :
- allow ccns queries with 2 chars to deal with acronyms ("tp" for "travaux publics") 
- add synonyms to Elastic mapping
- update idcc Elastic request


It also requires 2 other PRs to be merged :
- kali data where synonyms are actually defined 
https://github.com/SocialGouv/kali-data/pull/145
- CDTN admin where we forward synonyms from Kali data to CDTN data
https://github.com/SocialGouv/cdtn-admin/pull/210 