### PR TITLE
fix(frontend): button hover animation on firefox

### DIFF
--- a/packages/react-ui/src/Button/index.js
+++ b/packages/react-ui/src/Button/index.js
@@ -126,6 +126,7 @@ export const StyledButton = styled.button`
       border-color: ${borderColor};
       box-shadow: ${boxShadow};
       opacity: 1;
+      will-change: transform;
 
       &:link,
       &:visited {


### PR DESCRIPTION
On firefox, using transform animation leads to a light glitch : a small translation (~1px) to the left. Adding 'will-change' property fixes it.

### Before

https://user-images.githubusercontent.com/1775934/117624654-6c3a9280-b175-11eb-8ae3-c34addfc110d.mp4

### After

https://user-images.githubusercontent.com/1775934/117624672-72307380-b175-11eb-834e-5a74ad356a8f.mp4

