### PR TITLE
feature(simulator): add types thank typescrypt and eslint

### DIFF
--- a/packages/code-du-travail-frontend/.eslintrc.yml
+++ b/packages/code-du-travail-frontend/.eslintrc.yml
@@ -6,27 +6,21 @@ rules:
   jsx-a11y/anchor-is-valid: off
   jsx-a11y/label-has-for: off
   react/prop-types: off
-  import/no-unresolved: [
-    2,
-    ignore: [
-      wrapped-testing-library/react
-    ]
-  ]
-  no-console: [
-    "error",
-    allow: [
-      "warn",
-      "error"
-    ]
-  ]
+  import/no-unresolved: [2, ignore: [wrapped-testing-library/react]]
+  no-console: ["error", allow: ["warn", "error"]]
 
 settings:
   import/resolver:
-    node: {
-      "extensions": [".js", ".jsx", ".ts", ".tsx"]
-    }
+    node: { "extensions": [".js", ".jsx", ".ts", ".tsx"] }
 
 overrides:
   - files: ["*.test.js"]
     env:
       jest: true
+  - files: ["**/*.ts", "**/*.tsx"]
+    extends:
+      - "plugin:@typescript-eslint/recommended"
+    rules:
+      no-undef: "off"
+      "@typescript-eslint/ban-ts-comment": "warn"
+

--- a/packages/code-du-travail-frontend/pages/api/simulateurs/index.ts
+++ b/packages/code-du-travail-frontend/pages/api/simulateurs/index.ts
@@ -2,11 +2,16 @@ import externalTools from "@cdt/data...tools/externals.json";
 import tools from "@cdt/data...tools/internals.json";
 import { NextApiRequest, NextApiResponse } from "next";
 
