### PR TITLE
fix(frontend): replace getStaticPath with getServerSideProps

### DIFF
--- a/packages/code-du-travail-frontend/pages/outils/index.js
+++ b/packages/code-du-travail-frontend/pages/outils/index.js
@@ -69,7 +69,7 @@ const Outils = ({ cdtnSimulators, externalTools }) => (
   </Layout>
 );
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: getTools(),
   };


### PR DESCRIPTION
replace getStaticPath with getServerSideProps since we can't rely on build for prod and dev