### PR TITLE
fix(simulators): add e2e tests on préavis de démission

### DIFF
--- a/packages/code-du-travail-frontend-e2e/features/outils/heures-recherche-emploi.feature
+++ b/packages/code-du-travail-frontend-e2e/features/outils/heures-recherche-emploi.feature
@@ -1,0 +1,103 @@
+#language: fr
+
+@heure-recherche-emploi-outil
+Fonctionnalité: Outil - Heures pour recherche d’emploi
+  Pour pouvoir calculer mes heures pour recherche d'emploi
+  En tant que visiteur
+  Je veux pouvoir utiliser le calculateur d'heures pour recherche d'emploi (en renseignant ou non ma CC)
+
+  Scénario: Parcours sans convention collective
+    Soit un utilisateur sur la page "/outils/heures-recherche-emploi"
+
+    Alors je vois "Étapes"
+    Alors je vois "Heures pour recherche d’emploi"
+    Alors je vois "Ce simulateur vous permet de savoir si le salarié peut bénéficier d’heures d’absence autorisée pendant son préavis pour rechercher un emploi."
+
+    Quand je clique sur "Commencer"
+
+    Alors je vois "Quel est le nom de la convention collective applicable ?"
+    Quand je clique sur "Suivant"
+    Alors je vois "Vous devez répondre à cette question"
+    Quand je choisis "Je ne souhaite pas renseigner ma convention collective"
+    Alors je vois "Vous pouvez passer cette étape et poursuivre la simulation qui vous fournira un résultat basé sur le code du travail."
+    Quand je clique sur "Suivant"
+
+    Alors je vois "Nombre d’heures d’absence autorisée pour rechercher un emploi"
+    Alors je vois "Aucun résultat"
+    Quand j'ouvre l'accordion
+    Alors je vois "La convention collective n'a pas été renseignée"
+
+  Scénario: Parcours en connaissant sa convention collective et sans information complémentaire
+    Soit un utilisateur sur la page "/outils/heures-recherche-emploi"
+
+    Alors je vois "Étapes"
+    Alors je vois "Heures pour recherche d’emploi"
+    Alors je vois "Ce simulateur vous permet de savoir si le salarié peut bénéficier d’heures d’absence autorisée pendant son préavis pour rechercher un emploi."
+
+    Quand je clique sur "Commencer"
+
+    Alors je vois "Quel est le nom de la convention collective applicable ?"
+    Quand je clique sur "Suivant"
+    Alors je vois "Vous devez répondre à cette question"
+    Quand je choisis "Je sais quelle est ma convention collective"
+    Alors je vois "Précisez et sélectionnez votre convention collective"
+    Quand je renseigne "843" dans le champ "Nom de la convention collective ou son numéro d’identification IDCC"
+    Alors j'attends que le texte "Boulangerie" apparaisse
+    Quand je clique sur "Boulangerie"
+    Alors je vois "Cliquez sur Suivant pour poursuivre la simulation."
+    Quand je clique sur "Suivant"
+
+    Alors je vois "Pour quelle raison le contrat de travail a-t-il été rompu"
+    Quand je sélectionne "Licenciement" dans la liste "typeRupture"
+    Quand je clique sur "Suivant"
+
+    Alors je vois "Nombre d’heures d’absence autorisée pour rechercher un emploi"
+    Alors je vois "2 heures d'absence par jour pendant la dernière semaine du préavis"
+    Alors je vois "Rémunération pendant les heures d’absence autorisée"
+    Alors je vois "Le salaire est maintenu. Les heures non utilisés dans ce cadre ne donnent pas lieu à rémunération."
+    Alors je vois "Conditions d’utilisation"
+    Alors je vois "Les heures sont fixées un jour par l' employeur et le suivant par le salarié. Ils peuvent décider de regrouper tout ou partie de ces heures."
+
+    Quand j'ouvre l'accordion
+    Alors je vois "Boulangerie-pâtisserie (entreprises artisanales)"
+    Alors je vois "Licenciement"
+
+  Scénario: Parcours en connaissant sa convention collective et avec informations complémentaires
+    Soit un utilisateur sur la page "/outils/heures-recherche-emploi"
+
+    Alors je vois "Étapes"
+    Alors je vois "Heures pour recherche d’emploi"
+    Alors je vois "Ce simulateur vous permet de savoir si le salarié peut bénéficier d’heures d’absence autorisée pendant son préavis pour rechercher un emploi."
+
+    Quand je clique sur "Commencer"
+
+    Alors je vois "Quel est le nom de la convention collective applicable ?"
+    Quand je clique sur "Suivant"
+    Alors je vois "Vous devez répondre à cette question"
+    Quand je choisis "Je sais quelle est ma convention collective"
+    Alors je vois "Précisez et sélectionnez votre convention collective"
+    Quand je renseigne "787" dans le champ "Nom de la convention collective ou son numéro d’identification IDCC"
+    Alors j'attends que le texte "Personnel des cabinets d'experts-comptables et de commissaires aux comptes" apparaisse
+    Quand je clique sur "Personnel des cabinets d'experts-comptables et de commissaires aux comptes"
+    Alors je vois "Cliquez sur Suivant pour poursuivre la simulation."
+    Quand je clique sur "Suivant"
+
+    Alors je vois "Pour quelle raison le contrat de travail a-t-il été rompu"
+    Quand je sélectionne "Démission" dans la liste "typeRupture"
+    Quand je clique sur "Suivant"
+
+    Alors je vois "Quelle est l'ancienneté du salarié"
+    Quand je sélectionne "Au moins 5 ans" dans la liste "criteria.ancienneté"
+    Quand je clique sur "Suivant"
+
+    Alors je vois "Nombre d’heures d’absence autorisée pour rechercher un emploi"
+    Alors je vois "2 heures par journée d'ouverture du cabinet"
+    Alors je vois "Rémunération pendant les heures d’absence autorisée"
+    Alors je vois "Le salaire est maintenu."
+    Alors je vois "Conditions d’utilisation"
+    Alors je vois "Les heures sont fixées d'un commun accord entre l'employeur et le salarié. En l'absence d'accord, ces absences sont fixées un jour par l'employeur et le salarié. Le salarié qui a retrouvé un emploi ne peut plus utiliser ces heures."
+
+    Quand j'ouvre l'accordion
+    Alors je vois "Personnel des cabinets d'experts-comptables et de commissaires aux comptes"
+    Alors je vois "Démission"
+    Alors je vois "Au moins 5 ans"

