### PR TITLE
feat(meta): use the theme and CC to build title for contribution pages

### DIFF
--- a/packages/code-du-travail-frontend/pages/contribution/[slug].js
+++ b/packages/code-du-travail-frontend/pages/contribution/[slug].js
@@ -37,6 +37,32 @@ class PageContribution extends React.Component {
     return { data };
   }
 
+  function;
+
+  buildTitleAndDescription(breadcrumbs, conventionAnswer, title, description) {
+    if (breadcrumbs && breadcrumbs.length > 0 && conventionAnswer) {
+      const titleWithThemeAndCC =
+        breadcrumbs[breadcrumbs.length - 1].label +
+        " - " +
+        conventionAnswer.shortName;
+      return {
+        description: title + " " + description,
+        title: titleWithThemeAndCC,
+      };
+    }
+    return {
+      description,
+      title,
+    };
+  }
+
+  buildDescription(title, description) {
+    if (title) {
+      return title + " " + description;
+    }
+    return description;
+  }
+
   render() {
     const {
       data: {
@@ -48,10 +74,16 @@ class PageContribution extends React.Component {
       content,
     } = this.props;
 
+    const metas = this.buildTitleAndDescription(
+      breadcrumbs,
+      answers.conventionAnswer,
+      title,
+      description
+    );
     return (
       <div>
         <Layout>
-          <Metas title={title} description={description} />
+          <Metas title={metas.title} description={metas.description} />
           <Answer
             title={title}
             relatedItems={relatedItems}


### PR DESCRIPTION
Implement a new title on the contribution pages. 

Description (from issue):

If the contribution page is custom for a CC:
 * title = Main Theme + CC name
 * metadescription = question + old meta description

Else:
 * title = question
 * metadescription = old meta description

more detail in the issue

Closes #3326 