### PR TITLE
chore: move SDR URLs checkup to a cron job

### DIFF
--- a/.github/workflows/check-sdr-url.yml
+++ b/.github/workflows/check-sdr-url.yml
@@ -1,0 +1,24 @@
+name: Check SDR URLs (CRON)
+on:
+  schedule:
+    - cron: "00 09 * * *"
+  workflow_dispatch:
+
+jobs:
+  services-de-renseignement:
+    name: Check url from service de renseignement
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Test SDR urls
+        run: |
+          jq ".[].url" ./packages/code-du-travail-frontend/src/data/services-de-renseignement.json | xargs -n 1 wget  --spider
+      - name: Create the Mattermost Message
+        if: failure()
+        run: |
+          echo "{\"text\":\"Une ou plusieurs URLs des services de renseignement ne sont plus valides : ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"\"}" > mattermost.json
+      - uses: mattermost/action-mattermost-notify@master
+        if: failure()
+        env:
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}

--- a/.github/workflows/check-sdr-url.yml
+++ b/.github/workflows/check-sdr-url.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Create the Mattermost Message
         if: failure()
         run: |
-          echo "{\"text\":\"Une ou plusieurs URLs des services de renseignement ne sont plus valides : ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"\"}" > mattermost.json
+          echo "{\"text\":\"Une ou plusieurs URLs des services de renseignement ne sont plus valides : ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}\"}" > mattermost.json
       - uses: mattermost/action-mattermost-notify@master
         if: failure()
         env:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -124,12 +124,3 @@ jobs:
         with:
           recursive: true
 
-  services-de-renseignement:
-    name: Get url from service de renseignement
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Test SDR urls
-        run: |
-          jq ".[].url" ./packages/code-du-travail-frontend/src/data/services-de-renseignement.json | xargs -n 1 wget  --spider


### PR DESCRIPTION
Je fais tourner le cron le matin à 9h comme ça on a l'alerte pour 9h30 lors de notre daily si besoin. 

J'ai mis un message assez simple. L'URL étant dispo dans le job même si un peu complexe à trouver parmis les autres URLs.