--- a/packages/code-du-travail-frontend-e2e/features/outils/preavis-demission.feature
+++ b/packages/code-du-travail-frontend-e2e/features/outils/preavis-demission.feature
@@ -1,0 +1,61 @@
+#language: fr
+
+@preavis-demission-outil
+Fonctionnalité: Outil - Préavis de démission
+  Pour pouvoir calculer mon préavis de démission
+  En tant que visiteur
+  Je veux pouvoir utiliser le calculateur de préavis de démission (en renseignant ou non ma CC)
+
+  Scénario: Parcours sans convention collective
+    Soit un utilisateur sur la page "/outils/preavis-demission"
+
+    Alors je vois "Étapes"
+    Alors je vois "Préavis de démission"
+    Alors je vois "Le présent outil vous permet de connaitre la durée du préavis prévue par la convention collective en matière de démission."
+
+    Quand je clique sur "Commencer"
+
+    Alors je vois "Quel est le nom de la convention collective applicable ?"
+    Quand je clique sur "Suivant"
+    Alors je vois "Vous devez répondre à cette question"
+    Quand je choisis "Je ne souhaite pas renseigner ma convention collective"
+    Alors je vois "Vous pouvez passer cette étape et poursuivre la simulation qui vous fournira un résultat basé sur le code du travail."
+    Quand je clique sur "Suivant"
+
+    Alors je vois "Durée du préavis"
+    Alors je vois "Aucun résultat"
+    Alors je vois "la convention collective n’a pas été renseignée"
+
+  Scénario: Parcours en connaissant sa convention collective
+    Soit un utilisateur sur la page "/outils/preavis-demission"
+
+    Alors je vois "Étapes"
+    Alors je vois "Préavis de démission"
+    Alors je vois "Le présent outil vous permet de connaitre la durée du préavis prévue par la convention collective en matière de démission."
+
+    Quand je clique sur "Commencer"
+
+    Alors je vois "Quel est le nom de la convention collective applicable ?"
+    Quand je clique sur "Suivant"
+    Alors je vois "Vous devez répondre à cette question"
+    Quand je choisis "Je sais quelle est ma convention collective"
+    Alors je vois "Précisez et sélectionnez votre convention collective"
+    Quand je renseigne "843" dans le champ "Nom de la convention collective ou son numéro d’identification IDCC"
+    Alors j'attends que le texte "Boulangerie" apparaisse
+    Quand je clique sur "Boulangerie"
+    Alors je vois "Cliquez sur Suivant pour poursuivre la simulation."
+    Quand je clique sur "Suivant"
+
+    Alors je vois "Quelle est la catégorie professionnelle du salarié"
+    Quand je sélectionne "Personnel de fabrication, personnel de vente et personnel de services" dans la liste "criteria.catégorie professionnelle"
+    Alors je vois "Quelle est l'ancienneté du salarié"
+    Quand je sélectionne "Plus de 6 mois" dans la liste "criteria.ancienneté"
+    Quand je clique sur "Suivant"
+
+    Alors je vois "Durée du préavis"
+    Alors je vois "2 semaines"
+
+    Quand j'ouvre l'accordion
+    Alors je vois "Boulangerie-pâtisserie (entreprises artisanales)"
+    Alors je vois "Personnel de fabrication, personnel de vente et personnel de services"
+    Alors je vois "Plus de 6 mois"

