### PR TITLE
feat(simulators): Extraction du composant décorateur du simulateur

### DIFF
--- a/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/DebugInfo/__tests__/DebugInfo.test.tsx
+++ b/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/DebugInfo/__tests__/DebugInfo.test.tsx
@@ -1,0 +1,16 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import DebugInfo from "../index";
+
+describe("DebugInfo", () => {
+  it("should show the form values in pretty format", () => {
+    const { container } = render(
+      <DebugInfo formValues={{ name: "John", surname: "Doe" }} />
+    );
+    const pre = container.querySelector("pre");
+    expect(pre).not.toBeNull();
+    expect(pre?.innerHTML).toBe(
+      "{\n" + '  "name": "John",\n' + '  "surname": "Doe"\n' + "}"
+    );
+  });
+});

--- a/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/DebugInfo/index.tsx
+++ b/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/DebugInfo/index.tsx
@@ -1,0 +1,12 @@
+type Props = {
+  formValues: unknown;
+};
+
+const Index = ({ formValues }: Props): JSX.Element => (
+  <details>
+    <summary>state</summary>
+    <pre>{JSON.stringify(formValues, null, 2)}</pre>
+  </details>
+);
+
+export default Index;

--- a/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/FormStateToReducer.tsx
+++ b/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/FormStateToReducer.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { FormSpy } from "react-final-form";
+
+type Props<T> = {
+  updateFormState: (state: T) => void;
+};
+
+const FormStateToRedux = <T,>({ updateFormState }: Props<T>): JSX.Element => (
+  <FormSpy<T>
+    subscription={{ values: true }}
+    onChange={(state) => updateFormState(state.values)}
+  />
+);
+
+export default FormStateToRedux;

