### PR TITLE
feat(front): add relatedItems to tools

### DIFF
--- a/packages/code-du-travail-frontend/pages/outils/[slug].js
+++ b/packages/code-du-travail-frontend/pages/outils/[slug].js
@@ -53,7 +53,7 @@ function Outils({ description, icon, slug, relatedItems, title }) {
             <Tool icon={icon} title={title} />
           </Wrapper>
           <ToolSurvey />
-          <RelatedItems items={relatedItems} />
+          <RelatedItems disableSurvey items={relatedItems} />
         </Container>
       </StyledSection>
     </Layout>

--- a/packages/code-du-travail-frontend/src/common/RelatedItems.js
+++ b/packages/code-du-travail-frontend/src/common/RelatedItems.js
@@ -29,7 +29,7 @@ const matoSelectRelated = (reco, selection) => {
   ]);
 };
 
-export const RelatedItems = ({ items = [] }) => {
+export const RelatedItems = ({ disableSurvey = false, items = [] }) => {
   const isArticleSource = (source) =>
     ![SOURCES.EXTERNALS, SOURCES.LETTERS, SOURCES.TOOLS].includes(source);
 
@@ -47,53 +47,55 @@ export const RelatedItems = ({ items = [] }) => {
 
   return (
     <Container>
-      <SurveyModal>
-        {({
-          setModalVisible,
-          isPromptVisible,
-          isSurveyDisabled,
-          setPromptVisible,
-          setSurveyDisabled,
-        }) =>
-          !isSurveyDisabled &&
-          isPromptVisible && (
-            <PromptWrapper>
-              <Toast animate="from-right" wide shadow>
-                <CloseButton
-                  variant="naked"
-                  small
-                  narrow
-                  title="ne pas répondre aux questions"
-                  onClick={() => {
-                    setPromptVisible(false);
-                    setSurveyDisabled(true);
-                  }}
-                >
-                  <ScreenReaderOnly>fermer la modale</ScreenReaderOnly>
-                  <CloseIcon aria-hidden />
-                </CloseButton>
-                <PromptContainer>
-                  <Subtitle>Questionnaire</Subtitle>
-                  <PromptLabel>Aidez-nous à améliorer le site</PromptLabel>
-                  <Button
+      {!disableSurvey && (
+        <SurveyModal>
+          {({
+            setModalVisible,
+            isPromptVisible,
+            isSurveyDisabled,
+            setPromptVisible,
+            setSurveyDisabled,
+          }) =>
+            !isSurveyDisabled &&
+            isPromptVisible && (
+              <PromptWrapper>
+                <Toast animate="from-right" wide shadow>
+                  <CloseButton
+                    variant="naked"
                     small
+                    narrow
+                    title="ne pas répondre aux questions"
                     onClick={() => {
-                      matopush([
-                        "trackEvent",
-                        "survey",
-                        "open from related items",
-                      ]);
-                      setModalVisible(true);
+                      setPromptVisible(false);
+                      setSurveyDisabled(true);
                     }}
                   >
-                    Commencer
-                  </Button>
-                </PromptContainer>
-              </Toast>
-            </PromptWrapper>
-          )
-        }
-      </SurveyModal>
+                    <ScreenReaderOnly>fermer la modale</ScreenReaderOnly>
+                    <CloseIcon aria-hidden />
+                  </CloseButton>
+                  <PromptContainer>
+                    <Subtitle>Questionnaire</Subtitle>
+                    <PromptLabel>Aidez-nous à améliorer le site</PromptLabel>
+                    <Button
+                      small
+                      onClick={() => {
+                        matopush([
+                          "trackEvent",
+                          "survey",
+                          "open from related items",
+                        ]);
+                        setModalVisible(true);
+                      }}
+                    >
+                      Commencer
+                    </Button>
+                  </PromptContainer>
+                </Toast>
+              </PromptWrapper>
+            )
+          }
+        </SurveyModal>
+      )}
       {relatedGroups.map(
         ({ title, items }) =>
           items.length > 0 && (


### PR DESCRIPTION
closes https://github.com/SocialGouv/code-du-travail-numerique/issues/3133

Comme demandé Virginie, les contenus liés sont affichés dès le début et non pas seulement sur l'étape finale

<img width="1029" alt="Screenshot 2021-01-28 at 16 47 03" src="https://user-images.githubusercontent.com/705453/106164935-d319da00-618a-11eb-9994-eae353912857.png">
<img width="1032" alt="Screenshot 2021-01-28 at 16 48 58" src="https://user-images.githubusercontent.com/705453/106164939-d44b0700-618a-11eb-9ccd-d8b9b9101905.png">

