### PR TITLE
fix(search): fix deduplication between PQ and Search

### DIFF
--- a/packages/code-du-travail-api/src/routes/search/utils.js
+++ b/packages/code-du-travail-api/src/routes/search/utils.js
@@ -1,3 +1,4 @@
+import { getRouteBySource } from "@socialgouv/cdtn-sources";
 // merge by one of each
 
 const merge = (res1, res2, max_result) => {
@@ -16,7 +17,8 @@ const merge = (res1, res2, max_result) => {
 };
 
 // Remove Duplicates
-const predicateFn = ({ _source: { source, slug } }) => `${source}/${slug}`;
+const predicateFn = ({ _source: { source, slug } }) =>
+  `${getRouteBySource(source) || source}/${slug}`;
 
 const removeDuplicate = (arr, predicate = predicateFn) =>
   arr.flatMap((a, index) => {


### PR DESCRIPTION
Depuis la #2037 nous complétons les résultats `prequalifiés` avec les résultats `search`.
Nous dédupliquons les résultats en cas de doublon mais il restait un cas ou la déduplication ne fonctionnait pas.
(le champs source des resultats PQ doit être au format "Route" pour pouvoir le comparer aux resulats search et identifier les doublons)