### PR TITLE
feat(simulator): improve retirement simulator

### DIFF
--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/stepReducer.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/stepReducer.tsx
@@ -1,9 +1,4 @@
-import {
-  Action,
-  ActionName,
-  FormContent,
-  State,
-} from "../common/type/WizardType";
+import { Action, ActionName, FormContent, State } from "../common/type/WizardType";
 import Steps from "./steps";
 
 // Add only idcc number for Agreement asking for additional information
@@ -35,7 +30,7 @@ export const initialState: State = {
       name: "infos",
       skip: (values: FormContent): boolean => {
         if (
-          excludedCcnFromVoluntaryPath.includes(values.ccn.num) &&
+          excludedCcnFromVoluntaryPath.includes(values.ccn?.num) &&
           values["contrat salarié - mise à la retraite"] === "non"
         )
           return true;

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Anciennete.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Anciennete.tsx
@@ -1,9 +1,21 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 import { TextQuestion } from "../../common/TextQuestion";
+import { WizardStepProps } from "../../common/type/WizardType";
 import { isPositiveNumber } from "../../common/validators";
+import { usePublicodes } from "../../publicodes";
+import { mapToPublicodesSituation } from "../../publicodes/Utils";
 
-function AncienneteStep(): JSX.Element {
+function AncienneteStep({ form }: WizardStepProps): JSX.Element {
+  const publicodesContext = usePublicodes();
+
+  useEffect(() => {
+    publicodesContext.setSituation(
+      mapToPublicodesSituation(form.getState().values)
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [form]);
+
   return (
     <>
       <TextQuestion

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Result.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Result.tsx
@@ -1,22 +1,13 @@
 import { Alert } from "@socialgouv/cdtn-ui";
-import React, { useEffect } from "react";
+import React from "react";
 
 import { A11yLink } from "../../../common/A11yLink";
 import Mdx from "../../../common/Mdx";
 import { Highlight, SectionTitle } from "../../common/stepStyles";
-import { WizardStepProps } from "../../common/type/WizardType";
 import { usePublicodes } from "../../publicodes";
-import { mapToPublicodesSituation } from "../../publicodes/Utils";
 
-function ResultStep({ form }: WizardStepProps): JSX.Element {
+function ResultStep(): JSX.Element {
   const publicodesContext = usePublicodes();
-
-  useEffect(() => {
-    publicodesContext.setSituation(
-      mapToPublicodesSituation(form.getState().values)
-    );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [form]);
 
   const notifications = publicodesContext.getNotifications();
   const references = publicodesContext.getReferences();

--- a/packages/code-du-travail-modeles/src/__test__/depart.mise.retraite.commerces.de.gros.spec.ts
+++ b/packages/code-du-travail-modeles/src/__test__/depart.mise.retraite.commerces.de.gros.spec.ts
@@ -22,6 +22,7 @@ test.each`
 
     expect(result.nodeValue).toEqual(expectedNotice);
     expect(result.unit?.numerators).toEqual(["mois"]);
+    expect(result.missingVariables).toEqual({});
   }
 );
 
@@ -56,6 +57,7 @@ test.each`
 
     expect(result.nodeValue).toEqual(expectedNotice);
     expect(result.unit?.numerators).toEqual(["mois"]);
+    expect(result.missingVariables).toEqual({});
   }
 );
 
@@ -66,7 +68,7 @@ test.each`
   ${24}
 `(
   "Pour un employé possédant $seniority mois d'ancienneté en départ à la retraite, on doit afficher une notification",
-  ({ seniority, expectedNotice }) => {
+  ({ seniority }) => {
     const result = getNotifications(
       engine.setSituation({
         "contrat salarié . convention collective": "'IDCC0573'",
@@ -101,7 +103,7 @@ test.each`
   ${24}     | ${"Cadres"}
 `(
   "Pour un $category possédant $seniority mois d'ancienneté en départ à la retraite, on ne doit pas afficher de notification",
-  ({ seniority, category, expectedNotice }) => {
+  ({ seniority, category }) => {
     const result = getNotifications(
       engine.setSituation({
         "contrat salarié . convention collective": "'IDCC0573'",

--- a/packages/code-du-travail-modeles/src/__test__/depart.mise.retraite.habillement.commerce.succursales.spec.ts
+++ b/packages/code-du-travail-modeles/src/__test__/depart.mise.retraite.habillement.commerce.succursales.spec.ts
@@ -28,6 +28,7 @@ test.each`
 
     expect(result.nodeValue).toEqual(expectedNotice);
     expect(result.unit?.numerators).toEqual(["mois"]);
+    expect(result.missingVariables).toEqual({});
   }
 );
 
@@ -57,5 +58,6 @@ test.each`
 
     expect(result.nodeValue).toEqual(expectedNotice);
     expect(result.unit?.numerators).toEqual([expectedUnit]);
+    expect(result.missingVariables).toEqual({});
   }
 );

--- a/packages/code-du-travail-modeles/src/__test__/depart.mise.retraite.handicap.spec.ts
+++ b/packages/code-du-travail-modeles/src/__test__/depart.mise.retraite.handicap.spec.ts
@@ -39,6 +39,7 @@ test.each`
 
     expect(result.nodeValue).toEqual(expectedNotice);
     expect(result.unit?.numerators).toEqual(["mois"]);
+    expect(result.missingVariables).toEqual({});
   }
 );
 
@@ -77,6 +78,7 @@ test.each`
 
     expect(result.nodeValue).toEqual(expectedNotice);
     expect(result.unit?.numerators).toEqual(["mois"]);
+    expect(result.missingVariables).toEqual({});
   }
 );
 

--- a/packages/code-du-travail-modeles/src/__test__/depart.mise.retraite.industrie.pharmaceutique.spec.ts
+++ b/packages/code-du-travail-modeles/src/__test__/depart.mise.retraite.industrie.pharmaceutique.spec.ts
@@ -31,6 +31,7 @@ test.each`
 
     expect(result.nodeValue).toEqual(expectedNotice);
     expect(result.unit?.numerators).toEqual(["mois"]);
+    expect(result.missingVariables).toEqual({});
   }
 );
 
@@ -66,6 +67,7 @@ test.each`
 
     expect(result.nodeValue).toEqual(expectedNotice);
     expect(result.unit?.numerators).toEqual(["mois"]);
+    expect(result.missingVariables).toEqual({});
   }
 );
 

--- a/packages/code-du-travail-modeles/src/__test__/depart.mise.retraite.industries.metallurgiques.region.parisienne.spec.ts
+++ b/packages/code-du-travail-modeles/src/__test__/depart.mise.retraite.industries.metallurgiques.region.parisienne.spec.ts
@@ -24,6 +24,7 @@ test.each`
 
     expect(result.nodeValue).toEqual(expectedNotice);
     expect(result.unit?.numerators).toEqual(["mois"]);
+    expect(result.missingVariables).toEqual({});
   }
 );
 
@@ -47,5 +48,6 @@ test.each`
 
     expect(result.nodeValue).toEqual(expectedNotice);
     expect(result.unit?.numerators).toEqual(["mois"]);
+    expect(result.missingVariables).toEqual({});
   }
 );

--- a/packages/code-du-travail-modeles/src/__test__/depart.mise.retraite.metallurgie.ingenieurs.cadres.spec.ts
+++ b/packages/code-du-travail-modeles/src/__test__/depart.mise.retraite.metallurgie.ingenieurs.cadres.spec.ts
@@ -22,6 +22,7 @@ test.each`
 
     expect(result.nodeValue).toEqual(expectedNotice);
     expect(result.unit?.numerators).toEqual(["mois"]);
+    expect(result.missingVariables).toEqual({});
   }
 );
 
@@ -43,6 +44,7 @@ test.each`
 
     expect(result.nodeValue).toEqual(expectedNotice);
     expect(result.unit?.numerators).toEqual(["mois"]);
+    expect(result.missingVariables).toEqual({});
   }
 );
 

--- a/packages/code-du-travail-modeles/src/__test__/depart.mise.retraite.plasturgie.spec.ts
+++ b/packages/code-du-travail-modeles/src/__test__/depart.mise.retraite.plasturgie.spec.ts
@@ -27,6 +27,7 @@ test.each`
 
     expect(result.nodeValue).toEqual(expectedNotice);
     expect(result.unit?.numerators).toEqual(["mois"]);
+    expect(result.missingVariables).toEqual({});
   }
 );
 
@@ -54,6 +55,7 @@ test.each`
 
     expect(result.nodeValue).toEqual(expectedNotice);
     expect(result.unit?.numerators).toEqual(["mois"]);
+    expect(result.missingVariables).toEqual({});
   }
 );
 
@@ -80,6 +82,7 @@ test.each`
 
     expect(result.nodeValue).toEqual(expectedNotice);
     expect(result.unit?.numerators).toEqual(["mois"]);
+    expect(result.missingVariables).toEqual({});
   }
 );
 
@@ -107,5 +110,6 @@ test.each`
 
     expect(result.nodeValue).toEqual(expectedNotice);
     expect(result.unit?.numerators).toEqual(["mois"]);
+    expect(result.missingVariables).toEqual({});
   }
 );

--- a/packages/code-du-travail-modeles/src/__test__/depart.mise.retraite.references.spec.ts
+++ b/packages/code-du-travail-modeles/src/__test__/depart.mise.retraite.references.spec.ts
@@ -8,24 +8,25 @@ import {
 
 const engine = new Engine(mergeModels());
 
-test("Pour un préavis de mise à la retraite, on devrait avoir les références légales d'une mise à la retraite", () => {
-  const result = getReferences(
-    engine.setSituation({
-      "contrat salarié . ancienneté": 12,
-      "contrat salarié . mise à la retraite": "oui",
-    })
-  );
+test.each`
+  retirement  | seniority | expectedReferences
+  ${"depart"} | ${5}      | ${DepartRetraiteReferences}
+  ${"depart"} | ${6}      | ${DepartRetraiteReferences}
+  ${"depart"} | ${24}     | ${DepartRetraiteReferences}
+  ${"mise"}   | ${5}      | ${MiseRetraiteReferences}
+  ${"mise"}   | ${6}      | ${MiseRetraiteReferences}
+  ${"mise"}   | ${24}     | ${MiseRetraiteReferences}
+`(
+  "Vérification des références juridiques pour un employé avec une ancienneté de $seniority mois en $retirement à la retraite",
+  ({ retirement, seniority, expectedReferences }) => {
+    const result = getReferences(
+      engine.setSituation({
+        "contrat salarié . ancienneté": seniority,
+        "contrat salarié . mise à la retraite":
+          retirement === "mise" ? "oui" : "non",
+      })
+    );
 
-  expect(result).toEqual(expect.arrayContaining(MiseRetraiteReferences));
-});
-
-test("Pour un préavis de départ à la retraite, on devrait avoir les références légales d'un départ à la retraite", () => {
-  const result = getReferences(
-    engine.setSituation({
-      "contrat salarié . ancienneté": 12,
-      "contrat salarié . mise à la retraite": "non",
-    })
-  );
-
-  expect(result).toEqual(expect.arrayContaining(DepartRetraiteReferences));
-});
+    expect(result).toEqual(expect.arrayContaining(expectedReferences));
+  }
+);

--- a/packages/code-du-travail-modeles/src/__test__/depart.mise.retraite.spec.ts
+++ b/packages/code-du-travail-modeles/src/__test__/depart.mise.retraite.spec.ts
@@ -17,6 +17,7 @@ test.each`
   ({ seniority, expectedNotice }) => {
     const result = engine
       .setSituation({
+        "contrat salarié . convention collective": "''",
         "contrat salarié . ancienneté": seniority,
         "contrat salarié . mise à la retraite": "oui",
       })
@@ -24,6 +25,7 @@ test.each`
 
     expect(result.nodeValue).toEqual(expectedNotice);
     expect(result.unit?.numerators).toEqual(["mois"]);
+    expect(result.missingVariables).toEqual({});
   }
 );
 
@@ -41,6 +43,7 @@ test.each`
   ({ seniority, expectedNotice }) => {
     const result = engine
       .setSituation({
+        "contrat salarié . convention collective": "''",
         "contrat salarié . ancienneté": seniority,
         "contrat salarié . mise à la retraite": "non",
       })
@@ -48,5 +51,6 @@ test.each`
 
     expect(result.nodeValue).toEqual(expectedNotice);
     expect(result.unit?.numerators).toEqual(["mois"]);
+    expect(result.missingVariables).toEqual({});
   }
 );

--- a/packages/code-du-travail-modeles/src/__test__/depart.mise.retraite.transport.aerien.personnel.au.sol.spec.ts
+++ b/packages/code-du-travail-modeles/src/__test__/depart.mise.retraite.transport.aerien.personnel.au.sol.spec.ts
@@ -40,6 +40,7 @@ test.each`
 
     expect(result.nodeValue).toEqual(expectedNotice);
     expect(result.unit?.numerators).toEqual(["mois"]);
+    expect(result.missingVariables).toEqual({});
   }
 );
 
@@ -80,5 +81,6 @@ test.each`
 
     expect(result.nodeValue).toEqual(expectedNotice);
     expect(result.unit?.numerators).toEqual(["mois"]);
+    expect(result.missingVariables).toEqual({});
   }
 );

--- a/packages/code-du-travail-modeles/src/__test__/depart.mise.retraite.transports.routiers.spec.ts
+++ b/packages/code-du-travail-modeles/src/__test__/depart.mise.retraite.transports.routiers.spec.ts
@@ -41,6 +41,7 @@ test.each`
 
     expect(result.nodeValue).toEqual(expectedNotice);
     expect(result.unit?.numerators).toEqual(["mois"]);
+    expect(result.missingVariables).toEqual({});
   }
 );
 
@@ -81,6 +82,7 @@ test.each`
 
     expect(result.nodeValue).toEqual(expectedNotice);
     expect(result.unit?.numerators).toEqual([expectedUnit]);
+    expect(result.missingVariables).toEqual({});
   }
 );
 