--- a/packages/code-du-travail-frontend-e2e/features/outils/preavis-licenciement.feature
+++ b/packages/code-du-travail-frontend-e2e/features/outils/preavis-licenciement.feature
@@ -1,0 +1,82 @@
+#language: fr
+
+@preavis-licenciement-outil
+Fonctionnalité: Outil - Préavis de licenciement
+  Pour pouvoir calculer mon préavis de licenciement
+  En tant que visiteur
+  Je veux pouvoir utiliser le calculateur de préavis de licenciement (en renseignant ou non ma CC)
+
+  Scénario: Parcours sans convention collective
+    Soit un utilisateur sur la page "/outils/preavis-licenciement"
+
+    Alors je vois "Étapes"
+    Alors je vois "Préavis de licenciement"
+    Alors je vois "Le préavis est une période accordée au salarié entre la notification du licenciement et son départ effectif de l’entreprise (fin du contrat)."
+
+    Quand je clique sur "Commencer"
+
+    Alors je vois "Le licenciement est-il dû à une faute grave (ou lourde)"
+    Quand je choisis "Oui"
+    Quand je clique sur "Suivant"
+    Alors je vois "Dans le cas d’un licenciement pour faute grave ou lourde, il n’y pas d’obligation de respecter un préavis."
+    Quand je choisis "Non"
+    Alors je vois "Le salarié concerné est-il reconnu en tant que travailleur handicapé"
+    Quand je choisis "#disabledWorker-non"
+    Alors je vois "Quelle est l'ancienneté du salarié"
+    Quand je sélectionne "Plus de 2 ans" dans la liste "cdt.ancienneté"
+    Quand je clique sur "Suivant"
+
+    Alors je vois "Quel est le nom de la convention collective applicable ?"
+    Quand je clique sur "Suivant"
+    Alors je vois "Vous devez répondre à cette question"
+    Quand je choisis "Je ne souhaite pas renseigner ma convention collective"
+    Alors je vois "Vous pouvez passer cette étape et poursuivre la simulation qui vous fournira un résultat basé sur le code du travail."
+    Quand je clique sur "Suivant"
+
+    Alors je vois "Durée du préavis"
+    Alors je vois "2 mois"
+    Quand j'ouvre l'accordion
+    Alors je vois "Plus de 2 ans"
+    Alors je vois "La convention collective n'a pas été renseignée"
+
+  Scénario: Parcours en connaissant sa convention collective
+    Soit un utilisateur sur la page "/outils/preavis-licenciement"
+
+    Alors je vois "Étapes"
+    Alors je vois "Préavis de licenciement"
+    Alors je vois "Le préavis est une période accordée au salarié entre la notification du licenciement et son départ effectif de l’entreprise (fin du contrat)."
+
+    Quand je clique sur "Commencer"
+
+    Alors je vois "Le licenciement est-il dû à une faute grave (ou lourde)"
+    Quand je choisis "Non"
+    Alors je vois "Le salarié concerné est-il reconnu en tant que travailleur handicapé"
+    Quand je choisis "#disabledWorker-non"
+    Alors je vois "Quelle est l'ancienneté du salarié"
+    Quand je sélectionne "Plus de 2 ans" dans la liste "cdt.ancienneté"
+    Quand je clique sur "Suivant"
+
+    Alors je vois "Quel est le nom de la convention collective applicable ?"
+    Quand je clique sur "Suivant"
+    Alors je vois "Vous devez répondre à cette question"
+    Quand je choisis "Je sais quelle est ma convention collective"
+    Alors je vois "Précisez et sélectionnez votre convention collective"
+    Quand je renseigne "843" dans le champ "Nom de la convention collective ou son numéro d’identification IDCC"
+    Alors j'attends que le texte "Boulangerie" apparaisse
+    Quand je clique sur "Boulangerie"
+    Alors je vois "Cliquez sur Suivant pour poursuivre la simulation."
+    Quand je clique sur "Suivant"
+
+    Alors je vois "Quelle est la catégorie professionnelle du salarié"
+    Quand je sélectionne "Personnel de fabrication, personnel de vente et personnel de services" dans la liste "criteria.catégorie professionnelle"
+    Alors je vois "Quelle est l'ancienneté du salarié"
+    Quand je sélectionne "Plus de 2 ans" dans la liste "criteria.ancienneté"
+    Quand je clique sur "Suivant"
+
+    Alors je vois "Durée du préavis"
+    Alors je vois "2 mois"
+
+    Quand j'ouvre l'accordion
+    Alors je vois "Boulangerie-pâtisserie (entreprises artisanales)"
+    Alors je vois "Personnel de fabrication, personnel de vente et personnel de services"
+    Alors je vois "Plus de 2 ans"

