### PR TITLE
fix(front): naïve attempt to fix tables

### DIFF
--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers-[slug].test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers-[slug].test.js.snap
@@ -2411,10 +2411,18 @@ exports[`<ModelesDeCourrier /> should render 1`] = `
                         </div>
                       </a>
                     </div>
-                    <div>
-                      <p>
-                        youhou
-                      </p>
+                    <div
+                      class="c24"
+                    >
+                      <div
+                        class="c25"
+                      >
+                        <div>
+                          <p>
+                            youhou
+                          </p>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/packages/code-du-travail-frontend/pages/modeles-de-courriers/[slug].js
+++ b/packages/code-du-travail-frontend/pages/modeles-de-courriers/[slug].js
@@ -2,6 +2,7 @@ import {
   Badge,
   Button,
   icons,
+  OverflowWrapper,
   ScreenReaderOnly,
   Section,
   theme,
@@ -95,7 +96,9 @@ class ModeleCourrier extends React.Component {
                   </ScreenReaderOnly>
                 </Button>
               </FloatWrapper>
-              <Html>{html}</Html>
+              <OverflowWrapper>
+                <Html>{html}</Html>
+              </OverflowWrapper>
             </LightWrapper>
           </Section>
           <Notice>

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/Answer.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/Answer.test.js.snap
@@ -3606,6 +3606,7 @@ exports[`<Answer /> should renders related content 1`] = `
   position: -webkit-sticky;
   position: sticky;
   top: 16rem;
+  z-index: 1;
   width: calc(30% - 4rem);
   margin-left: 4rem;
 }

--- a/packages/code-du-travail-frontend/src/layout/AnswerLayout.js
+++ b/packages/code-du-travail-frontend/src/layout/AnswerLayout.js
@@ -25,6 +25,7 @@ export const MainContent = styled.div`
 export const AsideContent = styled(Section)`
   position: ${(props) => (props.sticky ? "sticky" : "static")};
   top: 16rem;
+  z-index: 1;
   width: calc(30% - ${spacings.larger});
   margin-left: ${spacings.larger};
   @media (min-width: ${breakpoints.tablet}) {


### PR DESCRIPTION
related to https://github.com/SocialGouv/code-du-travail-numerique/issues/3319

Hum, the only simple way to "fix" this is to put the overflow wrapper around the whole model. Not ideal but it works. We can’t insert the wrapper only around the table because the html is provided in a single block for the document.

@virginielastisneres what do you think of it ?