### PR TITLE
fix(secu): use non-privilegied docker user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,5 +53,6 @@ COPY --from=node_modules node_modules /app/node_modules
 
 COPY . /app
 
+USER 1000
 
 CMD [ "yarn", "start"]

--- a/packages/code-du-travail-api/Dockerfile
+++ b/packages/code-du-travail-api/Dockerfile
@@ -33,4 +33,6 @@ COPY --from=node_modules node_modules /app/node_modules
 
 COPY . /app
 
+USER 1000
+
 CMD [ "yarn", "start" ]


### PR DESCRIPTION
Par défaut c'est le user `root` qui est utilisé dans les images Docker.
Cette PR permet de faire tourner les images avec le user `node` déjà intégré dans l'image.
On utilise l'UID numerique du user qui permet à kubernetes d'être sûr qu'on tourne en UID>0