### PR TITLE
feat(simulator): add origin & seniority steps for business retirement simu

### DIFF
--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/stepReducer.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/stepReducer.tsx
@@ -1,12 +1,27 @@
-import { IntroductionStep } from "./steps/Introduction";
+import Steps from "./steps";
 
 export const initialState = {
   stepIndex: 0,
   steps: [
     {
-      component: IntroductionStep,
+      component: Steps.IntroductionStep,
       label: "Introduction",
       name: "intro",
+    },
+    {
+      component: Steps.OrigineStep,
+      label: "Origine du départ à la retraite",
+      name: "origine",
+    },
+    {
+      component: Steps.AncienneteStep,
+      label: "Ancienneté",
+      name: "anciennete",
+    },
+    {
+      component: Steps.ResultStep,
+      label: "Résultat",
+      name: "result",
     },
   ],
 };

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Anciennete.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Anciennete.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+import { TextQuestion } from "../../common/TextQuestion";
+import { isPositiveNumber } from "../../common/validators";
+
+function AncienneteStep() {
+  return (
+    <>
+      <TextQuestion
+        name="contrat salarié - ancienneté"
+        label="Quelle est votre ancienneté dans l’entreprise en mois&nbsp;?"
+        inputType="number"
+        validate={isPositiveNumber}
+        placeholder="0"
+      />
+    </>
+  );
+}
+
+export { AncienneteStep };

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Origine.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Origine.tsx
@@ -1,0 +1,49 @@
+import { InputRadio } from "@socialgouv/cdtn-ui";
+import React from "react";
+import { Field } from "react-final-form";
+
+import { ErrorField } from "../../common/ErrorField";
+import { Question } from "../../common/Question";
+import { RadioContainer } from "../../common/stepStyles";
+import { required } from "../../common/validators";
+
+function OrigineStep() {
+  return (
+    <>
+      <Question as="p" required>
+        Qui est à l’origine du départ en retraite&nbsp;?
+      </Question>
+      <RadioContainer>
+        <Field
+          type="radio"
+          name="contrat salarié - mise à la retraite"
+          value="oui"
+          validate={required}
+        >
+          {(props) => (
+            <InputRadio
+              label="L’employeur décide de lui-même de mettre à la retraite le salarié par une décision adressée à celui-ci."
+              {...props.input}
+            />
+          )}
+        </Field>
+        <Field
+          type="radio"
+          name="contrat salarié - mise à la retraite"
+          value="non"
+          validate={required}
+        >
+          {(props) => (
+            <InputRadio
+              label="Le salarié décide de quitter volontairement l’entreprise pour prendre sa retraite."
+              {...props.input}
+            />
+          )}
+        </Field>
+        <ErrorField name="contrat salarié - mise à la retraite" />
+      </RadioContainer>
+    </>
+  );
+}
+
+export { OrigineStep };

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Result.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Result.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+import { Highlight, SectionTitle } from "../../common/stepStyles";
+
+function ResultStep() {
+  return (
+    <>
+      <SectionTitle>Durée du préavis</SectionTitle>
+      <p>
+        À partir des éléments que vous avez saisis, la durée du préavis de
+        départ à la retraite est estimée à&nbsp;<Highlight>X</Highlight> mois.
+      </p>
+    </>
+  );
+}
+
+export { ResultStep };

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/index.ts
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/index.ts
@@ -1,0 +1,6 @@
+import { AncienneteStep } from "./Anciennete";
+import { IntroductionStep } from "./Introduction";
+import { OrigineStep } from "./Origine";
+import { ResultStep } from "./Result";
+
+export default { AncienneteStep, IntroductionStep, OrigineStep, ResultStep };

--- a/packages/code-du-travail-frontend/src/outils/common/validators.js
+++ b/packages/code-du-travail-frontend/src/outils/common/validators.js
@@ -16,6 +16,12 @@ export function isNumber(value) {
     : "Un nombre est attendu";
 }
 
+export function isPositiveNumber(value) {
+  return !isNaN(parseFloat(value)) && isFinite(value) && value >= 0
+    ? undefined
+    : "Un nombre positif est attendu";
+}
+
 export function isDate(value) {
   return isNaN(parse(value).getTime()) ? "La date est invalide" : undefined;
 }


### PR DESCRIPTION
First implementation of the steps: origine, ancienneté and résultat.

It's a first run. The idea is to implement the publicodes then come back on screens to improve them (with the feedbacks of the team).

 * Origine: I follow the github issue but I think the text can be better. The idea: submit to the team to get feedbacks.
 * Ancienneté: The idea is to ask the ancienneté in month or with 2 dates. In this first version, I'll ask only for the ancienneté in month. 
 * Résultat: Keep it simple first. Some information will be show to user depending of the computation but it will be provide by the publicodes.

<img width="1254" alt="CleanShot 2021-04-08 at 14 53 58@2x" src="https://user-images.githubusercontent.com/992514/114030060-74539980-987a-11eb-893d-03fe3eaad44e.png">

<img width="1250" alt="CleanShot 2021-04-08 at 14 54 13@2x" src="https://user-images.githubusercontent.com/992514/114030072-774e8a00-987a-11eb-8b3f-d23dd2f52835.png">

<img width="1222" alt="CleanShot 2021-04-08 at 14 54 37@2x" src="https://user-images.githubusercontent.com/992514/114030083-7a497a80-987a-11eb-8ce2-7c3b271bef55.png">

So next step: Implement the publicodes context 🙃 
