### PR TITLE
feat(simulator): show user input detail on retirement notice

### DIFF
--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Origine.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Origine.tsx
@@ -1,13 +1,25 @@
 import { InputRadio } from "@socialgouv/cdtn-ui";
-import React from "react";
+import React, { useEffect } from "react";
 import { Field } from "react-final-form";
 
 import { ErrorField } from "../../common/ErrorField";
 import { Question } from "../../common/Question";
 import { RadioContainer } from "../../common/stepStyles";
+import { WizardStepProps } from "../../common/type/WizardType";
 import { required } from "../../common/validators";
+import { usePublicodes } from "../../publicodes";
+import { mapToPublicodesSituation } from "../../publicodes/Utils";
 
-function OrigineStep(): JSX.Element {
+function OrigineStep({ form }: WizardStepProps): JSX.Element {
+  const publicodesContext = usePublicodes();
+
+  useEffect(() => {
+    publicodesContext.setSituation(
+      mapToPublicodesSituation(form.getState().values)
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [form]);
+
   return (
     <>
       <Question as="p" required>

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Result.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Result.tsx
@@ -5,9 +5,10 @@ import { A11yLink } from "../../../common/A11yLink";
 import Mdx from "../../../common/Mdx";
 import PubliSituation from "../../common/PubliSituation";
 import { Highlight, SectionTitle } from "../../common/stepStyles";
+import { WizardStepProps } from "../../common/type/WizardType";
 import { usePublicodes } from "../../publicodes";
 
-function ResultStep(): JSX.Element {
+function ResultStep({ form }: WizardStepProps): JSX.Element {
   const publicodesContext = usePublicodes();
 
   const notifications = publicodesContext.getNotifications();

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Result.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/Result.tsx
@@ -3,6 +3,7 @@ import React from "react";
 
 import { A11yLink } from "../../../common/A11yLink";
 import Mdx from "../../../common/Mdx";
+import PubliSituation from "../../common/PubliSituation";
 import { Highlight, SectionTitle } from "../../common/stepStyles";
 import { usePublicodes } from "../../publicodes";
 
@@ -33,6 +34,10 @@ function ResultStep(): JSX.Element {
           ))}
         </Alert>
       )}
+      <PubliSituation
+        situation={publicodesContext.situation}
+        form={form.getState().values}
+      />
       {references.length > 0 && (
         <>
           <SectionTitle>Source</SectionTitle>

--- a/packages/code-du-travail-frontend/src/outils/common/InfosCCn.js
+++ b/packages/code-du-travail-frontend/src/outils/common/InfosCCn.js
@@ -26,6 +26,7 @@ function StepInfoCCn({ form, isOptionnal = true }) {
     form.batch(() => {
       // Simulateur Duree Preavis Retraite:  Delete infos when change CC
       form.change("infos", undefined);
+      form.change("contrat salarié - ancienneté", undefined);
       form.change("criteria", undefined);
       form.change("typeRupture", undefined);
       form.change(CONVENTION_NAME, storedConvention);

--- a/packages/code-du-travail-frontend/src/outils/common/PubliQuestion.tsx
+++ b/packages/code-du-travail-frontend/src/outils/common/PubliQuestion.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { Rule, RuleType } from "../publicodes";
+import { reverseValues } from "../publicodes/Utils";
 import { SelectQuestion } from "./SelectQuestion";
 import { TextQuestion } from "./TextQuestion";
 import { YesNoPubliQuestion } from "./YesNoPubliQuestion";
@@ -31,13 +32,5 @@ const PubliQuestion: React.FC<Props> = ({ name, rule, onChange }) => {
       );
   }
 };
-
-const reverseValues = (
-  values: Record<string, string>
-): Record<string, string> =>
-  Object.entries(values).reduce((state, [key, value]) => {
-    state[value] = key;
-    return state;
-  }, {});
 
 export default PubliQuestion;

--- a/packages/code-du-travail-frontend/src/outils/common/PubliSituation.tsx
+++ b/packages/code-du-travail-frontend/src/outils/common/PubliSituation.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+
+import { RuleType, SituationElement } from "../publicodes";
+import { reverseValues } from "../publicodes/Utils";
+import { SectionTitle } from "./stepStyles";
+import { FormContent } from "./type/WizardType";
+
+type PublicodesInputProps = {
+  element: SituationElement;
+  form: FormContent;
+};
+
+function SituationInput({ element, form }: PublicodesInputProps): JSX.Element {
+  if (element.name === "contrat salarié - convention collective") {
+    return <>{form.ccn.shortTitle}</>;
+  }
+  switch (element.rawNode.cdtn?.type) {
+    case RuleType.Liste:
+      return <>{reverseValues(element.rawNode.cdtn.valeurs)[element.value]}</>;
+    case RuleType.OuiNon:
+      return <>{element.value}</>;
+  }
+  return (
+    <>
+      {element.value} {element.rawNode.unité}
+    </>
+  );
+}
+
+type Props = {
+  situation: SituationElement[];
+  form: FormContent;
+};
+
+const PubliSituation: React.FC<Props> = ({ situation, form }) => (
+  <>
+    <SectionTitle>Récapitulatif des éléments saisis</SectionTitle>
+    <ul>
+      {situation.map((element) => (
+        <li key={element.name}>
+          {element.rawNode.titre}:{" "}
+          <b>
+            <SituationInput element={element} form={form} />
+          </b>
+        </li>
+      ))}
+    </ul>
+  </>
+);
+
+export default PubliSituation;

--- a/packages/code-du-travail-frontend/src/outils/common/PubliSituation.tsx
+++ b/packages/code-du-travail-frontend/src/outils/common/PubliSituation.tsx
@@ -18,7 +18,7 @@ function SituationInput({ element, form }: PublicodesInputProps): JSX.Element {
     case RuleType.Liste:
       return <>{reverseValues(element.rawNode.cdtn.valeurs)[element.value]}</>;
     case RuleType.OuiNon:
-      return <>{element.value}</>;
+      return <>{element.value === "oui" ? "Oui" : "Non"}</>;
   }
   return (
     <>

--- a/packages/code-du-travail-frontend/src/outils/publicodes/Utils.ts
+++ b/packages/code-du-travail-frontend/src/outils/publicodes/Utils.ts
@@ -7,9 +7,16 @@ export const mapToPublicodesSituation = (
   form: FormContent
 ): Record<string, string> => {
   const { ccn, infos, ...formWithoutCcn } = form;
-  const ccnId = ccn ? `'IDCC${ccn.num.toString().padStart(4, "0")}'` : "''";
+  if (ccn) {
+    return {
+      "contrat salarié - convention collective": `'IDCC${ccn.num
+        .toString()
+        .padStart(4, "0")}'`,
+      ...infos,
+      ...formWithoutCcn,
+    };
+  }
   return {
-    "contrat salarié - convention collective": ccnId,
     ...infos,
     ...formWithoutCcn,
   };

--- a/packages/code-du-travail-frontend/src/outils/publicodes/Utils.ts
+++ b/packages/code-du-travail-frontend/src/outils/publicodes/Utils.ts
@@ -14,3 +14,11 @@ export const mapToPublicodesSituation = (
     ...formWithoutCcn,
   };
 };
+
+export const reverseValues = (
+  values: Record<string, string>
+): Record<string, string> =>
+  Object.entries(values).reduce((state, [key, value]) => {
+    state[value] = key;
+    return state;
+  }, {});

--- a/packages/code-du-travail-modeles/src/__test__/check.rule.title.spec.ts
+++ b/packages/code-du-travail-modeles/src/__test__/check.rule.title.spec.ts
@@ -16,6 +16,7 @@ allCc.forEach((idcc) => {
     Object.keys(result.missingVariables).forEach((missingVariable) => {
       const rule = engine.getRule(missingVariable);
       expect(rule.rawNode).toContainTitre();
+      expect(rule.rawNode).toContainQuestion();
       expect(rule.rawNode).toContainValidCdtnType();
     });
   });

--- a/packages/code-du-travail-modeles/src/__test__/check.rule.title.spec.ts
+++ b/packages/code-du-travail-modeles/src/__test__/check.rule.title.spec.ts
@@ -21,3 +21,15 @@ allCc.forEach((idcc) => {
     });
   });
 });
+
+test("Vérification que toutes les règles avec une question ont bien un titre avec un type cdtn", () => {
+  Object.values(engine.getParsedRules())
+    .filter(
+      (rule) => rule.rawNode.nom !== "contrat salarié . convention collective"
+    )
+    .filter((rule) => rule.rawNode.question !== undefined)
+    .forEach((rule) => {
+      expect(rule.rawNode).toContainTitre();
+      expect(rule.rawNode).toContainValidCdtnType();
+    });
+});

--- a/packages/code-du-travail-modeles/src/__test__/check.rule.title.spec.ts
+++ b/packages/code-du-travail-modeles/src/__test__/check.rule.title.spec.ts
@@ -1,0 +1,22 @@
+import Engine from "publicodes";
+import { mergeModels } from "../internal/merger";
+import "./matchers/PubliMatcher";
+import { extractCcnIds } from "../internal/extractor";
+
+const engine = new Engine(mergeModels());
+const allCc = extractCcnIds(engine).concat("");
+allCc.forEach((idcc) => {
+  test(`Vérification que l'ensemble des données manquantes pour la CC ${idcc} possède un titre avec un type cdtn`, () => {
+    const result = engine
+      .setSituation({
+        "contrat salarié . convention collective": `'${idcc}'`,
+      })
+      .evaluate("contrat salarié . préavis de retraite");
+
+    Object.keys(result.missingVariables).forEach((missingVariable) => {
+      const rule = engine.getRule(missingVariable);
+      expect(rule.rawNode).toContainTitre();
+      expect(rule.rawNode).toContainValidCdtnType();
+    });
+  });
+});

--- a/packages/code-du-travail-modeles/src/__test__/matchers/PubliMatcher.ts
+++ b/packages/code-du-travail-modeles/src/__test__/matchers/PubliMatcher.ts
@@ -1,0 +1,49 @@
+import { Rule } from "publicodes";
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toContainTitre: () => R;
+      toContainValidCdtnType: () => R;
+    }
+  }
+}
+
+expect.extend({
+  toContainTitre(rule: Rule) {
+    if (rule.titre === undefined || rule.titre === null) {
+      return {
+        pass: false,
+        message: () => `Missing property 'titre' on ${rule.nom}`,
+      };
+    }
+    return {
+      pass: rule.titre.trim() !== "",
+      message: () => `Invalid 'titre' on ${rule.nom}. Titre can't be empty`,
+    };
+  },
+  toContainValidCdtnType(rule: Rule) {
+    const cdtnRule = (rule as any).cdtn;
+    if (!cdtnRule) {
+      return {
+        pass: false,
+        message: () => `Missing 'cdtn' property on ${rule.nom}`,
+      };
+    }
+    const type = cdtnRule["type"];
+    if (!type) {
+      return {
+        pass: false,
+        message: () => `Missing 'cdtn.type' property on ${rule.nom}`,
+      };
+    }
+    const validCdtnType = ["oui-non", "liste", "entier"];
+    return {
+      pass: validCdtnType.includes(type),
+      message: () =>
+        `Type ${type} on ${rule.nom} is not valid. Valid types are ${validCdtnType}`,
+    };
+  },
+});
+
+export default undefined;

