### PR TITLE
fix: k8s variable

### DIFF
--- a/.k8s/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
@@ -422,7 +422,7 @@ data:
   PIWIK_URL: https://matomo.fabrique.social.gouv.fr
   PROD_HOSTNAME: code.travail.gouv.fr
   SENTRY_PUBLIC_DSN: https://c2aa7e731a494cfd8f7fb1ddabca11c9@sentry.fabrique.social.gouv.fr/5
-  SENTRY_ENV: preproduction
+  SENTRY_ENV: production
 ---
 apiVersion: v1
 kind: Service

--- a/.k8s/environments/preprod/www.configmap.yaml
+++ b/.k8s/environments/preprod/www.configmap.yaml
@@ -11,4 +11,4 @@ data:
   PIWIK_URL: https://matomo.fabrique.social.gouv.fr
   PROD_HOSTNAME: "code.travail.gouv.fr"
   SENTRY_PUBLIC_DSN: "https://c2aa7e731a494cfd8f7fb1ddabca11c9@sentry.fabrique.social.gouv.fr/5"
-  SENTRY_ENV: "preproduction"
+  SENTRY_ENV: "production"

--- a/.k8s/package.json
+++ b/.k8s/package.json
@@ -32,7 +32,8 @@
     "lint:fix": "yarn lint --write",
     "precommit": "lint-staged",
     "prepush": "yarn test",
-    "test": "jest"
+    "test": "jest",
+    "test:update": "jest -u"
   },
   "lint-staged": {
     "{__tests__,components,environments,utils}/**/*.{js,ts,yml,yaml}": [


### PR DESCRIPTION
En gros, on a une variable SENTRY_ENV (que normalement on utilise pas), qui est côté serveur et qui se base sur NEXT_PUBLIC_SENTRY_ENV. On utilise soit production soit env normalement