### PR TITLE
fix(k8s): fix redirect ingress apiVersion

### DIFF
--- a/.k8s/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -535,7 +535,7 @@ spec:
     kind: Deployment
     name: www
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:

--- a/.k8s/environments/prod/yaml/ingress-prod.yml
+++ b/.k8s/environments/prod/yaml/ingress-prod.yml
@@ -1,5 +1,5 @@
 # specific to prod environment
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:


### PR DESCRIPTION
[deprecated in kube 1.22](https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/)