### PR TITLE
fix(e2e): title has changed

### DIFF
--- a/packages/code-du-travail-frontend-e2e/features/dossier.feature
+++ b/packages/code-du-travail-frontend-e2e/features/dossier.feature
@@ -13,5 +13,5 @@ Fonctionnalité: Dossier Coronavirus
     Alors je vois "Sommaire"
 
     Quand je clique sur "Covid-19 : Les mesures de protection"
-    Quand j'attends que le titre de page "Covid-19 : Les mesures de protection en entreprise (Protocole national [infographie])" apparaisse
+    Quand j'attends que le titre de page "Covid-19 : Les mesures de protection en entreprise (Protocole national) [infographie]" apparaisse
     Alors je vois "L’employeur doit mettre en place, dans le cadre du dialogue social de proximité, notamment en associant représentants du personnel et représentants syndicaux, des mesures d’hygiène, organisationnelles et de protection collective dans le but de veiller au respect des gestes barrières."


### PR DESCRIPTION
Correctif sur les tests e2e suite à la modification du dossier covid 19. Le titre de la [page](https://preprod-code-du-travail-numerique.dev.fabrique.social.gouv.fr/information/covid-19-les-mesures-de-protection-en-entreprise-protocole-national) a changé.

Avant : 

> Covid-19 : Les mesures de protection en entreprise (Protocole national [infographie])

Après :

> Covid-19 : Les mesures de protection en entreprise (Protocole national) [infographie]