--- a/packages/code-du-travail-modeles/src/modeles/contrat-salarie.yaml
+++ b/packages/code-du-travail-modeles/src/modeles/contrat-salarie.yaml
@@ -12,48 +12,36 @@ contrat salarié . départ à la retraite:
 
 contrat salarié . préavis de retraite: 0 mois
 
-contrat salarié . préavis de retraite . mise à la retraite inférieur à 6 mois:
-  applicable si:
-    toutes ces conditions:
-      - ancienneté < 6 mois
-      - contrat salarié . mise à la retraite
-  remplace: contrat salarié . préavis de retraite
-  valeur: contrat salarié . préavis de retraite collective
-  références:
-    Article L1237-6: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006901180/2008-05-01
-    Article L1234-1: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000006901112/2008-05-01/#LEGIARTI000006901112
-
-contrat salarié . préavis de retraite . départ à la retraite inférieur à 6 mois:
-  applicable si:
-    toutes ces conditions:
-      - ancienneté < 6 mois
-      - contrat salarié . départ à la retraite
-  remplace: contrat salarié . préavis de retraite
-  valeur: contrat salarié . préavis de retraite collective
-  références:
-    Article L1237-10: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000006901184/2008-05-01/
-    Article L1234-1: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000006901112/2008-05-01/#LEGIARTI000006901112
-
 contrat salarié . préavis de retraite . mise à la retraite:
   applicable si: mise à la retraite
