### PR TITLE
ci(k8s): remove cdtn prefix on preprod env when deployed

### DIFF
--- a/.gitlab-ci/env.sh
+++ b/.gitlab-ci/env.sh
@@ -35,10 +35,10 @@ fi
 
 if [[ -n "${COMMIT_TAG}" ]]; then
   # For versions we replace the version number v2.3.1 to v2-3-1
-  export BRANCH_HASH="cdtn-preprod";
+  export BRANCH_HASH="preprod";
   export IMAGE_TAG=$(printf "${COMMIT_TAG}" | sed "s/^v//")
-  export ES_INDEX_PREFIX="cdtn-preprod"
-  export K8S_NAMESPACE="cdtn-preprod"
+  export ES_INDEX_PREFIX="cdtn-${BRANCH_HASH}"
+  export K8S_NAMESPACE="cdtn-${BRANCH_HASH}"
   export AZURE_CONTAINER="cdtn"
 fi
 


### PR DESCRIPTION
so 
```diff
- https://cdtn-preprod-code-travail.dev2.fabrique.social.gouv.fr/  
+ https://preprod-code-travail.dev2.fabrique.social.gouv.fr/ 
```