--- a/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/Navigation/__tests__/Navigation.test.tsx
+++ b/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/Navigation/__tests__/Navigation.test.tsx
@@ -1,0 +1,40 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import Navigation from "../index";
+
+describe("Navigation", () => {
+  describe("On the first screen of the simulator", () => {
+    it("should only render the button to start", () => {
+      const { getByText, getAllByRole } = render(
+        <Navigation showNext={true} />
+      );
+      const buttons = getAllByRole("button");
+      expect(buttons).toHaveLength(1);
+      expect(getByText(/Commencer/)).toBeInTheDocument();
+    });
+  });
+
+  describe("On a step of the simulator", () => {
+    it("should only render the previous and next button", () => {
+      const { getByText, getAllByRole } = render(
+        <Navigation showNext={true} onPrevious={() => {}} />
+      );
+      const buttons = getAllByRole("button");
+      expect(buttons).toHaveLength(2);
+      expect(getByText(/Précédent/)).toBeInTheDocument();
+      expect(getByText(/Suivant/)).toBeInTheDocument();
+    });
+  });
+
+  describe("On the last step of the simulator", () => {
+    it("should only render the previous and print button", () => {
+      const { getByText, getAllByRole } = render(
+        <Navigation showNext={false} onPrevious={() => {}} onPrint={() => {}} />
+      );
+      const buttons = getAllByRole("button");
+      expect(buttons).toHaveLength(2);
+      expect(getByText(/Précédent/)).toBeInTheDocument();
+      expect(getByText(/Imprimer le résultat/)).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/Navigation/index.tsx
+++ b/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/Navigation/index.tsx
@@ -1,0 +1,81 @@
+import { Button, icons, theme } from "@socialgouv/cdtn-ui";
+import React from "react";
+import styled from "styled-components";
+
+export type NavigationProps = {
+  hasError?: boolean;
+  showNext: boolean;
+  onPrevious?: () => void;
+  onPrint?: () => void;
+};
+
+const Index = ({
+  hasError = false,
+  showNext = false,
+  onPrint,
+  onPrevious,
+}: NavigationProps): JSX.Element => {
+  return (
+    <>
+      <StyledDiv>
+        {onPrevious && (
+          <StyledButton small type="button" onClick={onPrevious} variant="flat">
+            Précédent
+          </StyledButton>
+        )}
+        {showNext && !onPrevious && (
+          <StyledButtonReverse disabled={hasError} variant="primary">
+            Commencer
+            <ArrowIcon />
+          </StyledButtonReverse>
+        )}
+        {showNext && onPrevious && (
+          <StyledButton disabled={hasError} variant="primary">
+            Suivant
+            <ArrowIcon />
+          </StyledButton>
+        )}
+        {onPrint && (
+          <StyledButton type="button" onClick={onPrint}>
+            Imprimer le résultat
+          </StyledButton>
+        )}
+      </StyledDiv>
+    </>
+  );
+};
+
+export default Index;
+
+const { breakpoints, spacings } = theme;
+
+const StyledButton = styled(Button)`
+  & + & {
+    @media (max-width: ${breakpoints.tablet}) {
+      margin-top: ${spacings.base};
+    }
+  }
+`;
+
+const StyledDiv = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 5rem 0 ${spacings.large} 0;
+  @media (max-width: ${breakpoints.tablet}) {
+    flex-flow: column;
+    align-items: stretch;
+  }
+  @media print {
+    display: none;
+  }
+`;
+
+const StyledButtonReverse = styled(StyledButton)`
+  margin-left: auto;
+`;
+
+const ArrowIcon = styled(icons.DirectionRight)`
+  width: 3rem;
+  margin-left: ${spacings.small};
+`;

--- a/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/StepList/__tests__/StepList.test.tsx
+++ b/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/StepList/__tests__/StepList.test.tsx
@@ -1,0 +1,64 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import StepList from "../index";
+
+const steps = [
+  {
+    label: "Introduction",
+    name: "intro",
+  },
+  {
+    label: "Convention collective",
+    name: "agreement",
+  },
+  {
+    label: "Informations",
+    name: "infos",
+  },
+  {
+    label: "Résultat",
+    name: "result",
+  },
+];
+
+describe("StepList", () => {
+  describe("Show multiple steps with first active", () => {
+    it("should show the count of steps", () => {
+      const { getByText } = render(
+        <StepList activeIndex={0} steps={steps} width={"28rem"} />
+      );
+      expect(getByText(/1\/4/)).toBeInTheDocument();
+    });
+
+    it("should show all steps", () => {
+      const { getByText, getAllByRole } = render(
+        <StepList activeIndex={0} steps={steps} width={"28rem"} />
+      );
+      const li = getAllByRole("listitem");
+      expect(li).toHaveLength(steps.length);
+      steps.forEach((step) => {
+        expect(getByText(new RegExp(step.label))).toBeInTheDocument();
+      });
+    });
+
+    it("should have the first item active", () => {
+      const { getByRole } = render(
+        <StepList activeIndex={0} steps={steps} width={"28rem"} />
+      );
+      const li = getByRole("listitem", { name: "onglet actif" });
+      expect(li).toBeInTheDocument();
+      expect(li.innerHTML).toContain(steps[0].label);
+    });
+  });
+
+  describe("Show multiple steps with third step active", () => {
+    it("should have the third item active", () => {
+      const { getByRole } = render(
+        <StepList activeIndex={2} steps={steps} width={"28rem"} />
+      );
+      const li = getByRole("listitem", { name: "onglet actif" });
+      expect(li).toBeInTheDocument();
+      expect(li.innerHTML).toContain(steps[2].label);
+    });
+  });
+});

--- a/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/StepList/index.tsx
+++ b/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/StepList/index.tsx
@@ -19,7 +19,7 @@ const Index = ({
   listRef,
 }: StepListProps): JSX.Element => {
   return (
-    <StyledWrapper variant="dark" width={width}>
+    <StyledWrapper variant="dark" defaultWidth={width}>
       <Title>
         Étape<HideOnMobile>s</HideOnMobile>
         <StepProgress>
@@ -52,14 +52,14 @@ export default Index;
 
 const { box, spacings, breakpoints } = theme;
 
-const StyledWrapper = styled(Wrapper)<{ width: string }>`
+const StyledWrapper = styled(Wrapper)<{ defaultWidth: string }>`
   position: absolute;
   top: 0;
   bottom: 0;
   left: 0;
   display: flex;
   flex-direction: column;
-  width: ${({ width }) => width};
+  width: ${({ defaultWidth }) => defaultWidth};
   padding: 6rem ${spacings.larger} ${spacings.larger} ${spacings.larger};
   border-radius: ${box.borderRadius} 0 0 ${box.borderRadius};
   @media (max-width: ${breakpoints.tablet}) {

--- a/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/StepList/index.tsx
+++ b/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/StepList/index.tsx
@@ -1,0 +1,137 @@
+import { FlatList, theme, Wrapper } from "@socialgouv/cdtn-ui";
+import React from "react";
+import styled from "styled-components";
+
+export type StepListProps = {
+  activeIndex: number;
+  steps: {
+    name: string;
+    label: string;
+  }[];
+  width: string;
+  listRef?: React.Ref<HTMLLIElement>;
+};
+
+const Index = ({
+  activeIndex,
+  steps,
+  width,
+  listRef,
+}: StepListProps): JSX.Element => {
+  return (
+    <StyledWrapper variant="dark" width={width}>
+      <Title>
+        Étape<HideOnMobile>s</HideOnMobile>
+        <StepProgress>
+          &nbsp;{`${activeIndex + 1}/${steps.length}`}
+        </StepProgress>
+      </Title>
+      <FlatList as="ol">
+        {steps.map((item, index) => (
+          <StyledListItem
+            key={item.name}
+            index={index}
+            isActive={activeIndex === index}
+            ref={activeIndex === index ? listRef : undefined}
+            tabIndex={activeIndex === index ? "-1" : undefined}
+            aria-live={activeIndex === index ? "polite" : undefined}
+            title={activeIndex === index ? "onglet actif" : null}
+          >
+            <IndexCircle isActive={activeIndex === index}>
+              {index + 1}
+            </IndexCircle>
+            {item.label}
+          </StyledListItem>
+        ))}
+      </FlatList>
+    </StyledWrapper>
+  );
+};
+
+export default Index;
+
+const { box, spacings, breakpoints } = theme;
+
+const StyledWrapper = styled(Wrapper)<{ width: string }>`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  flex-direction: column;
+  width: ${({ width }) => width};
+  padding: 6rem ${spacings.larger} ${spacings.larger} ${spacings.larger};
+  border-radius: ${box.borderRadius} 0 0 ${box.borderRadius};
+  @media (max-width: ${breakpoints.tablet}) {
+    position: relative;
+    flex-direction: row-reverse;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    margin: 0;
+    padding: ${spacings.base} ${spacings.small};
+    border-radius: ${box.borderRadius};
+  }
+  @media print {
+    display: none;
+  }
+`;
+
+const Title = styled.span.attrs({
+  "aria-level": "2",
+  role: "heading",
+})`
+  margin: ${spacings.medium} 0;
+  font-weight: 600;
+  @media (max-width: ${breakpoints.tablet}) {
+    margin: 0;
+  }
+`;
+const HideOnMobile = styled.span`
+  @media (max-width: ${breakpoints.tablet}) {
+    display: none;
+  }
+`;
+const StepProgress = styled.span`
+  display: none;
+  @media (max-width: ${breakpoints.tablet}) {
+    display: inline-block;
+  }
+`;
+
+const StyledListItem = styled.li`
+  display: flex;
+  align-items: center;
+  color: ${({ isActive, theme }) =>
+    isActive ? theme.altText : theme.placeholder};
+  font-weight: 600;
+  line-height: 1;
+  text-align: left;
+  text-decoration: none;
+  & + & {
+    margin-top: ${spacings.base};
+  }
+  outline: none; /* StepListItem may receive focus in order to improve accessibility */
+  @media (max-width: ${breakpoints.tablet}) {
+    display: ${({ isActive }) => (isActive ? "flex" : "none")};
+    & + & {
+      margin-top: 0;
+    }
+  }
+`;
+
+const IndexCircle = styled.span`
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 2.8rem;
+  height: 2.8rem;
+  margin: ${spacings.tiny} ${spacings.small};
+  margin-left: 0;
+  color: ${({ isActive, theme }) =>
+    isActive ? theme.white : theme.placeholder};
+  background-color: ${({ isActive, theme }) =>
+    isActive ? theme.secondary : theme.bgTertiary};
+  border-radius: 49%;
+`;

--- a/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/Title/__tests__/Title.test.tsx
+++ b/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/Title/__tests__/Title.test.tsx
@@ -1,0 +1,18 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import Title from "../index";
+
+describe("Title", () => {
+  describe("Show the title of the simulator", () => {
+    it("should show the title", () => {
+      const { getByText } = render(<Title title="Simulateur titre" />);
+      expect(getByText(/Simulateur titre/)).toBeInTheDocument();
+    });
+    it("should show the duration", () => {
+      const { getByText } = render(
+        <Title title="Simulateur titre" icon="" duration="5 min" />
+      );
+      expect(getByText(/5 min/)).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/Title/index.tsx
+++ b/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/Title/index.tsx
@@ -1,0 +1,89 @@
+import { icons, theme } from "@socialgouv/cdtn-ui";
+import React from "react";
+import styled from "styled-components";
+
+export type TitleProps = {
+  duration?: string;
+  hasNoMarginBottom?: boolean;
+  icon?: string;
+  title: string;
+};
+
+const Duration = ({ duration }: { duration: string }): JSX.Element => {
+  return (
+    <ToolDuration key="test">
+      <TimeWithLabel aria-hidden="true" />
+      <ToolDurationLabel>{duration}</ToolDurationLabel>
+    </ToolDuration>
+  );
+};
+
+const Index = ({
+  title,
+  icon,
+  duration,
+  hasNoMarginBottom,
+}: TitleProps): JSX.Element => {
+  const Icon = icons[icon];
+  return (
+    <ToolTitle hasNoMarginBottom={hasNoMarginBottom}>
+      <StyledTitleBox>
+        {Icon && (
+          <IconWrapper>
+            <Icon />
+          </IconWrapper>
+        )}
+        <StyledTitle>{title}</StyledTitle>
+      </StyledTitleBox>
+      {duration && <Duration duration={duration} />}
+    </ToolTitle>
+  );
+};
+
+export default Index;
+
+const { breakpoints, spacings, fonts } = theme;
+
+const ToolTitle = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: ${(props) =>
+    props.hasNoMarginBottom ? "0px" : spacings.large};
+  padding-bottom: ${spacings.base};
+  border-bottom: 1px solid ${({ theme }) => theme.border};
+  @media (max-width: ${breakpoints.tablet}) {
+    margin-bottom: ${spacings.base};
+    padding: ${spacings.base} 0 ${spacings.small} 0;
+    border-bottom: 0;
+  }
+`;
+
+const StyledTitle = styled.h1`
+  margin: 0;
+`;
+const StyledTitleBox = styled.div`
+  display: flex;
+  align-items: center;
+`;
+const IconWrapper = styled.span`
+  flex: 0 0 auto;
+  width: 5.2rem;
+  height: 5.2rem;
+  margin-right: ${spacings.base};
+`;
+
+const ToolDuration = styled.div`
+  position: relative;
+  padding-right: 45px;
+`;
+const ToolDurationLabel = styled.span`
+  position: absolute;
+  bottom: 3px;
+  left: 28px;
+  font-size: ${fonts.sizes.tiny};
+  color: ${({ theme }) => theme.paragraph};
+`;
+const TimeWithLabel = styled(icons.TimeWithLabel)`
+  width: 4.2rem;
+`;

--- a/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/index.ts
+++ b/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/index.ts
@@ -1,0 +1,5 @@
+export { default as DebugInfo } from "./DebugInfo";
+export { default as FormStateToReducer } from "./FormStateToReducer";
+export { default as Navigation } from "./Navigation";
+export { default as StepList } from "./StepList";
+export { default as Title } from "./Title";

--- a/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/types.ts
+++ b/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/Components/types.ts
@@ -1,0 +1,5 @@
+import type { NavigationProps } from "./Navigation";
+import type { StepListProps } from "./StepList";
+import type { TitleProps } from "./Title";
+
+export type { NavigationProps, StepListProps, TitleProps };

--- a/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/__tests__/SimulatorDecorator.test.tsx
+++ b/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/__tests__/SimulatorDecorator.test.tsx
@@ -1,0 +1,43 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import SimulatorDecorator from "../index";
+import { FormApi } from "final-form";
+
+type FormState = {
+  name?: string;
+};
+
+const callback: (values: FormState, form: FormApi<FormState>) => void = () => {
+  /* nothing to do */
+};
+const onFormStepSubmit = jest.fn(callback);
+
+describe("SimulatorDecorator", () => {
+  describe("Render a step", () => {
+    it("should show all information provided to the decorator", () => {
+      const { getByText } = render(
+        <SimulatorDecorator<FormState>
+          initialValues={{ name: "John" }}
+          title={{ title: "Titre du simulateur" }}
+          navigation={{ showNext: true }}
+          steps={{
+            activeIndex: 0,
+            steps: [],
+          }}
+          onFormStepSubmit={onFormStepSubmit}
+          showDebug={false}
+          renderStep={(values) => <>Nom: {values.getState().values.name}</>}
+          Annotations={() => <>Rendu des annotations</>}
+        />
+      );
+      expect(getByText(/Nom: John/)).toBeInTheDocument();
+      expect(getByText(/Rendu des annotations/)).toBeInTheDocument();
+      expect(getByText(/Titre du simulateur/)).toBeInTheDocument();
+
+      const startButton = getByText(/Commencer/);
+      expect(startButton).toBeInTheDocument();
+      startButton.click();
+      expect(onFormStepSubmit).toBeCalledTimes(1);
+    });
+  });
+});

--- a/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/__tests__/SimulatorDecorator.test.tsx
+++ b/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/__tests__/SimulatorDecorator.test.tsx
@@ -27,7 +27,7 @@ describe("SimulatorDecorator", () => {
           onFormStepSubmit={onFormStepSubmit}
           showDebug={false}
           renderStep={(values) => <>Nom: {values.getState().values.name}</>}
-          Annotations={() => <>Rendu des annotations</>}
+          annotations={<>Rendu des annotations</>}
         />
       );
       expect(getByText(/Nom: John/)).toBeInTheDocument();

--- a/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/index.tsx
+++ b/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/index.tsx
@@ -1,0 +1,114 @@
+import { theme, Wrapper } from "@socialgouv/cdtn-ui";
+import React from "react";
+import { Form } from "react-final-form";
+import styled from "styled-components";
+
+import {
+  DebugInfo,
+  FormStateToReducer,
+  Navigation,
+  StepList,
+  Title,
+} from "./Components";
+import type {
+  NavigationProps,
+  StepListProps,
+  TitleProps,
+} from "./Components/types";
+import { Decorator, FormApi, Mutator, ValidationErrors } from "final-form";
+
+type Props<FormValues> = {
+  title: TitleProps;
+  navigation: Omit<Omit<NavigationProps, "hasError">, "onPrevious"> & {
+    onPrevious?: (values: FormValues) => void;
+  };
+  steps: Omit<StepListProps, "width">;
+  initialValues?: FormValues;
+  onFormStateUpdate?: (values: FormValues) => void;
+  onFormStepSubmit: (values: FormValues, form: FormApi<FormValues>) => void;
+  showDebug: boolean;
+  validate?: (
+    values: FormValues
+  ) => ValidationErrors | Promise<ValidationErrors>;
+  decorators?: Array<Decorator<FormValues, Partial<FormValues>>>;
+  mutators?: { [key: string]: Mutator<FormValues, Partial<FormValues>> };
+  Annotations?: () => JSX.Element;
+  renderStep: (form: FormApi<FormValues>) => JSX.Element;
+};
+
+const SimulatorDecorator = <FormValues,>({
+  title,
+  navigation,
+  steps,
+  initialValues,
+  onFormStateUpdate,
+  onFormStepSubmit,
+  showDebug,
+  validate,
+  decorators,
+  mutators,
+  Annotations,
+  renderStep,
+}: Props<FormValues>): JSX.Element => {
+  const onPrevious = navigation.onPrevious;
+
+  return (
+    <Wrapper variant="main">
+      <Form<FormValues>
+        initialValues={initialValues}
+        onSubmit={onFormStepSubmit}
+        validate={validate}
+        decorators={decorators}
+        mutators={mutators}
+      >
+        {({ handleSubmit, form, invalid, submitFailed }) => {
+          return (
+            <StyledForm onSubmit={handleSubmit}>
+              {onFormStateUpdate && (
+                <FormStateToReducer<FormValues>
+                  updateFormState={onFormStateUpdate}
+                />
+              )}
+              <Title {...title} />
+              <StepList {...steps} width={STEP_LIST_WIDTH} />
+              {renderStep(form)}
+              <Navigation
+                {...navigation}
+                hasError={invalid && submitFailed}
+                onPrevious={
+                  onPrevious &&
+                  (() => {
+                    onPrevious(form.getState().values);
+                  })
+                }
+              />
+              {Annotations && (
+                <p>
+                  <Annotations />
+                </p>
+              )}
+              {showDebug && <DebugInfo formValues={form.getState().values} />}
+            </StyledForm>
+          );
+        }}
+      </Form>
+    </Wrapper>
+  );
+};
+
+export default SimulatorDecorator;
+
+const STEP_LIST_WIDTH = "28rem";
+
+const { breakpoints } = theme;
+
+const StyledForm = styled.form`
+  padding: 0 0 0 ${STEP_LIST_WIDTH};
+  overflow: visible;
+  @media (max-width: ${breakpoints.tablet}) {
+    padding: 0;
+  }
+  @media print {
+    border: 0;
+  }
+`;

--- a/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/index.tsx
+++ b/packages/code-du-travail-frontend/src/outils/Components/SimulatorDecorator/index.tsx
@@ -32,7 +32,7 @@ type Props<FormValues> = {
   ) => ValidationErrors | Promise<ValidationErrors>;
   decorators?: Array<Decorator<FormValues, Partial<FormValues>>>;
   mutators?: { [key: string]: Mutator<FormValues, Partial<FormValues>> };
-  Annotations?: () => JSX.Element;
+  annotations?: JSX.Element;
   renderStep: (form: FormApi<FormValues>) => JSX.Element;
 };
 
@@ -47,7 +47,7 @@ const SimulatorDecorator = <FormValues,>({
   validate,
   decorators,
   mutators,
-  Annotations,
+  annotations,
   renderStep,
 }: Props<FormValues>): JSX.Element => {
   const onPrevious = navigation.onPrevious;
@@ -82,11 +82,7 @@ const SimulatorDecorator = <FormValues,>({
                   })
                 }
               />
-              {Annotations && (
-                <p>
-                  <Annotations />
-                </p>
-              )}
+              {annotations && <p>{annotations}</p>}
               {showDebug && <DebugInfo formValues={form.getState().values} />}
             </StyledForm>
           );

--- a/packages/code-du-travail-frontend/src/outils/Components/index.ts
+++ b/packages/code-du-travail-frontend/src/outils/Components/index.ts
@@ -1,0 +1,1 @@
+export { default as SimulatorDecorator } from "./SimulatorDecorator";

--- a/packages/code-du-travail-frontend/src/outils/ConventionCollective/index.tsx
+++ b/packages/code-du-travail-frontend/src/outils/ConventionCollective/index.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 
 import { Enterprise } from "../../conventions/Search/api/enterprises.service";
-import { WizardTitle } from "../common/Wizard";
+import { Title } from "../Components/SimulatorDecorator/Components";
 import {
   NavProvider,
   ScreenType,
@@ -140,7 +140,7 @@ function AgreementSearchTool({ icon, title }: Props): JSX.Element {
   }
   return (
     <WizardWrapper variant="main">
-      <WizardTitle title={title} icon={icon} />
+      <Title title={title} icon={icon} />
       {Step}
     </WizardWrapper>
   );

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisDemission/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisDemission/__tests__/__snapshots__/index.test.tsx.snap
@@ -263,11 +263,6 @@ exports[`<DureePreavisDemission /> should render 1`] = `
   border-radius: 49%;
 }
 
-.c1 {
-  padding: 0 0 0 28rem;
-  overflow: visible;
-}
-
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -284,6 +279,21 @@ exports[`<DureePreavisDemission /> should render 1`] = `
   margin-bottom: 3.2rem;
   padding-bottom: 1.6rem;
   border-bottom: 1px solid #bbcadf;
+}
+
+.c4 {
+  margin: 0;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c5 {
@@ -303,19 +313,9 @@ exports[`<DureePreavisDemission /> should render 1`] = `
   width: 4.2rem;
 }
 
-.c4 {
-  margin: 0;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c1 {
+  padding: 0 0 0 28rem;
+  overflow: visible;
 }
 
 @media print {
@@ -461,6 +461,14 @@ exports[`<DureePreavisDemission /> should render 1`] = `
 }
 
 @media (max-width:980px) {
+  .c2 {
+    margin-bottom: 1.6rem;
+    padding: 1.6rem 0 1rem 0;
+    border-bottom: 0;
+  }
+}
+
+@media (max-width:980px) {
   .c1 {
     padding: 0;
   }
@@ -469,14 +477,6 @@ exports[`<DureePreavisDemission /> should render 1`] = `
 @media print {
   .c1 {
     border: 0;
-  }
-}
-
-@media (max-width:980px) {
-  .c2 {
-    margin-bottom: 1.6rem;
-    padding: 1.6rem 0 1rem 0;
-    border-bottom: 0;
   }
 }
 
@@ -551,6 +551,7 @@ exports[`<DureePreavisDemission /> should render 1`] = `
       </div>
       <div
         class="c8 c9"
+        width="28rem"
       >
         <span
           aria-level="2"

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisDemission/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisDemission/__tests__/__snapshots__/index.test.tsx.snap
@@ -551,7 +551,6 @@ exports[`<DureePreavisDemission /> should render 1`] = `
       </div>
       <div
         class="c8 c9"
-        width="28rem"
       >
         <span
           aria-level="2"

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisDemission/steps/AgreementStep.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisDemission/steps/AgreementStep.tsx
@@ -5,19 +5,14 @@ import { SelectAgreement } from "../../common";
 import { getSupportedCC } from "../../common/situations.utils";
 import { WizardStepProps } from "../../common/type/WizardType";
 
-export const AgreementStep = (props: WizardStepProps): JSX.Element => {
-  console.log("Step; ", props.form.getState().values);
-  return (
-    <>
-      <SelectAgreement
-        title={props.title}
-        form={props.form}
-        onChange={() => {
-          // Delete infos when change CC
-          props.form.change("infos", undefined);
-        }}
-        supportedAgreements={getSupportedCC(data.situations)}
-      />
-    </>
-  );
-};
+export const AgreementStep = (props: WizardStepProps): JSX.Element => (
+  <SelectAgreement
+    title={props.title}
+    form={props.form}
+    onChange={() => {
+      // Delete infos when change CC
+      props.form.change("infos", undefined);
+    }}
+    supportedAgreements={getSupportedCC(data.situations)}
+  />
+);

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisDemission/steps/AgreementStep.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisDemission/steps/AgreementStep.tsx
@@ -6,6 +6,7 @@ import { getSupportedCC } from "../../common/situations.utils";
 import { WizardStepProps } from "../../common/type/WizardType";
 
 export const AgreementStep = (props: WizardStepProps): JSX.Element => {
+  console.log("Step; ", props.form.getState().values);
   return (
     <>
       <SelectAgreement

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisLicenciement/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisLicenciement/__tests__/__snapshots__/index.test.js.snap
@@ -551,7 +551,6 @@ exports[`<DureePreavisLicenciement /> should render 1`] = `
       </div>
       <div
         class="c8 c9"
-        width="28rem"
       >
         <span
           aria-level="2"

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisLicenciement/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisLicenciement/__tests__/__snapshots__/index.test.js.snap
@@ -263,11 +263,6 @@ exports[`<DureePreavisLicenciement /> should render 1`] = `
   border-radius: 49%;
 }
 
-.c1 {
-  padding: 0 0 0 28rem;
-  overflow: visible;
-}
-
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -284,6 +279,21 @@ exports[`<DureePreavisLicenciement /> should render 1`] = `
   margin-bottom: 3.2rem;
   padding-bottom: 1.6rem;
   border-bottom: 1px solid #bbcadf;
+}
+
+.c4 {
+  margin: 0;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c5 {
@@ -303,19 +313,9 @@ exports[`<DureePreavisLicenciement /> should render 1`] = `
   width: 4.2rem;
 }
 
-.c4 {
-  margin: 0;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c1 {
+  padding: 0 0 0 28rem;
+  overflow: visible;
 }
 
 @media print {
@@ -461,6 +461,14 @@ exports[`<DureePreavisLicenciement /> should render 1`] = `
 }
 
 @media (max-width:980px) {
+  .c2 {
+    margin-bottom: 1.6rem;
+    padding: 1.6rem 0 1rem 0;
+    border-bottom: 0;
+  }
+}
+
+@media (max-width:980px) {
   .c1 {
     padding: 0;
   }
@@ -469,14 +477,6 @@ exports[`<DureePreavisLicenciement /> should render 1`] = `
 @media print {
   .c1 {
     border: 0;
-  }
-}
-
-@media (max-width:980px) {
-  .c2 {
-    margin-bottom: 1.6rem;
-    padding: 1.6rem 0 1rem 0;
-    border-bottom: 0;
   }
 }
 
@@ -551,6 +551,7 @@ exports[`<DureePreavisLicenciement /> should render 1`] = `
       </div>
       <div
         class="c8 c9"
+        width="28rem"
       >
         <span
           aria-level="2"

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/stepReducer.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/stepReducer.tsx
@@ -15,7 +15,7 @@ export const initialState: State = {
   stepIndex: 0,
   steps: [
     {
-      annotation: IntroAnnotation,
+      annotation: <IntroAnnotation />,
       component: () => <Steps.IntroductionStep />,
       label: "Introduction",
       name: "intro",

--- a/packages/code-du-travail-frontend/src/outils/HeuresRechercheEmploi/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/code-du-travail-frontend/src/outils/HeuresRechercheEmploi/__tests__/__snapshots__/index.test.tsx.snap
@@ -551,7 +551,6 @@ exports[`<HeuresRechercheEmploi /> should render 1`] = `
       </div>
       <div
         class="c8 c9"
-        width="28rem"
       >
         <span
           aria-level="2"

--- a/packages/code-du-travail-frontend/src/outils/HeuresRechercheEmploi/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/code-du-travail-frontend/src/outils/HeuresRechercheEmploi/__tests__/__snapshots__/index.test.tsx.snap
@@ -263,11 +263,6 @@ exports[`<HeuresRechercheEmploi /> should render 1`] = `
   border-radius: 49%;
 }
 
-.c1 {
-  padding: 0 0 0 28rem;
-  overflow: visible;
-}
-
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -284,6 +279,21 @@ exports[`<HeuresRechercheEmploi /> should render 1`] = `
   margin-bottom: 3.2rem;
   padding-bottom: 1.6rem;
   border-bottom: 1px solid #bbcadf;
+}
+
+.c4 {
+  margin: 0;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c5 {
@@ -303,19 +313,9 @@ exports[`<HeuresRechercheEmploi /> should render 1`] = `
   width: 4.2rem;
 }
 
-.c4 {
-  margin: 0;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c1 {
+  padding: 0 0 0 28rem;
+  overflow: visible;
 }
 
 @media print {
@@ -461,6 +461,14 @@ exports[`<HeuresRechercheEmploi /> should render 1`] = `
 }
 
 @media (max-width:980px) {
+  .c2 {
+    margin-bottom: 1.6rem;
+    padding: 1.6rem 0 1rem 0;
+    border-bottom: 0;
+  }
+}
+
+@media (max-width:980px) {
   .c1 {
     padding: 0;
   }
@@ -469,14 +477,6 @@ exports[`<HeuresRechercheEmploi /> should render 1`] = `
 @media print {
   .c1 {
     border: 0;
-  }
-}
-
-@media (max-width:980px) {
-  .c2 {
-    margin-bottom: 1.6rem;
-    padding: 1.6rem 0 1rem 0;
-    border-bottom: 0;
   }
 }
 
@@ -551,6 +551,7 @@ exports[`<HeuresRechercheEmploi /> should render 1`] = `
       </div>
       <div
         class="c8 c9"
+        width="28rem"
       >
         <span
           aria-level="2"

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/__tests__/__snapshots__/index.test.js.snap
@@ -263,11 +263,6 @@ exports[`<CalculateurIndemnite /> should render 1`] = `
   border-radius: 49%;
 }
 
-.c1 {
-  padding: 0 0 0 28rem;
-  overflow: visible;
-}
-
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -284,6 +279,21 @@ exports[`<CalculateurIndemnite /> should render 1`] = `
   margin-bottom: 3.2rem;
   padding-bottom: 1.6rem;
   border-bottom: 1px solid #bbcadf;
+}
+
+.c4 {
+  margin: 0;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c5 {
@@ -303,19 +313,9 @@ exports[`<CalculateurIndemnite /> should render 1`] = `
   width: 4.2rem;
 }
 
-.c4 {
-  margin: 0;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c1 {
+  padding: 0 0 0 28rem;
+  overflow: visible;
 }
 
 @media print {
@@ -461,6 +461,14 @@ exports[`<CalculateurIndemnite /> should render 1`] = `
 }
 
 @media (max-width:980px) {
+  .c2 {
+    margin-bottom: 1.6rem;
+    padding: 1.6rem 0 1rem 0;
+    border-bottom: 0;
+  }
+}
+
+@media (max-width:980px) {
   .c1 {
     padding: 0;
   }
@@ -469,14 +477,6 @@ exports[`<CalculateurIndemnite /> should render 1`] = `
 @media print {
   .c1 {
     border: 0;
-  }
-}
-
-@media (max-width:980px) {
-  .c2 {
-    margin-bottom: 1.6rem;
-    padding: 1.6rem 0 1rem 0;
-    border-bottom: 0;
   }
 }
 
@@ -551,6 +551,7 @@ exports[`<CalculateurIndemnite /> should render 1`] = `
       </div>
       <div
         class="c8 c9"
+        width="28rem"
       >
         <span
           aria-level="2"

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/__tests__/__snapshots__/index.test.js.snap
@@ -551,7 +551,6 @@ exports[`<CalculateurIndemnite /> should render 1`] = `
       </div>
       <div
         class="c8 c9"
-        width="28rem"
       >
         <span
           aria-level="2"

--- a/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/__tests__/__snapshots__/index.test.js.snap
@@ -263,11 +263,6 @@ exports[`<SimulateurIndemnitePrecarite /> should render 1`] = `
   border-radius: 49%;
 }
 
-.c1 {
-  padding: 0 0 0 28rem;
-  overflow: visible;
-}
-
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -284,6 +279,21 @@ exports[`<SimulateurIndemnitePrecarite /> should render 1`] = `
   margin-bottom: 3.2rem;
   padding-bottom: 1.6rem;
   border-bottom: 1px solid #bbcadf;
+}
+
+.c4 {
+  margin: 0;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c5 {
@@ -303,19 +313,9 @@ exports[`<SimulateurIndemnitePrecarite /> should render 1`] = `
   width: 4.2rem;
 }
 
-.c4 {
-  margin: 0;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c1 {
+  padding: 0 0 0 28rem;
+  overflow: visible;
 }
 
 @media print {
@@ -461,6 +461,14 @@ exports[`<SimulateurIndemnitePrecarite /> should render 1`] = `
 }
 
 @media (max-width:980px) {
+  .c2 {
+    margin-bottom: 1.6rem;
+    padding: 1.6rem 0 1rem 0;
+    border-bottom: 0;
+  }
+}
+
+@media (max-width:980px) {
   .c1 {
     padding: 0;
   }
@@ -469,14 +477,6 @@ exports[`<SimulateurIndemnitePrecarite /> should render 1`] = `
 @media print {
   .c1 {
     border: 0;
-  }
-}
-
-@media (max-width:980px) {
-  .c2 {
-    margin-bottom: 1.6rem;
-    padding: 1.6rem 0 1rem 0;
-    border-bottom: 0;
   }
 }
 
@@ -551,6 +551,7 @@ exports[`<SimulateurIndemnitePrecarite /> should render 1`] = `
       </div>
       <div
         class="c8 c9"
+        width="28rem"
       >
         <span
           aria-level="2"

--- a/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/__tests__/__snapshots__/index.test.js.snap
@@ -551,7 +551,6 @@ exports[`<SimulateurIndemnitePrecarite /> should render 1`] = `
       </div>
       <div
         class="c8 c9"
-        width="28rem"
       >
         <span
           aria-level="2"

--- a/packages/code-du-travail-frontend/src/outils/common/Wizard.tsx
+++ b/packages/code-du-travail-frontend/src/outils/common/Wizard.tsx
@@ -159,7 +159,7 @@ export const Wizard = ({
         mutators={{
           ...arrayMutators,
         }}
-        Annotations={Annotation}
+        annotations={Annotation}
         renderStep={(form) => {
           return (
             <>

--- a/packages/code-du-travail-frontend/src/outils/common/__tests__/__snapshots__/Wizard.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/common/__tests__/__snapshots__/Wizard.test.js.snap
@@ -505,7 +505,6 @@ exports[`<Wizard /> should call navigate the previous step when click on précé
       </div>
       <div
         class="c5 c6"
-        width="28rem"
       >
         <span
           aria-level="2"
@@ -1134,7 +1133,6 @@ exports[`<Wizard /> should handle initialState.stepIndex 1`] = `
       </div>
       <div
         class="c5 c6"
-        width="28rem"
       >
         <span
           aria-level="2"
@@ -1702,7 +1700,6 @@ exports[`<Wizard /> should handle initialValues 1`] = `
       </div>
       <div
         class="c5 c6"
-        width="28rem"
       >
         <span
           aria-level="2"
@@ -2274,7 +2271,6 @@ exports[`<Wizard /> should inject rules component 1`] = `
       </div>
       <div
         class="c5 c6"
-        width="28rem"
       >
         <span
           aria-level="2"
@@ -2918,7 +2914,6 @@ exports[`<Wizard /> should navigate to the second step when click on Commencer 1
       </div>
       <div
         class="c5 c6"
-        width="28rem"
       >
         <span
           aria-level="2"
@@ -3486,7 +3481,6 @@ exports[`<Wizard /> should render a step 1`] = `
       </div>
       <div
         class="c5 c6"
-        width="28rem"
       >
         <span
           aria-level="2"

--- a/packages/code-du-travail-frontend/src/outils/common/__tests__/__snapshots__/Wizard.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/common/__tests__/__snapshots__/Wizard.test.js.snap
@@ -263,11 +263,6 @@ exports[`<Wizard /> should call navigate the previous step when click on précé
   border-radius: 49%;
 }
 
-.c1 {
-  padding: 0 0 0 28rem;
-  overflow: visible;
-}
-
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -299,6 +294,11 @@ exports[`<Wizard /> should call navigate the previous step when click on précé
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c1 {
+  padding: 0 0 0 28rem;
+  overflow: visible;
 }
 
 @media print {
@@ -464,6 +464,14 @@ exports[`<Wizard /> should call navigate the previous step when click on précé
 }
 
 @media (max-width:980px) {
+  .c2 {
+    margin-bottom: 1.6rem;
+    padding: 1.6rem 0 1rem 0;
+    border-bottom: 0;
+  }
+}
+
+@media (max-width:980px) {
   .c1 {
     padding: 0;
   }
@@ -472,14 +480,6 @@ exports[`<Wizard /> should call navigate the previous step when click on précé
 @media print {
   .c1 {
     border: 0;
-  }
-}
-
-@media (max-width:980px) {
-  .c2 {
-    margin-bottom: 1.6rem;
-    padding: 1.6rem 0 1rem 0;
-    border-bottom: 0;
   }
 }
 
@@ -505,6 +505,7 @@ exports[`<Wizard /> should call navigate the previous step when click on précé
       </div>
       <div
         class="c5 c6"
+        width="28rem"
       >
         <span
           aria-level="2"
@@ -899,11 +900,6 @@ exports[`<Wizard /> should handle initialState.stepIndex 1`] = `
   border-radius: 49%;
 }
 
-.c1 {
-  padding: 0 0 0 28rem;
-  overflow: visible;
-}
-
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -935,6 +931,11 @@ exports[`<Wizard /> should handle initialState.stepIndex 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c1 {
+  padding: 0 0 0 28rem;
+  overflow: visible;
 }
 
 @media print {
@@ -1092,6 +1093,14 @@ exports[`<Wizard /> should handle initialState.stepIndex 1`] = `
 }
 
 @media (max-width:980px) {
+  .c2 {
+    margin-bottom: 1.6rem;
+    padding: 1.6rem 0 1rem 0;
+    border-bottom: 0;
+  }
+}
+
+@media (max-width:980px) {
   .c1 {
     padding: 0;
   }
@@ -1100,14 +1109,6 @@ exports[`<Wizard /> should handle initialState.stepIndex 1`] = `
 @media print {
   .c1 {
     border: 0;
-  }
-}
-
-@media (max-width:980px) {
-  .c2 {
-    margin-bottom: 1.6rem;
-    padding: 1.6rem 0 1rem 0;
-    border-bottom: 0;
   }
 }
 
@@ -1133,6 +1134,7 @@ exports[`<Wizard /> should handle initialState.stepIndex 1`] = `
       </div>
       <div
         class="c5 c6"
+        width="28rem"
       >
         <span
           aria-level="2"
@@ -1478,11 +1480,6 @@ exports[`<Wizard /> should handle initialValues 1`] = `
   border-radius: 49%;
 }
 
-.c1 {
-  padding: 0 0 0 28rem;
-  overflow: visible;
-}
-
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1514,6 +1511,11 @@ exports[`<Wizard /> should handle initialValues 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c1 {
+  padding: 0 0 0 28rem;
+  overflow: visible;
 }
 
 @media print {
@@ -1659,6 +1661,14 @@ exports[`<Wizard /> should handle initialValues 1`] = `
 }
 
 @media (max-width:980px) {
+  .c2 {
+    margin-bottom: 1.6rem;
+    padding: 1.6rem 0 1rem 0;
+    border-bottom: 0;
+  }
+}
+
+@media (max-width:980px) {
   .c1 {
     padding: 0;
   }
@@ -1667,14 +1677,6 @@ exports[`<Wizard /> should handle initialValues 1`] = `
 @media print {
   .c1 {
     border: 0;
-  }
-}
-
-@media (max-width:980px) {
-  .c2 {
-    margin-bottom: 1.6rem;
-    padding: 1.6rem 0 1rem 0;
-    border-bottom: 0;
   }
 }
 
@@ -1700,6 +1702,7 @@ exports[`<Wizard /> should handle initialValues 1`] = `
       </div>
       <div
         class="c5 c6"
+        width="28rem"
       >
         <span
           aria-level="2"
@@ -2049,11 +2052,6 @@ exports[`<Wizard /> should inject rules component 1`] = `
   border-radius: 49%;
 }
 
-.c1 {
-  padding: 0 0 0 28rem;
-  overflow: visible;
-}
-
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -2085,6 +2083,11 @@ exports[`<Wizard /> should inject rules component 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c1 {
+  padding: 0 0 0 28rem;
+  overflow: visible;
 }
 
 @media print {
@@ -2230,6 +2233,14 @@ exports[`<Wizard /> should inject rules component 1`] = `
 }
 
 @media (max-width:980px) {
+  .c2 {
+    margin-bottom: 1.6rem;
+    padding: 1.6rem 0 1rem 0;
+    border-bottom: 0;
+  }
+}
+
+@media (max-width:980px) {
   .c1 {
     padding: 0;
   }
@@ -2241,14 +2252,6 @@ exports[`<Wizard /> should inject rules component 1`] = `
   }
 }
 
-@media (max-width:980px) {
-  .c2 {
-    margin-bottom: 1.6rem;
-    padding: 1.6rem 0 1rem 0;
-    border-bottom: 0;
-  }
-}
-
 <div>
   <div
     class="c0"
@@ -2256,9 +2259,6 @@ exports[`<Wizard /> should inject rules component 1`] = `
     <form
       class="c1"
     >
-      <p>
-        Rule
-      </p>
       <div
         class="c2"
       >
@@ -2274,6 +2274,7 @@ exports[`<Wizard /> should inject rules component 1`] = `
       </div>
       <div
         class="c5 c6"
+        width="28rem"
       >
         <span
           aria-level="2"
@@ -2321,6 +2322,9 @@ exports[`<Wizard /> should inject rules component 1`] = `
           </li>
         </ol>
       </div>
+      <p>
+        Rule
+      </p>
       <p>
         Premiere Etape
       </p>
@@ -2668,11 +2672,6 @@ exports[`<Wizard /> should navigate to the second step when click on Commencer 1
   border-radius: 49%;
 }
 
-.c1 {
-  padding: 0 0 0 28rem;
-  overflow: visible;
-}
-
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -2704,6 +2703,11 @@ exports[`<Wizard /> should navigate to the second step when click on Commencer 1
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c1 {
+  padding: 0 0 0 28rem;
+  overflow: visible;
 }
 
 @media print {
@@ -2873,6 +2877,14 @@ exports[`<Wizard /> should navigate to the second step when click on Commencer 1
 }
 
 @media (max-width:980px) {
+  .c2 {
+    margin-bottom: 1.6rem;
+    padding: 1.6rem 0 1rem 0;
+    border-bottom: 0;
+  }
+}
+
+@media (max-width:980px) {
   .c1 {
     padding: 0;
   }
@@ -2881,14 +2893,6 @@ exports[`<Wizard /> should navigate to the second step when click on Commencer 1
 @media print {
   .c1 {
     border: 0;
-  }
-}
-
-@media (max-width:980px) {
-  .c2 {
-    margin-bottom: 1.6rem;
-    padding: 1.6rem 0 1rem 0;
-    border-bottom: 0;
   }
 }
 
@@ -2914,6 +2918,7 @@ exports[`<Wizard /> should navigate to the second step when click on Commencer 1
       </div>
       <div
         class="c5 c6"
+        width="28rem"
       >
         <span
           aria-level="2"
@@ -3259,11 +3264,6 @@ exports[`<Wizard /> should render a step 1`] = `
   border-radius: 49%;
 }
 
-.c1 {
-  padding: 0 0 0 28rem;
-  overflow: visible;
-}
-
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -3295,6 +3295,11 @@ exports[`<Wizard /> should render a step 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c1 {
+  padding: 0 0 0 28rem;
+  overflow: visible;
 }
 
 @media print {
@@ -3440,6 +3445,14 @@ exports[`<Wizard /> should render a step 1`] = `
 }
 
 @media (max-width:980px) {
+  .c2 {
+    margin-bottom: 1.6rem;
+    padding: 1.6rem 0 1rem 0;
+    border-bottom: 0;
+  }
+}
+
+@media (max-width:980px) {
   .c1 {
     padding: 0;
   }
@@ -3448,14 +3461,6 @@ exports[`<Wizard /> should render a step 1`] = `
 @media print {
   .c1 {
     border: 0;
-  }
-}
-
-@media (max-width:980px) {
-  .c2 {
-    margin-bottom: 1.6rem;
-    padding: 1.6rem 0 1rem 0;
-    border-bottom: 0;
   }
 }
 
@@ -3481,6 +3486,7 @@ exports[`<Wizard /> should render a step 1`] = `
       </div>
       <div
         class="c5 c6"
+        width="28rem"
       >
         <span
           aria-level="2"

--- a/packages/code-du-travail-frontend/src/outils/common/type/WizardType.ts
+++ b/packages/code-du-travail-frontend/src/outils/common/type/WizardType.ts
@@ -13,7 +13,7 @@ export type Step = {
   label: string;
   name: string;
   skip?: SkipFn;
-  annotation?: () => JSX.Element;
+  annotation?: JSX.Element;
   isForm?: boolean;
   hasNoMarginBottom?: boolean;
   onStepDone?: (title: string, values: FormContent) => void;


### PR DESCRIPTION
J'ai refacto la partie UI du Wizard pour extraire les composants en stateless. Il reste la partie form qui est géré dans le composant mais c'est plus lié à la lib utilisée.

La prochaine étape est d'avoir un Wizard basé sur le reducer. Pour cette étape, je ne pourrais pas mutualisé le code comme ici mais on aura déjà pas mal de code mutualisé :)

Linked to #4371 