### PR TITLE
ci: replace version tag with preprod for host name

### DIFF
--- a/.gitlab-ci/env.sh
+++ b/.gitlab-ci/env.sh
@@ -35,7 +35,8 @@ fi
 if [[ -n "${COMMIT_TAG}" ]]; then
   # For versions we replace the version number v2.3.1 to v2-3-1
   export BRANCH_HASH="cdtn-preprod";
-  export IMAGE_TAG=$(printf "${COMMIT_TAG}" | sed "s/^v//")
+  # export IMAGE_TAG=$(printf "${COMMIT_TAG}" | sed "s/^v//")
+  export IMAGE_TAG="cdtn-preprod";
   export ES_INDEX_PREFIX="cdtn-preprod"
   export K8S_NAMESPACE="cdtn-preprod"
 fi

--- a/.gitlab-ci/variables.yml
+++ b/.gitlab-ci/variables.yml
@@ -1,18 +1,14 @@
 variables:
   PROJECT: cdtn
-  APM_SERVER_PORT: 8200
   DOCKER_COMPOSE_VERSION: "1.23.2"
   DOCKER_DRIVER: overlay2
   DOCKER_HOST: tcp://localhost:2375
   DOCKER_VERSION: 18
-  ELASTICSEARCH_INTER_NODE_PORT: 9300
   ELASTICSEARCH_PORT: 9200
   FRONTEND_PORT: 3000
   GIT_STRATEGY: fetch
   HASH_SIZE: 7
   IMAGE_INFRA_BASE_NAME: infra/images-docker
-  KIBANA_PORT: 5601
   NLP_URL: https://preprod-serving-ml.dev2.fabrique.social.gouv.fr
   CDTN_ADMIN_ENDPOINT: https://cdtn-admin.fabrique.social.gouv.fr/api/graphql
-  PYTHON_VERSION: 3.7.2-alpine
   RANCHER_PROJECT_ID: c-kk8xm:p-8q2jj


### PR DESCRIPTION
how can we also have `https://preprod-code-travail.dev2.fabrique.social.gouv.fr` too ?