-  non applicable si: ancienneté < 6 mois
   remplace: contrat salarié . préavis de retraite
-  valeur:
-    le maximum de:
-      - contrat salarié . préavis de retraite . tranches
-      - contrat salarié . préavis de retraite collective
+  variations:
+    - si:
+        toutes ces conditions:
+          - ancienneté < 6 mois
+          - préavis de retraite collective # Hack pour empêcher que la règle ne soit pas évaluer
+      alors: contrat salarié . préavis de retraite collective
+    - sinon:
+        le maximum de:
+          - contrat salarié . préavis de retraite . tranches
+          - contrat salarié . préavis de retraite collective
   références:
     Article L1237-6: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006901180/2008-05-01
     Article L1234-1: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000006901112/2008-05-01/#LEGIARTI000006901112
 
 contrat salarié . préavis de retraite . départ à la retraite:
   applicable si: départ à la retraite
-  non applicable si: ancienneté < 6 mois
   remplace: contrat salarié . préavis de retraite
-  valeur:
-    le minimum de:
-      - contrat salarié . préavis de retraite . tranches
-      - contrat salarié . préavis de retraite collective
+  variations:
+    - si:
+        toutes ces conditions:
+          - ancienneté < 6 mois
+          - préavis de retraite collective # Hack pour empêcher que la règle ne soit pas évaluer
+      alors: contrat salarié . préavis de retraite collective
+    - sinon:
+        le minimum de:
+          - contrat salarié . préavis de retraite . tranches
+          - contrat salarié . préavis de retraite collective
   références:
     Article L1237-10: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000006901184/2008-05-01/
     Article L1234-1: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000006901112/2008-05-01/#LEGIARTI000006901112