-export default (req: NextApiRequest, res: NextApiResponse) => {
+interface Tools {
+  cdtnSimulators: any;
+  externalTools: any;
+}
+
+export default (req: NextApiRequest, res: NextApiResponse): void => {
   res.json(getTools());
 };
 
-export function getTools() {
+export function getTools(): Tools {
   return {
     cdtnSimulators: tools.filter(
       (tool) => tool.enable || process.env.IS_PRODUCTION_DEPLOYMENT !== "true"

--- a/packages/code-du-travail-frontend/pages/outils/[slug].tsx
+++ b/packages/code-du-travail-frontend/pages/outils/[slug].tsx
@@ -1,6 +1,8 @@
 import tools from "@cdt/data...tools/internals.json";
 import * as Sentry from "@sentry/browser";
+import { SOURCES } from "@socialgouv/cdtn-sources";
 import { Container, Section, theme, Wrapper } from "@socialgouv/cdtn-ui";
+import { GetServerSideProps } from "next";
 import getConfig from "next/config";
 import React, { useEffect } from "react";
 import styled from "styled-components";
@@ -20,8 +22,6 @@ import { SimulateurIndemnitePrecarite } from "../../src/outils/IndemnitePrecarit
 import { SimulateurEmbauche } from "../../src/outils/SimulateurEmbauche";
 import { matopush } from "../../src/piwik";
 
-const { SOURCES } = require("@socialgouv/cdtn-sources");
-
 const {
   publicRuntimeConfig: { API_URL },
 } = getConfig();
@@ -36,14 +36,23 @@ const toolsBySlug = {
   "simulateur-embauche": SimulateurEmbauche,
 };
 
+interface Props {
+  description: string;
+  icon: string;
+  publicodesRules: any;
+  relatedItems: Array<any>;
+  slug: string;
+  title: string;
+}
+
 function Outils({
   description,
   icon,
   slug,
   relatedItems,
   title,
-  publicodeRules,
-}) {
+  publicodesRules,
+}: Props): JSX.Element {
   const Tool = toolsBySlug[slug];
   useEffect(() => {
     matopush(["trackEvent", "outil", `view_step_${title}`, "start"]);
@@ -58,7 +67,11 @@ function Outils({
         <Container>
           <Flex>
             <Wrapper variant="main">
-              <Tool icon={icon} title={title} publicodeRules={publicodeRules} />
+              <Tool
+                icon={icon}
+                title={title}
+                publicodesRules={publicodesRules}
+              />
             </Wrapper>
             <ShareContainer>
               <Share title={title} metaDescription={description} />
@@ -74,8 +87,10 @@ function Outils({
 
 export default Outils;
 
-export async function getServerSideProps({ query }) {
-  const { slug } = query;
+export const getServerSideProps: GetServerSideProps<Props> = async ({
+  query,
+}) => {
+  const slug = query.slug as string;
   const { description, icon, title } = tools.find((tool) => tool.slug === slug);
   let relatedItems = [];
   try {
@@ -88,19 +103,19 @@ export async function getServerSideProps({ query }) {
     Sentry.captureException(e);
   }
 
-  const publicodeRules = loadPublicodes(slug);
+  const publicodesRules = loadPublicodes(slug);
 
   return {
     props: {
       description,
       icon,
-      publicodeRules,
+      publicodesRules,
       relatedItems,
       slug,
       title,
     },
   };
-}
+};
 
 const { breakpoints, spacings } = theme;
 

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/index.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/index.tsx
@@ -1,12 +1,22 @@
 import React from "react";
 
 import { Wizard } from "../common/Wizard";
-import { PublicodesProvider } from "../publicodes/index";
+import { PublicodesProvider } from "../publicodes";
 import { initialState, stepReducer } from "./stepReducer";
 
-const SimulateurPreavisRetraite = ({ icon, title, publicodeRules }) => (
+interface Props {
+  icon: string;
+  title: string;
+  publicodesRules: any;
+}
+
+const SimulateurPreavisRetraite = ({
+  icon,
+  title,
+  publicodesRules,
+}: Props): JSX.Element => (
   <PublicodesProvider
-    rules={publicodeRules}
+    rules={publicodesRules}
     targetRule="contrat salarié . préavis de retraite"
   >
     <Wizard

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/stepReducer.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/stepReducer.tsx
@@ -1,6 +1,7 @@
+import { Action, ActionName, State } from "../common/type/WizardType";
 import Steps from "./steps";
 
-export const initialState = {
+export const initialState: State = {
   stepIndex: 0,
   steps: [
     {
@@ -26,16 +27,16 @@ export const initialState = {
   ],
 };
 
-export function stepReducer(state, { type, payload }) {
-  switch (type) {
-    case "reset": {
+export function stepReducer(state: State, action: Action): State {
+  switch (action.type) {
+    case ActionName.reset: {
       return { ...initialState };
     }
-    case "setStepIndex": {
-      return { stepIndex: payload, steps: state.steps };
+    case ActionName.setStepIndex: {
+      return { stepIndex: action.payload, steps: state.steps };
     }
     default:
-      console.warn("action unknow", type);
+      console.warn("action unknown", action);
       return state;
   }
 }

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Anciennete.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Anciennete.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { TextQuestion } from "../../common/TextQuestion";
 import { isPositiveNumber } from "../../common/validators";
 
-function AncienneteStep() {
+function AncienneteStep(): JSX.Element {
   return (
     <>
       <TextQuestion

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Introduction.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Introduction.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const IntroductionStep = () => (
+const IntroductionStep = (): JSX.Element => (
   <>
     <p>
       Ce simulateur est un outil qui permet de calculer la durée de préavis à

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Origine.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Origine.tsx
@@ -7,7 +7,7 @@ import { Question } from "../../common/Question";
 import { RadioContainer } from "../../common/stepStyles";
 import { required } from "../../common/validators";
 
-function OrigineStep() {
+function OrigineStep(): JSX.Element {
   return (
     <>
       <Question as="p" required>

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Result.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Result.tsx
@@ -1,14 +1,17 @@
 import React, { useEffect } from "react";
 
 import { Highlight, SectionTitle } from "../../common/stepStyles";
+import { WizardStepProps } from "../../common/type/WizardType";
 import { usePublicodes } from "../../publicodes";
 
-function ResultStep({ form }) {
-  const publicodeContext = usePublicodes();
+function ResultStep({
+  form,
+}: WizardStepProps<Record<string, string>>): JSX.Element {
+  const publicodesContext = usePublicodes();
 
   useEffect(() => {
-    publicodeContext.setSituation(form.getState().values);
-  }, [form]);
+    publicodesContext.setSituation(form.getState().values);
+  }, [form, publicodesContext]);
 
   return (
     <>
@@ -16,7 +19,7 @@ function ResultStep({ form }) {
       <p>
         À partir des éléments que vous avez saisis, la durée du préavis de
         départ à la retraite est estimée à&nbsp;
-        <Highlight>{publicodeContext.result}</Highlight> mois.
+        <Highlight>{publicodesContext.result}</Highlight> mois.
       </p>
     </>
   );

--- a/packages/code-du-travail-frontend/src/outils/api/LoadPublicodes.ts
+++ b/packages/code-du-travail-frontend/src/outils/api/LoadPublicodes.ts
@@ -1,6 +1,6 @@
 import modeles from "@socialgouv/modeles-social";
 
-export const loadPublicodes = (simulator: string) => {
+export const loadPublicodes = (simulator: string): any => {
   switch (simulator) {
     case "preavis-retraite":
       return modeles;

--- a/packages/code-du-travail-frontend/src/outils/common/type/WizardType.ts
+++ b/packages/code-du-travail-frontend/src/outils/common/type/WizardType.ts
@@ -1,0 +1,26 @@
+import { FormApi } from "final-form";
+
+export interface Step {
+  component: (props: WizardStepProps<Record<string, string>>) => JSX.Element;
+  label: string;
+  name: string;
+}
+
+export interface State {
+  steps: Array<Step>;
+  stepIndex: number;
+}
+
+export enum ActionName {
+  reset = "reset",
+  setStepIndex = "setStepIndex",
+}
+
+export type Action =
+  | { type: ActionName.reset }
+  | { type: ActionName.setStepIndex; payload: number };
+
+export interface WizardStepProps<Data> {
+  form: FormApi<Data>;
+  dispatch: (state: State, action: Action) => State;
+}

--- a/packages/code-du-travail-frontend/src/outils/publicodes/index.tsx
+++ b/packages/code-du-travail-frontend/src/outils/publicodes/index.tsx
@@ -1,6 +1,6 @@
+import Engine, { Evaluation, Rule } from "publicodes";
 import React, { createContext, useContext } from "react";
-import Engine, { Evaluation } from "publicodes";
-import { Rule } from "publicodes/dist/types/rule";
+
 import usePublicodesHandler from "./Handler";
 
 interface MissingArgs {
@@ -16,9 +16,11 @@ export interface PublicodesContextInterface {
 }
 
 const publicodesContext = createContext<PublicodesContextInterface>({
-  result: null,
   missingArgs: [],
-  setSituation: () => {},
+  result: null,
+  setSituation: () => {
+    throw Error("Not implemented");
+  },
 });
 
 export function usePublicodes(): PublicodesContextInterface {
@@ -29,7 +31,7 @@ const { Provider } = publicodesContext;
 
 export const PublicodesProvider: React.FC<
   { children: React.ReactNode } & {
-    rules: string;
+    rules: any;
     targetRule: string;
   }
 > = ({ children, rules, targetRule }) => {
@@ -39,7 +41,7 @@ export const PublicodesProvider: React.FC<
   });
 
   return (
-    <Provider value={{ result, missingArgs, setSituation }}>
+    <Provider value={{ missingArgs, result, setSituation }}>
       {children}
     </Provider>
   );


### PR DESCRIPTION
Use ESLint with typescript to improve the type checking in our codebase 🚀 

There are few limitations:
 
 * the type provided by the publicodes rules is set to any. It can be improved by generating the typescript definition of all rules. Programmed in a future PR.
 * Data provided by the package `code-du-travail-data/tools` are not typed. There are set to any at this moment. It can be improved by moving the package to typescript (not essential at this moment).
 * relatedItems provided by a call to external APIs are set to any. It can be improved by writing TS files for APIs but the best solution should be to define types from the source and export it (not essential at this moment).