### PR TITLE
Feature/publicode types

### DIFF
--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/stepReducer.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/stepReducer.tsx
@@ -1,6 +1,8 @@
 import { Action, ActionName, State } from "../common/type/WizardType";
 import Steps from "./steps";
 
+const supportedCcn = [292];
+
 export const initialState: State = {
   stepIndex: 0,
   steps: [
@@ -23,6 +25,7 @@ export const initialState: State = {
       component: Steps.Informations,
       label: "Informations",
       name: "infos",
+      skip: (values) => !values.ccn || !supportedCcn.includes(values.ccn.num),
     },
     {
       component: Steps.AncienneteStep,

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Informations.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Informations.tsx
@@ -1,54 +1,16 @@
-import React, { useEffect } from "react";
+import React from "react";
 
-import PubliQuestion from "../../common/PubliQuestion";
+import { StepDynamicPublicodes } from "../../common/StepDynamicPublicodes";
 import { WizardStepProps } from "../../common/type/WizardType";
-import { usePublicodes } from "../../publicodes";
-import { transformInfoCcn } from "../../publicodes/TransformInfoCcn";
 
-function Informations({ form }: WizardStepProps): JSX.Element {
-  const publicodesContext = usePublicodes();
+const excludedRules = [
+  "contrat salarié - ancienneté",
+  "contrat salarié - convention collective",
+  "contrat salarié - mise à la retraite",
+];
 
-  // List of excluded rules to show in this step.
-  // Pulicodes can return them as missing args, but there are populated by another steps.
-  const excludedRules = [
-    "contrat salarié - ancienneté",
-    "contrat salarié - convention collective",
-    "contrat salarié - mise à la retraite",
-  ];
-  useEffect(() => {
-    publicodesContext.setSituation(transformInfoCcn(form.getState().values));
-  }, [form]);
-
-  return (
-    <>
-      <>
-        {publicodesContext.situation
-          .filter((item) => !excludedRules.includes(item.name))
-          .map((item) => {
-            return (
-              <PubliQuestion
-                key={item.name}
-                name={"infos." + item.name}
-                rule={item.rawNode}
-              />
-            );
-          })}
-      </>
-      <>
-        {publicodesContext.missingArgs
-          .filter((item) => !excludedRules.includes(item.name))
-          .map((item) => {
-            return (
-              <PubliQuestion
-                key={item.name}
-                name={"infos." + item.name}
-                rule={item.rawNode}
-              />
-            );
-          })}
-      </>
-    </>
-  );
-}
+const Informations = (props: WizardStepProps): JSX.Element => (
+  <StepDynamicPublicodes {...props} excludedRules={excludedRules} />
+);
 
 export { Informations };

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Informations.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Informations.tsx
@@ -28,7 +28,7 @@ function Informations({ form }: WizardStepProps): JSX.Element {
             return (
               <PubliQuestion
                 key={item.name}
-                name={item.name}
+                name={"infos." + item.name}
                 rule={item.rawNode}
               />
             );
@@ -41,7 +41,7 @@ function Informations({ form }: WizardStepProps): JSX.Element {
             return (
               <PubliQuestion
                 key={item.name}
-                name={item.name}
+                name={"infos." + item.name}
                 rule={item.rawNode}
               />
             );

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Informations.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Informations.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 
-import { TextQuestion } from "../../common/TextQuestion";
+import PubliQuestion from "../../common/PubliQuestion";
 import { WizardStepProps } from "../../common/type/WizardType";
 import { usePublicodes } from "../../publicodes";
 import { transformInfoCcn } from "../../publicodes/TransformInfoCcn";
@@ -26,12 +26,10 @@ function Informations({ form }: WizardStepProps): JSX.Element {
           .filter((item) => !excludedRules.includes(item.name))
           .map((item) => {
             return (
-              <TextQuestion
+              <PubliQuestion
                 key={item.name}
                 name={item.name}
-                label={item.rawNode.question}
-                validate={undefined}
-                placeholder="0"
+                rule={item.rawNode}
               />
             );
           })}
@@ -41,11 +39,10 @@ function Informations({ form }: WizardStepProps): JSX.Element {
           .filter((item) => !excludedRules.includes(item.name))
           .map((item) => {
             return (
-              <TextQuestion
+              <PubliQuestion
                 key={item.name}
                 name={item.name}
-                label={item.rawNode.question}
-                validate={() => true}
+                rule={item.rawNode}
               />
             );
           })}

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Result.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Result.tsx
@@ -3,13 +3,15 @@ import React, { useEffect } from "react";
 import { Highlight, SectionTitle } from "../../common/stepStyles";
 import { WizardStepProps } from "../../common/type/WizardType";
 import { usePublicodes } from "../../publicodes";
-import { transformInfoCcn } from "../../publicodes/TransformInfoCcn";
+import { mapToPublicodesSituation } from "../../publicodes/Utils";
 
 function ResultStep({ form }: WizardStepProps): JSX.Element {
   const publicodesContext = usePublicodes();
 
   useEffect(() => {
-    publicodesContext.setSituation(transformInfoCcn(form.getState().values));
+    publicodesContext.setSituation(
+      mapToPublicodesSituation(form.getState().values)
+    );
   }, [form]);
 
   return (

--- a/packages/code-du-travail-frontend/src/outils/common/InfosCCn.js
+++ b/packages/code-du-travail-frontend/src/outils/common/InfosCCn.js
@@ -24,6 +24,8 @@ function StepInfoCCn({ form, isOptionnal = true }) {
   );
   useEffect(() => {
     form.batch(() => {
+      // Simulateur Duree Preavis Retraite:  Delete infos when change CC
+      form.change("infos", undefined);
       form.change("criteria", undefined);
       form.change("typeRupture", undefined);
       form.change(CONVENTION_NAME, storedConvention);

--- a/packages/code-du-travail-frontend/src/outils/common/PubliQuestion.tsx
+++ b/packages/code-du-travail-frontend/src/outils/common/PubliQuestion.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+
+import { Rule, RuleType } from "../publicodes";
+import { SelectQuestion } from "./SelectQuestion";
+import { TextQuestion } from "./TextQuestion";
+
+interface Props {
+  name: string;
+  rule: Rule;
+  onChange?: () => void;
+}
+
+const PubliQuestion: React.FC<Props> = ({ name, rule, onChange }) => {
+  switch (rule?.cdtn?.type) {
+    case RuleType.Liste:
+      return (
+        <SelectQuestion
+          name={name}
+          label={rule.question}
+          subLabel={rule.description}
+          options={reverseValues(rule.cdtn.valeurs)}
+          onChange={onChange}
+        />
+      );
+    default:
+      return (
+        <TextQuestion name={name} label={rule.question} validate={undefined} />
+      );
+  }
+};
+
+const reverseValues = (
+  values: Record<string, string>
+): Record<string, string> => {
+  const output = {};
+  Object.entries(values).map(([key, value]) => {
+    output[value] = key;
+  });
+  return output;
+};
+
+export default PubliQuestion;

--- a/packages/code-du-travail-frontend/src/outils/common/PubliQuestion.tsx
+++ b/packages/code-du-travail-frontend/src/outils/common/PubliQuestion.tsx
@@ -31,12 +31,10 @@ const PubliQuestion: React.FC<Props> = ({ name, rule, onChange }) => {
 
 const reverseValues = (
   values: Record<string, string>
-): Record<string, string> => {
-  const output = {};
-  Object.entries(values).map(([key, value]) => {
-    output[value] = key;
-  });
-  return output;
-};
+): Record<string, string> =>
+  Object.entries(values).reduce((state, [key, value]) => {
+    state[value] = key;
+    return state;
+  }, {});
 
 export default PubliQuestion;

--- a/packages/code-du-travail-frontend/src/outils/common/StepDynamicPublicodes.tsx
+++ b/packages/code-du-travail-frontend/src/outils/common/StepDynamicPublicodes.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect } from "react";
+
+import { usePublicodes } from "../publicodes";
+import { mapToPublicodesSituation } from "../publicodes/Utils";
+import PubliQuestion from "./PubliQuestion";
+import { WizardStepProps } from "./type/WizardType";
+
+interface Props extends WizardStepProps {
+  excludedRules: Array<string>;
+}
+
+/**
+ * React component to show step by step missing arguments from publicodes.
+ * This step allows the user to come back to an answered question.
+ * It will reset the depending questions.
+ *
+ * Note: The collected answers will be stored in the `infos` object in the form. You can use the method `mapToPublicodesSituation` to map to a publicodes situation object from yours steps.
+ *
+ * @param excludedRules list of rules to exclude from this step. For instance: there are populated by another steps (like CC)
+ * @param form the form from react final form provided by the wizard.
+ * @constructor
+ */
+function StepDynamicPublicodes({ excludedRules, form }: Props): JSX.Element {
+  const publicodesContext = usePublicodes();
+
+  useEffect(() => {
+    publicodesContext.setSituation(
+      mapToPublicodesSituation(form.getState().values)
+    );
+  }, [form]);
+
+  /**
+   * Function called when a older question has been asked.
+   * We need to reset the form for next questions to remove them from the UI.
+   * It's a generic function because the form is based on publicodes
+   */
+  const resetNextQuestions = (name: string) => {
+    const infos = form.getState().values.infos;
+    if (infos) {
+      const infosKeys = Object.keys(infos);
+      const indexOfKeyChanged = infosKeys.findIndex((key) => key === name);
+      if (indexOfKeyChanged !== -1) {
+        infosKeys
+          .slice(indexOfKeyChanged + 1, infosKeys.length)
+          .forEach((keyToDelete) => {
+            form.batch(() => {
+              form.change(`infos.${keyToDelete}`, undefined);
+            });
+          });
+      }
+    }
+  };
+
+  return (
+    <>
+      <>
+        {publicodesContext.situation
+          .filter((item) => !excludedRules.includes(item.name))
+          .map((item) => {
+            return (
+              <PubliQuestion
+                key={item.name}
+                name={"infos." + item.name}
+                rule={item.rawNode}
+                onChange={() => resetNextQuestions(item.name)}
+              />
+            );
+          })}
+      </>
+      <>
+        {publicodesContext.missingArgs
+          .filter((item) => !excludedRules.includes(item.name))
+          .map((item) => {
+            return (
+              <PubliQuestion
+                key={item.name}
+                name={"infos." + item.name}
+                rule={item.rawNode}
+              />
+            );
+          })}
+      </>
+    </>
+  );
+}
+
+export { StepDynamicPublicodes };

--- a/packages/code-du-travail-frontend/src/outils/common/StepDynamicPublicodes.tsx
+++ b/packages/code-du-travail-frontend/src/outils/common/StepDynamicPublicodes.tsx
@@ -14,7 +14,8 @@ interface Props extends WizardStepProps {
  * This step allows the user to come back to an answered question.
  * It will reset the depending questions.
  *
- * Note: The collected answers will be stored in the `infos` object in the form. You can use the method `mapToPublicodesSituation` to map to a publicodes situation object from yours steps.
+ * Note: The collected answers will be stored in the `infos` object in the form.
+ * You can use the method `mapToPublicodesSituation` to map to a publicodes situation object from yours steps.
  *
  * @param excludedRules list of rules to exclude from this step. For instance: there are populated by another steps (like CC)
  * @param form the form from react final form provided by the wizard.
@@ -36,19 +37,21 @@ function StepDynamicPublicodes({ excludedRules, form }: Props): JSX.Element {
    */
   const resetNextQuestions = (name: string) => {
     const infos = form.getState().values.infos;
-    if (infos) {
-      const infosKeys = Object.keys(infos);
-      const indexOfKeyChanged = infosKeys.findIndex((key) => key === name);
-      if (indexOfKeyChanged !== -1) {
-        infosKeys
-          .slice(indexOfKeyChanged + 1, infosKeys.length)
-          .forEach((keyToDelete) => {
-            form.batch(() => {
-              form.change(`infos.${keyToDelete}`, undefined);
-            });
-          });
-      }
+    if (!infos) {
+      return;
     }
+    const infosKeys = Object.keys(infos);
+    const indexOfKeyChanged = infosKeys.findIndex((key) => key === name);
+    if (indexOfKeyChanged === -1) {
+      return;
+    }
+    form.batch(() => {
+      infosKeys
+        .slice(indexOfKeyChanged + 1, infosKeys.length)
+        .forEach((keyToDelete) => {
+          form.change(`infos.${keyToDelete}`, undefined);
+        });
+    });
   };
 
   return (

--- a/packages/code-du-travail-frontend/src/outils/common/type/WizardType.ts
+++ b/packages/code-du-travail-frontend/src/outils/common/type/WizardType.ts
@@ -35,4 +35,5 @@ interface ConventionCollective {
 
 export type FormContent = Record<string, string> & {
   ccn?: ConventionCollective;
+  infos?: Record<string, string>;
 };

--- a/packages/code-du-travail-frontend/src/outils/common/type/WizardType.ts
+++ b/packages/code-du-travail-frontend/src/outils/common/type/WizardType.ts
@@ -4,6 +4,7 @@ export interface Step {
   component: (props: WizardStepProps) => JSX.Element;
   label: string;
   name: string;
+  skip?: (values: FormContent) => boolean;
 }
 
 export interface State {

--- a/packages/code-du-travail-frontend/src/outils/publicodes/Handler.tsx
+++ b/packages/code-du-travail-frontend/src/outils/publicodes/Handler.tsx
@@ -1,7 +1,7 @@
 import Engine from "publicodes";
 import { useMemo, useState } from "react";
 
-import { SituationElement, PublicodesContextInterface } from "./index";
+import { PublicodesContextInterface, SituationElement } from "./index";
 
 interface State {
   engine: Partial<Engine>;
@@ -12,7 +12,9 @@ const usePublicodesHandler = ({
   engine,
   targetRule,
 }: State): PublicodesContextInterface => {
-  const [situation, setSituation] = useState<Map<string, SituationElement>>(new Map());
+  const [situation, setSituation] = useState<Map<string, SituationElement>>(
+    new Map()
+  );
 
   function newSituation(args: Record<string, string>): void {
     const situation: Map<string, SituationElement> = new Map();

--- a/packages/code-du-travail-frontend/src/outils/publicodes/TransformInfoCcn.ts
+++ b/packages/code-du-travail-frontend/src/outils/publicodes/TransformInfoCcn.ts
@@ -1,10 +1,11 @@
 import { FormContent } from "../common/type/WizardType";
 
 export const transformInfoCcn = (form: FormContent): Record<string, string> => {
-  const { ccn, ...formWithoutCcn } = form;
+  const { ccn, infos, ...formWithoutCcn } = form;
   const ccnId = ccn ? `'IDCC${ccn.num.toString().padStart(4, "0")}'` : "''";
   return {
     "contrat salarié - convention collective": ccnId,
+    ...infos,
     ...formWithoutCcn,
   };
 };

--- a/packages/code-du-travail-frontend/src/outils/publicodes/Utils.ts
+++ b/packages/code-du-travail-frontend/src/outils/publicodes/Utils.ts
@@ -1,6 +1,11 @@
 import { FormContent } from "../common/type/WizardType";
 
-export const transformInfoCcn = (form: FormContent): Record<string, string> => {
+/**
+ * Take the form values from react-final-form and transform to a flat object for publicodes.
+ */
+export const mapToPublicodesSituation = (
+  form: FormContent
+): Record<string, string> => {
   const { ccn, infos, ...formWithoutCcn } = form;
   const ccnId = ccn ? `'IDCC${ccn.num.toString().padStart(4, "0")}'` : "''";
   return {

--- a/packages/code-du-travail-frontend/src/outils/publicodes/index.tsx
+++ b/packages/code-du-travail-frontend/src/outils/publicodes/index.tsx
@@ -1,4 +1,4 @@
-import Engine, { Evaluation, Rule } from "publicodes";
+import Engine, { Evaluation, Rule as PubliRule } from "publicodes";
 import React, { createContext, useContext } from "react";
 
 import usePublicodesHandler from "./Handler";
@@ -7,6 +7,21 @@ interface MissingArgs {
   name: string;
   indice: number;
   rawNode: Rule;
+}
+
+export enum RuleType {
+  Liste = "liste",
+}
+
+export interface RuleListe {
+  type: RuleType.Liste;
+  valeurs: Record<string, string>;
+}
+
+export type RuleCdtn = RuleListe;
+
+export interface Rule extends PubliRule {
+  cdtn?: RuleCdtn;
 }
 
 export interface SituationElement {
@@ -24,11 +39,11 @@ export interface PublicodesContextInterface {
 
 const publicodesContext = createContext<PublicodesContextInterface>({
   missingArgs: [],
-  situation: [],
   result: null,
   setSituation: () => {
     throw Error("Not implemented");
   },
+  situation: [],
 });
 
 export function usePublicodes(): PublicodesContextInterface {

--- a/packages/code-du-travail-modeles/src/modeles/conventions/plasturgie.yaml
+++ b/packages/code-du-travail-modeles/src/modeles/conventions/plasturgie.yaml
@@ -6,12 +6,11 @@ contrat salarié . convention collective . plasturgie:
 
 contrat salarié . convention collective . plasturgie . catégorie profressionnelle:
   question: Quelle est votre catégorie professionelle ?
-  formule:
-    une possibilité:
-      choix obligatoire: oui
-      possibilités:
-        - Cadres
-        - Collaborateurs
+  cdtn:
+    type: liste
+    valeurs:
+      Cadres: "'Cadres'"
+      Collaborateurs: "'Collaborateurs'"
 
 contrat salarié . convention collective . plasturgie . catégorie profressionnelle . Cadres:
   applicable si: catégorie profressionnelle = 'Cadres'
@@ -28,6 +27,11 @@ contrat salarié . convention collective . plasturgie . catégorie profressionne
 
 contrat salarié . convention collective . plasturgie . catégorie profressionnelle . Collaborateurs . coefficient:
   question: Quelle est votre coefficient ?
+  cdtn:
+    type: liste
+    valeurs:
+      "Entre 700 et 750": 700
+      "Entre 800 et 830": 800
 
 contrat salarié . convention collective . plasturgie . catégorie profressionnelle . Collaborateurs . préavis de retaite tranches:
   titre: Tranches du préavis de retraite pour un collaborateur


### PR DESCRIPTION
 * Création d'un composant `PubliQuestion` qui va s'appuyer sur les données dans le publicodes pour afficher le champ du formulaire
  * Création d'un composant `StepDynamicPublicodes` pour gérer l'enchainement des questions
  * Reset des informations saisies quand on change de CC
  * Skip de l'étape information si pas CC renseignée ou non supportée
  
  Pour le dernier point, je ne suis pas très satisfait car l'info est en dur. Par contre, je ne peux pas récupérer l'info depuis publicodes car je dois être dans un composant react. A discuter mais peut être ajouter une dépendance dans le Wizard à publicodes afin qu'il le passe en entrée avec les values et du coup on peut l'utiliser pour passer l'étape. Ce n'est pas bloquant pour le moment je pense.