--- a/packages/code-du-travail-frontend-e2e/step_definitions/global.js
+++ b/packages/code-du-travail-frontend-e2e/step_definitions/global.js
@@ -47,6 +47,13 @@ Quand("je choisis {string}", (text) => {
   I.checkOption(text);
 });
 
+Quand(
+  "je sélectionne {string} dans la liste {string}",
+  (optionName, selectName) => {
+    I.selectOption(selectName, optionName);
+  }
+);
+
 Quand("je ferme la modale", () => {
   I.click('button[title="fermer la modale"]');
 });

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisLicenciement/steps/Status.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisLicenciement/steps/Status.tsx
@@ -4,13 +4,14 @@ import Link from "next/link";
 import React from "react";
 
 import Html from "../../../common/Html";
-import { MatomoActionEvent, trackQuestion } from "../../../lib/matomo";
+import { MatomoActionEvent, trackQuestion } from "../../../lib";
 import { SelectQuestion } from "../../common/SelectQuestion";
 import {
   filterSituations,
   getOptions,
   getSituationsFor,
 } from "../../common/situations.utils";
+import { WizardStepProps } from "../../common/type/WizardType";
 import { YesNoQuestion } from "../../common/YesNoQuestion";
 
 const { questions, situations: allSituations } = data;
@@ -19,13 +20,17 @@ const questionsMap = questions.reduce(
   {}
 );
 
-function validate({ seriousMisconduct }) {
-  const errors: any = {};
+type Validate = {
+  seriousMisconduct?: JSX.Element;
+};
+
+function validate({ seriousMisconduct }): Validate {
+  const errors: Validate = {};
   if (seriousMisconduct) {
     errors.seriousMisconduct = (
       <Toast>
         Dans le cas d’un licenciement pour faute grave ou lourde, il n’y pas
-        d’obligation de respecter un préavis.Vous pouvez trouver plus
+        d’obligation de respecter un préavis. Vous pouvez trouver plus
         d’informations sur le préavis de licenciement sur{" "}
         <Link href={`/fiche-service-public/preavis-de-licenciement`}>
           <a>cette fiche</a>
@@ -37,7 +42,7 @@ function validate({ seriousMisconduct }) {
   return errors;
 }
 
-function StepStatus({ form }) {
+function StepStatus({ form }: WizardStepProps): JSX.Element {
   const { seriousMisconduct, disabledWorker } = form.getState().values;
   const seniorityKey = "ancienneté";
 


### PR DESCRIPTION
Ajout des tests e2e sur les simulateurs impactés par les changements. 

Il reste le simulateur indémnité de précarité mais il est plus complexe à tester. Je le placerai dans une autre PR pour ne pas avoir une PR trop grosse.

Related to #4224 