--- a/packages/code-du-travail-modeles/src/modeles/conventions/commerces_de_gros.yaml
+++ b/packages/code-du-travail-modeles/src/modeles/conventions/commerces_de_gros.yaml
@@ -5,6 +5,7 @@ contrat salarié . convention collective . commerces de gros:
   valeur: oui
 
 contrat salarié . convention collective . commerces de gros . catégorie professionnelle:
+  applicable si: mise à la retraite
   question: Quelle est votre catégorie professionelle ?
   cdtn:
     type: liste

--- a/packages/code-du-travail-modeles/src/modeles/conventions/transport_aerien_personnel_au_sol.yaml
+++ b/packages/code-du-travail-modeles/src/modeles/conventions/transport_aerien_personnel_au_sol.yaml
@@ -69,6 +69,7 @@ contrat salarié . convention collective . transport aérien personnel au sol . 
 
 contrat salarié . convention collective . transport aérien personnel au sol . Cadres:
   applicable si: catégorie professionnelle = 'Cadres'
+  valeur: oui
 
 contrat salarié . convention collective . transport aérien personnel au sol . Cadres . préavis départ à la retraite:
   remplace: contrat salarié . préavis de retraite collective


### PR DESCRIPTION
J'ai fait quelques modifications pour améliorer les perfs sur le context. Notamment, je garde le moteur publicodes via `useMemo` pour éviter d'en créer un nouveau à chaque fois. J'ai aussi bouger la détection des changement sur le formulaire dans l'écran de l'ancienneté au lieu de result. Comme ça quand on arrive dans les résultats, tout est calculé (plus de comportement étranges sur les références par exemple). 

J'ai aussi ajouté des tests sur les références pour le cas de l'ancienneté < 6 mois du code du travail. Les références ne s'affichaient pas...

Et pour finir, j'ai ajouté un test pour valider qu'il ne restait pas de missignArgs à la fin des tests pour éviter d'avoir des règles que l'on aurait oublié.

Prochaine étape:
 * Ajouter les informations saisies par l'utilisateur sur l'écran de résultat
 * Ajouter le détail du calcul (mode basique comme on avait parlé dans un premier temps)
Tout cela en parallèle du dev des CCs.
