### PR TITLE
fix: use official URL for recherche-entreprises

### DIFF
--- a/packages/code-du-travail-frontend/src/conventions/Search/api/enterprises.service.ts
+++ b/packages/code-du-travail-frontend/src/conventions/Search/api/enterprises.service.ts
@@ -47,7 +47,7 @@ const siretNumberError =
   "Veuillez indiquer un numéro Siret (14 chiffres uniquement)";
 
 const ENTERPRISE_API_URL =
-  "https://search-recherche-entreprises.fabrique.social.gouv.fr/api/v1";
+  "https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1";
 
 const makeSearchUrl = ({ query, address }) => {
   const params: { k: string; v: string }[] = [


### PR DESCRIPTION
use "api.recherche-entreprises.fabrique.social.gouv.fr" instead of legacy URL