### PR TITLE
fix(k8s): use code.travail.gouv.fr as default

### DIFF
--- a/.gitlab-ci/env.sh
+++ b/.gitlab-ci/env.sh
@@ -65,6 +65,7 @@ export FRONTEND_HOST="${DOMAIN}";
 
 if [[ -n "${PRODUCTION+x}" ]]; then
   export API_HOST="api.${DOMAIN}";
+  export FRONTEND_HOST="code.travail.gouv.fr";
 fi
 
 export API_URL="https://${API_HOST}"

--- a/.k8s/ingress-prod.yml
+++ b/.k8s/ingress-prod.yml
@@ -4,31 +4,6 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
-    kubernetes.io/tls-acme: "true"
-  labels:
-    app.kubernetes.io/instance: frontend
-  name: frontend-nodejs-code
-  namespace: cdtn
-spec:
-  rules:
-    - host: code.travail.gouv.fr
-      http:
-        paths:
-          - backend:
-              serviceName: frontend-nodejs
-              servicePort: http
-            path: /
-  tls:
-    - hosts:
-        - code.travail.gouv.fr
-      secretName: frontend-crt-code
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/permanent-redirect: https://code.travail.gouv.fr$request_uri
     certmanager.k8s.io/cluster-issuer: letsencrypt-prod
     kubernetes.io/tls-acme: "true"
@@ -40,8 +15,10 @@ metadata:
 spec:
   rules:
   - host: www.code.travail.gouv.fr
+  - host: code.travail.fabrique.social.gouv.fr
   tls:
   - hosts:
     - www.code.travail.gouv.fr
+    - code.travail.fabrique.social.gouv.fr
     secretName: redirect-crt
 

--- a/packages/code-du-travail-frontend/package.json
+++ b/packages/code-du-travail-frontend/package.json
@@ -28,6 +28,7 @@
     "@next/bundle-analyzer": "^10.0.9",
     "@sentry/browser": "^6.2.2",
     "@sentry/node": "^6.2.2",
+    "@socialgouv/cdtn-logger": "^1.1.2",
     "@socialgouv/cdtn-slugify": "^4.45.0",
     "@socialgouv/cdtn-sources": "^4.45.0",
     "@socialgouv/cdtn-ui": "^4.46.0",

--- a/packages/code-du-travail-frontend/server/__tests__/__snapshots__/routes.test.js.snap
+++ b/packages/code-du-travail-frontend/server/__tests__/__snapshots__/routes.test.js.snap
@@ -5,7 +5,13 @@ exports[`/IS_PRODUCTION_DEPLOYMENT=false should return dev robots.txt 1`] = `
 Disallow: /"
 `;
 
-exports[`/IS_PRODUCTION_DEPLOYMENT=true should return production robots.txt 1`] = `"Redirecting to <a href=\\"https://prod-test-hostname/robots.txt\\">https://prod-test-hostname/robots.txt</a>."`;
+exports[`/IS_PRODUCTION_DEPLOYMENT=true should return production robots.txt 1`] = `
+"User-agent: *
+Disallow: /assets/
+Disallow: /images/
+
+Sitemap: https://prod-test-hostname/sitemap.xml"
+`;
 
 exports[`/NODE_ENV=* should set dev CSP 1`] = `"default-src 'self' *.travail.gouv.fr *.data.gouv.fr *.fabrique.social.gouv.fr http://127.0.0.1:*/;font-src 'self' data: blob:;frame-src 'self' https://mon-entreprise.fr https://matomo.fabrique.social.gouv.fr *.dailymotion.com;img-src 'self' data: *.fabrique.social.gouv.fr https://travail-emploi.gouv.fr https://mon-entreprise.fr https://ad.doubleclick.net https://cdtnadmindev.blob.core.windows.net;script-src 'self' 'unsafe-inline' https://mon-entreprise.fr https://www.googletagmanager.com *.fabrique.social.gouv.fr https://cdnjs.cloudflare.com 'unsafe-eval';style-src 'self' 'unsafe-inline';report-uri /report-violation"`;
 

--- a/packages/code-du-travail-frontend/server/__tests__/routes.test.js
+++ b/packages/code-du-travail-frontend/server/__tests__/routes.test.js
@@ -44,14 +44,7 @@ describe("/IS_PRODUCTION_DEPLOYMENT=true", () => {
     const response = await request(app.callback()).get("/robots.txt");
     expect(response.headers["x-robots-tag"]).toBe(undefined);
   });
-  it("should redirect to production url", async () => {
-    const response = await request(app.callback()).get("/some-url");
-    expect(response.status).toBe(301);
-    expect(response.headers.location).toEqual(
-      `https://prod-test-hostname/some-url`
-    );
-    process.env.NODE_ENV = "test";
-  });
+
   it("should return health probe", async () => {
     const response = await request(app.callback()).get("/health");
     expect(response.status).toBe(200);


### PR DESCRIPTION
this makes code.travail.gouv.fr the default ingress rule.

The ingress-prod.yml ensure a 301 redirect to code.travail.gouv.fr when another host is used