--- a/packages/code-du-travail-modeles/src/__test__/matchers/PubliMatcher.ts
+++ b/packages/code-du-travail-modeles/src/__test__/matchers/PubliMatcher.ts
@@ -4,6 +4,7 @@ declare global {
   namespace jest {
     interface Matchers<R> {
       toContainTitre: () => R;
+      toContainQuestion: () => R;
       toContainValidCdtnType: () => R;
     }
   }
@@ -20,6 +21,19 @@ expect.extend({
     return {
       pass: rule.titre.trim() !== "",
       message: () => `Invalid 'titre' on ${rule.nom}. Titre can't be empty`,
+    };
+  },
+  toContainQuestion(rule: Rule) {
+    if (rule.question === undefined || rule.question === null) {
+      return {
+        pass: false,
+        message: () => `Missing property 'question' on ${rule.nom}`,
+      };
+    }
+    return {
+      pass: rule.question.trim() !== "",
+      message: () =>
+        `Invalid 'question' on ${rule.nom}. Question can't be empty`,
     };
   },
   toContainValidCdtnType(rule: Rule) {

--- a/packages/code-du-travail-modeles/src/internal/extractor.ts
+++ b/packages/code-du-travail-modeles/src/internal/extractor.ts
@@ -1,0 +1,20 @@
+import Engine from "publicodes";
+
+export function extractCcnIds(engine: Engine): Array<String> {
+  return Object.values(engine.getParsedRules())
+    .flatMap((rule) => {
+      // @ts-ignore
+      const applicableSi = rule.rawNode["applicable si"];
+      return applicableSi && typeof applicableSi == "string"
+        ? [applicableSi]
+        : [];
+    })
+    .filter((applicable) => {
+      return applicable.startsWith("convention collective = 'IDCC");
+    })
+    .map((applicableCc) => {
+      const regex = /convention collective = '(IDCC[0-9]*)'/gm;
+      const m = regex.exec(applicableCc);
+      return m ? m[1] : "";
+    });
+}

--- a/packages/code-du-travail-modeles/src/modeles/contrat-salarie.yaml
+++ b/packages/code-du-travail-modeles/src/modeles/contrat-salarie.yaml
@@ -3,6 +3,8 @@ contrat salarié . ancienneté:
   titre: Ancienneté du salarié
   question: Quel est votre ancienneté en mois ?
   unité: mois
+  cdtn:
+    type: entier
 
 contrat salarié . mise à la retraite:
   titre: Origine du départ à la retraite

--- a/packages/code-du-travail-modeles/src/modeles/contrat-salarie.yaml
+++ b/packages/code-du-travail-modeles/src/modeles/contrat-salarie.yaml
@@ -1,11 +1,17 @@
 contrat salarié: oui
 contrat salarié . ancienneté:
-  title: Ancienneté du salarié
+  titre: Ancienneté du salarié
   question: Quel est votre ancienneté en mois ?
+  unité: mois
 
 contrat salarié . mise à la retraite:
-  title: Origine du départ à la retraite
+  titre: Origine du départ à la retraite
   question: L’employeur a-t-il décidé de lui-même de mettre à la retraite le salarié par une décision adressée à celui-ci ?
+  cdtn:
+    type: liste
+    valeurs:
+      Mise à la retraite: oui
+      Départ à la retraite: non
 
 contrat salarié . départ à la retraite:
   valeur: mise à la retraite = non
@@ -60,5 +66,6 @@ contrat salarié . préavis de retraite . tranches:
 contrat salarié . préavis de retraite collective: non
 
 contrat salarié . convention collective:
+  titre: Convention collective
   question: Quelle est votre convention collective ?
   par défaut: "''"

--- a/packages/code-du-travail-modeles/src/modeles/conventions/commerces_de_gros.yaml
+++ b/packages/code-du-travail-modeles/src/modeles/conventions/commerces_de_gros.yaml
@@ -6,6 +6,7 @@ contrat salarié . convention collective . commerces de gros:
 
 contrat salarié . convention collective . commerces de gros . catégorie professionnelle:
   applicable si: mise à la retraite
+  titre: Catégorie professionnelle
   question: Quelle est votre catégorie professionelle ?
   cdtn:
     type: liste

--- a/packages/code-du-travail-modeles/src/modeles/conventions/habillement_commerce_succursales.yaml
+++ b/packages/code-du-travail-modeles/src/modeles/conventions/habillement_commerce_succursales.yaml
@@ -6,6 +6,7 @@ contrat salarié . convention collective . habillement commerce succursales:
 
 contrat salarié . convention collective . habillement commerce succursales . catégorie professionnelle:
   question: Quel est votre catégorie professionnelle ?
+  titre: Catégorie professionnelle
   cdtn:
     type: liste
     valeurs:

--- a/packages/code-du-travail-modeles/src/modeles/conventions/handicap.yaml
+++ b/packages/code-du-travail-modeles/src/modeles/conventions/handicap.yaml
@@ -6,6 +6,7 @@ contrat salarié . convention collective . établissement handicap:
 
 contrat salarié . convention collective . établissement handicap . catégorie professionnelle:
   question: Quelle est votre catégorie professionelle ?
+  titre: Catégorie professionnelle
   cdtn:
     type: liste
     valeurs:
@@ -26,8 +27,8 @@ contrat salarié . convention collective . établissement handicap . catégorie 
   valeur: oui
 
 contrat salarié . convention collective . établissement handicap . catégorie professionnelle . Cadres:
-  applicable si: 
-    une de ces conditions: 
+  applicable si:
+    une de ces conditions:
       - catégorie professionnelle = 'Directeurs de service'
       - catégorie professionnelle = 'Directeurs d'établissement'
       - catégorie professionnelle = 'Directeurs de centre de formation en travail social'
@@ -39,7 +40,7 @@ contrat salarié . convention collective . établissement handicap . catégorie 
   remplace : contrat salarié . préavis de retraite collective
   valeur: 1 mois
   références:
-    Article 16 :	https://www.legifrance.gouv.fr/conv_coll/id/KALIARTI000005863125/?idConteneur=KALICONT000005635407  
+    Article 16 :	https://www.legifrance.gouv.fr/conv_coll/id/KALIARTI000005863125/?idConteneur=KALICONT000005635407
     Article 18 : https://www.legifrance.gouv.fr/conv_coll/id/KALIARTI000005863127/?idConteneur=KALICONT000005635407
 
 contrat salarié . convention collective . établissement handicap . catégorie professionnelle . Autres cadres . preavis de depart:
@@ -47,8 +48,8 @@ contrat salarié . convention collective . établissement handicap . catégorie 
   remplace : contrat salarié . préavis de retraite collective
   valeur: 2 mois
   références:
-    Article 16: https://www.legifrance.gouv.fr/conv_coll/id/KALIARTI000005863125/?idConteneur=KALICONT000005635407  
-    Article 18 : https://www.legifrance.gouv.fr/conv_coll/id/KALIARTI000005863127/?idConteneur=KALICONT000005635407 
+    Article 16: https://www.legifrance.gouv.fr/conv_coll/id/KALIARTI000005863125/?idConteneur=KALICONT000005635407
+    Article 18 : https://www.legifrance.gouv.fr/conv_coll/id/KALIARTI000005863127/?idConteneur=KALICONT000005635407
     Annexe n° 6 Dispositions spéciales aux cadres, article 9 : https://www.legifrance.gouv.fr/conv_coll/article/KALIARTI000022837394?idConteneur=KALICONT000005635407
 
 contrat salarié . convention collective . établissement handicap . catégorie professionnelle . Cadres . preavis de depart:
@@ -59,11 +60,11 @@ contrat salarié . convention collective . établissement handicap . catégorie 
     tranches:
       - montant: 2 mois
         plafond: 24 mois
-      - montant: 3 mois 
+      - montant: 3 mois
   références:
-    Article 16: https://www.legifrance.gouv.fr/conv_coll/id/KALIARTI000005863125/?idConteneur=KALICONT000005635407  
-    Article 18 : https://www.legifrance.gouv.fr/conv_coll/id/KALIARTI000005863127/?idConteneur=KALICONT000005635407 
-    Annexe n° 6 Dispositions spéciales aux cadres, article 9 : https://www.legifrance.gouv.fr/conv_coll/article/KALIARTI000022837394?idConteneur=KALICONT000005635407 
+    Article 16: https://www.legifrance.gouv.fr/conv_coll/id/KALIARTI000005863125/?idConteneur=KALICONT000005635407
+    Article 18 : https://www.legifrance.gouv.fr/conv_coll/id/KALIARTI000005863127/?idConteneur=KALICONT000005635407
+    Annexe n° 6 Dispositions spéciales aux cadres, article 9 : https://www.legifrance.gouv.fr/conv_coll/article/KALIARTI000022837394?idConteneur=KALICONT000005635407
 
 contrat salarié . convention collective . établissement handicap . catégorie professionnelle . Non cadres . preavis de mise à la retraite:
   applicable si : mise à la retraite
@@ -73,15 +74,15 @@ contrat salarié . convention collective . établissement handicap . catégorie 
     tranches:
       - montant: 1 mois
         plafond: 24 mois
-      - montant: 2 mois 
-  références: 
+      - montant: 2 mois
+  références:
     Article 16 : https://www.legifrance.gouv.fr/conv_coll/id/KALIARTI000005863125/?idConteneur=KALICONT000005635407
 
 contrat salarié . convention collective . établissement handicap . catégorie professionnelle . Autres cadres . preavis de mise à la retraite:
   applicable si : mise à la retraite
   remplace : contrat salarié . préavis de retraite collective
   valeur: 4 mois
-  références: 
+  références:
     Annexe n° 6 Dispositions spéciales aux cadres, article 9 : https://www.legifrance.gouv.fr/conv_coll/article/KALIARTI000022837394?idConteneur=KALICONT000005635407
 
 contrat salarié . convention collective . établissement handicap . catégorie professionnelle . Cadres . preavis de mise à la retraite:
@@ -92,7 +93,7 @@ contrat salarié . convention collective . établissement handicap . catégorie 
     tranches:
       - montant: 4 mois
         plafond: 24 mois
-      - montant: 6 mois 
+      - montant: 6 mois
   références:
     Annexe n° 6 Dispositions spéciales aux cadres, article 9 : https://www.legifrance.gouv.fr/conv_coll/article/KALIARTI000022837394?idConteneur=KALICONT000005635407
 

--- a/packages/code-du-travail-modeles/src/modeles/conventions/hospitalisation_privee_but_non_lucratif.yaml
+++ b/packages/code-du-travail-modeles/src/modeles/conventions/hospitalisation_privee_but_non_lucratif.yaml
@@ -5,6 +5,7 @@ contrat salarié . convention collective . hospitalisation privée à but non lu
   valeur: oui
 
 contrat salarié . convention collective . hospitalisation privée à but non lucratif . catégorie professionnelle:
+  titre: Catégorie professionnelle
   question: Quelle est votre catégorie professionelle ?
   cdtn:
     type: liste
@@ -21,6 +22,7 @@ contrat salarié . convention collective . hospitalisation privée à but non lu
       Autres cadres: "'Autres cadres'"
 
 contrat salarié . convention collective . hospitalisation privée à but non lucratif . coefficient:
+  titre: Coefficient
   question: Quel est votre coefficient ?
   cdtn:
     type: liste

--- a/packages/code-du-travail-modeles/src/modeles/conventions/industrie_pharmaceutique.yaml
+++ b/packages/code-du-travail-modeles/src/modeles/conventions/industrie_pharmaceutique.yaml
@@ -5,8 +5,8 @@ contrat salarié . convention collective . industrie pharmaceutique:
   valeur: oui
 
 contrat salarié . convention collective . industrie pharmaceutique . groupe:
+  titre: Groupe
   question: Quel est votre groupe ?
-  description: Description sur le groupe
   cdtn:
     type: liste
     valeurs:
@@ -18,6 +18,7 @@ contrat salarié . convention collective . industrie pharmaceutique . groupe:
       "Groupe 6+": 6
 
 contrat salarié . convention collective . industrie pharmaceutique . conclu après 1 juillet 2019:
+  titre: Contrat de travail conclu après le 1er juillet 2019
   question: Avez vous conclu votre contrat de travail après le 1er juillet 2019 ?
   cdtn:
     type: oui-non

--- a/packages/code-du-travail-modeles/src/modeles/conventions/industries_chimiques.yaml
+++ b/packages/code-du-travail-modeles/src/modeles/conventions/industries_chimiques.yaml
@@ -6,6 +6,7 @@ contrat salarié . convention collective . industries chimiques:
 
 contrat salarié . convention collective . industries chimiques . catégorie professionnelle:
   applicable si: mise à la retraite
+  titre: Catégorie professionnelle
   question: Quelle est votre catégorie professionelle ?
   cdtn:
     type: liste
@@ -27,6 +28,7 @@ contrat salarié . convention collective . industries chimiques . catégorie pro
   valeur: oui
 
 contrat salarié . convention collective . industries chimiques . catégorie professionnelle . ouvriers et collaborateurs . coefficient:
+  titre: Coefficient
   question: Quelle est votre coefficient ?
   cdtn:
     type: liste
@@ -58,6 +60,7 @@ contrat salarié . convention collective . industries chimiques . catégorie pro
   valeur: oui
 
 contrat salarié . convention collective . industries chimiques . catégorie professionnelle . agents de maitrise et techniciens . coefficient:
+  titre: Coefficient
   question: Quelle est votre coefficient ?
   cdtn:
     type: liste

--- a/packages/code-du-travail-modeles/src/modeles/conventions/industries_chimiques.yaml
+++ b/packages/code-du-travail-modeles/src/modeles/conventions/industries_chimiques.yaml
@@ -33,7 +33,7 @@ contrat salarié . convention collective . industries chimiques . catégorie pro
   cdtn:
     type: liste
     valeurs:
-      "Inférieur 190": 189
+      "Inférieur à 190": 189
       "190 et plus": 190
 
 contrat salarié . convention collective . industries chimiques . catégorie professionnelle . ouvriers et collaborateurs . préavis de mise à la retraite:
@@ -65,7 +65,7 @@ contrat salarié . convention collective . industries chimiques . catégorie pro
   cdtn:
     type: liste
     valeurs:
-      "Inférieur 275": 274
+      "Inférieur à 275": 274
       "275 et plus": 275
   références:
     Avenant n° 2 Agents de maîtrise et techniciens du 14 mars 1955 Article 20: https://www.legifrance.gouv.fr/conv_coll/id/KALIARTI000005846461/?idConteneur=KALICONT000005635613

--- a/packages/code-du-travail-modeles/src/modeles/conventions/plasturgie.yaml
+++ b/packages/code-du-travail-modeles/src/modeles/conventions/plasturgie.yaml
@@ -5,6 +5,7 @@ contrat salarié . convention collective . plasturgie:
   valeur: oui
 
 contrat salarié . convention collective . plasturgie . catégorie professionnelle:
+  titre: Catégorie professionnelle
   question: Quelle est votre catégorie professionelle ?
   cdtn:
     type: liste

--- a/packages/code-du-travail-modeles/src/modeles/conventions/plasturgie.yaml
+++ b/packages/code-du-travail-modeles/src/modeles/conventions/plasturgie.yaml
@@ -31,6 +31,7 @@ contrat salarié . convention collective . plasturgie . catégorie professionnel
 
 contrat salarié . convention collective . plasturgie . catégorie professionnelle . Collaborateurs . coefficient:
   question: Quelle est votre coefficient ?
+  titre: Coefficient
   cdtn:
     type: liste
     valeurs:

--- a/packages/code-du-travail-modeles/src/modeles/conventions/transport_aerien_personnel_au_sol.yaml
+++ b/packages/code-du-travail-modeles/src/modeles/conventions/transport_aerien_personnel_au_sol.yaml
@@ -5,6 +5,7 @@ contrat salarié . convention collective . transport aérien personnel au sol:
   valeur: oui
 
 contrat salarié . convention collective . transport aérien personnel au sol . catégorie professionnelle:
+  titre: Catégorie professionnelle
   question: Quelle est la catégorie professionnelle du salarié ?
   cdtn:
     type: liste

--- a/packages/code-du-travail-modeles/src/modeles/conventions/transports_routiers.yaml
+++ b/packages/code-du-travail-modeles/src/modeles/conventions/transports_routiers.yaml
@@ -42,6 +42,7 @@ contrat salarié . convention collective . transports routiers . catégorie prof
 
 contrat salarié . convention collective . transports routiers . catégorie professionnelle . TAM . groupe:
   question: Quelle est votre groupe ?
+  titre: Groupe
   cdtn:
     type: liste
     valeurs:

--- a/packages/code-du-travail-modeles/src/modeles/conventions/transports_routiers.yaml
+++ b/packages/code-du-travail-modeles/src/modeles/conventions/transports_routiers.yaml
@@ -5,6 +5,7 @@ contrat salarié . convention collective . transports routiers:
   valeur: oui
 
 contrat salarié . convention collective . transports routiers . catégorie professionnelle:
+  titre: Catégorie professionnelle
   question: Quelle est votre catégorie professionelle ?
   cdtn:
     type: liste


### PR DESCRIPTION
Ajout du détail de la saisie de l'utilisateur.

J'ai ajouté un test sur l'ensemble des CCs afin de valider que les règles avait bien les propriétés `titre` et `cdtn.type` quand c'était des questions. Cela évitera renforcer le concept qu'une règle doit avoir un titre + une propriété `cdtn.type` pour être correctement gérer pour le code du frontend.