### PR TITLE
fix(k8s): increase www pod requests to reduce HPA issues

### DIFF
--- a/.k8s/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/.k8s/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -335,10 +335,10 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 560Mi
+              memory: 768Mi
             requests:
-              cpu: 200m
-              memory: 256Mi
+              cpu: 300m
+              memory: 512Mi
           startupProbe:
             failureThreshold: 12
             httpGet:

--- a/.k8s/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
@@ -334,10 +334,10 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 560Mi
+              memory: 768Mi
             requests:
-              cpu: 200m
-              memory: 256Mi
+              cpu: 300m
+              memory: 512Mi
           startupProbe:
             failureThreshold: 12
             httpGet:

--- a/.k8s/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -340,10 +340,10 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 560Mi
+              memory: 768Mi
             requests:
-              cpu: 200m
-              memory: 256Mi
+              cpu: 300m
+              memory: 512Mi
           startupProbe:
             failureThreshold: 12
             httpGet:

--- a/.k8s/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -253,7 +253,7 @@ metadata:
   name: api
   namespace: cdtn
 spec:
-  minReplicas: 1
+  minReplicas: 2
   maxReplicas: 10
   metrics:
     - resource:
@@ -494,7 +494,7 @@ metadata:
   name: www
   namespace: cdtn
 spec:
-  minReplicas: 1
+  minReplicas: 2
   maxReplicas: 10
   metrics:
     - resource:

--- a/.k8s/components/api.ts
+++ b/.k8s/components/api.ts
@@ -76,7 +76,7 @@ export default async () => {
   const hpa = new HorizontalPodAutoscaler({
     metadata: deployment.metadata,
     spec: {
-      minReplicas: 1,
+      minReplicas: 2,
       maxReplicas: 10,
 
       metrics: [

--- a/.k8s/components/www.ts
+++ b/.k8s/components/www.ts
@@ -103,7 +103,7 @@ export default async () => {
   const hpa = new HorizontalPodAutoscaler({
     metadata: deployment.metadata,
     spec: {
-      minReplicas: 1,
+      minReplicas: 2,
       maxReplicas: 10,
 
       metrics: [

--- a/.k8s/components/www.ts
+++ b/.k8s/components/www.ts
@@ -56,12 +56,12 @@ export default async () => {
         },
         resources: {
           requests: {
-            cpu: "200m",
-            memory: "256Mi",
+            cpu: "300m",
+            memory: "512Mi",
           },
           limits: {
             cpu: "500m",
-            memory: "560Mi",
+            memory: "768Mi",
           },
         },
         env: [


### PR DESCRIPTION
Augmente les `requests` de mémoire pour le pod "www" (frontend) pour éviter d'avoir 10 pods en permanence. En effet, le scaling se déclenche actuellement pour atteindre 80% de charge max par rapport aux requests. et on ne consomme quasi rien en CPU

<img width="909" alt="Capture d’écran 2021-12-07 à 10 08 15" src="https://user-images.githubusercontent.com/124937/144999942-39f54cb3-4d15-47ef-b8de-6a7b884a7a80.png">

[lien grafana](https://grafana.fabrique.social.gouv.fr/d/SMl8X9c7z/kubernetes-compute-resources-namespace-pods?orgId=1&refresh=10s)

