### PR TITLE
fix(tools): le résultat de la convention collective mal renseigné

### DIFF
--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/state/__tests__/dummies.ts
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/state/__tests__/dummies.ts
@@ -32,7 +32,6 @@ export const generateStore = (
 export const publicodesData: PublicodesData<PublicodesPreavisRetraiteResult> = {
   missingArgs: [],
   result: {
-    valid: true,
     unit: PublicodesConvertedUnit.MONTH,
     value: 1,
     valueInDays: 30,

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/state/usecases/computeNotice.ts
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/state/usecases/computeNotice.ts
@@ -32,15 +32,14 @@ const computeNotice = (state: PreavisRetraiteStore): PreavisRetraiteStore => {
       result: {
         notice: {
           result: result.result,
-          agreement: agreementResult.valid
-            ? {
-                result: agreementResult,
-                maximum: agreementMaximumResult.valid
-                  ? agreementMaximumResult
-                  : null,
-              }
-            : null,
-          legal: legalResult.valid ? legalResult : null,
+          agreement: {
+            result: agreementResult,
+            maximum:
+              agreementMaximumResult.valueInDays > 0
+                ? agreementMaximumResult
+                : null,
+          },
+          legal: legalResult,
           type,
           notifications: publicodes.getNotifications(),
         },

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/ResultStep/Components/DecryptedResult.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/ResultStep/Components/DecryptedResult.tsx
@@ -16,7 +16,7 @@ type Props = {
   agreement: {
     result: PublicodesPreavisRetraiteResult;
     maximum: PublicodesPreavisRetraiteResult | null;
-  } | null;
+  };
 };
 
 const ShowResult: React.FC<{
@@ -96,7 +96,7 @@ export const createRootData = (
   result: PublicodesPreavisRetraiteResult,
   legalResult: PublicodesPreavisRetraiteResult,
   supportedCcn: AgreementInfo[],
-  agreementResult?: PublicodesPreavisRetraiteResult
+  agreementResult: PublicodesPreavisRetraiteResult | null
 ): RootData => {
   let agreement: Agreement | null = null;
   if (data.ccn?.selected) {
@@ -194,7 +194,7 @@ const DecryptedResult: React.FC<Props> = ({
     result,
     legalResult,
     supportedCcn,
-    agreement?.result
+    agreement.result
   );
   const description = getDescription(rootData);
   return (
@@ -204,16 +204,16 @@ const DecryptedResult: React.FC<Props> = ({
         Durée prévue par le code du travail (durée légale)&nbsp;:&nbsp;
         <ShowResult
           result={legalResult}
-          agreementMaximumResult={agreement && agreement.maximum}
+          agreementMaximumResult={agreement.maximum}
         />
       </Paragraph>
       <Paragraph>
         Durée prévue par la convention collective (durée
         conventionnelle)&nbsp;:&nbsp;
         <ShowResultAgreement
-          result={agreement && agreement.result}
+          result={agreement.result}
           detail={rootData.agreement}
-          agreementMaximumResult={agreement && agreement.maximum}
+          agreementMaximumResult={agreement.maximum}
         />
       </Paragraph>
       {description && <Paragraph>{description}</Paragraph>}

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/ResultStep/Step.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/ResultStep/Step.tsx
@@ -29,11 +29,11 @@ export enum WarningType {
 export type ResultStepProps = {
   notice: {
     result: PublicodesPreavisRetraiteResult;
-    legal: PublicodesPreavisRetraiteResult | null;
+    legal: PublicodesPreavisRetraiteResult;
     agreement: {
       result: PublicodesPreavisRetraiteResult;
       maximum: PublicodesPreavisRetraiteResult | null;
-    } | null;
+    };
     type: "mise" | "départ";
     notifications: Notification[];
   };
@@ -54,7 +54,7 @@ function ResultStep({ notice, detail, warning }: ResultStepProps): JSX.Element {
     <>
       <ShowResult
         result={notice.result}
-        agreementMaximumResult={notice.agreement && notice.agreement.maximum}
+        agreementMaximumResult={notice.agreement.maximum}
         type={notice.type}
         notifications={notice.notifications}
       />
@@ -64,14 +64,12 @@ function ResultStep({ notice, detail, warning }: ResultStepProps): JSX.Element {
           elements={detail.situation}
           minSeniorityYear={detail.minYearCount}
         />
-        {notice.legal && (
-          <DecryptedResult
-            data={detail.values}
-            legalResult={notice.legal}
-            result={notice.result}
-            agreement={notice.agreement}
-          />
-        )}
+        <DecryptedResult
+          data={detail.values}
+          legalResult={notice.legal}
+          result={notice.result}
+          agreement={notice.agreement}
+        />
         <PubliReferences references={detail.references} />
       </ShowDetails>
       <WarningResult hasNotice={warning.hasNotice} type={warning.type} />

--- a/packages/code-du-travail-modeles/src/publicodes/PreavisRetraitePublicodes.ts
+++ b/packages/code-du-travail-modeles/src/publicodes/PreavisRetraitePublicodes.ts
@@ -3,7 +3,7 @@ import type { EvaluatedNode } from "publicodes";
 import type { Publicodes } from "./Publicodes";
 import { PublicodesBase } from "./PublicodesBase";
 import type { PublicodesPreavisRetraiteResult } from "./types";
-import { PublicodesConvertedUnit, PublicodesSimulator } from "./types";
+import { PublicodesSimulator } from "./types";
 import { convertDaysIntoBetterUnit } from "./utils";
 
 class PreavisRetraitePublicodes
@@ -17,14 +17,6 @@ class PreavisRetraitePublicodes
   protected convertedResult(
     evaluatedNode: EvaluatedNode
   ): PublicodesPreavisRetraiteResult {
-    if (evaluatedNode.nodeValue === false) {
-      return {
-        unit: PublicodesConvertedUnit.DAY,
-        valid: false,
-        value: -1,
-        valueInDays: -1,
-      };
-    }
     return convertDaysIntoBetterUnit(
       evaluatedNode.nodeValue as unknown as string
     );

--- a/packages/code-du-travail-modeles/src/publicodes/__tests__/PreavisRetraitePublicodes.test.ts
+++ b/packages/code-du-travail-modeles/src/publicodes/__tests__/PreavisRetraitePublicodes.test.ts
@@ -108,7 +108,6 @@ describe("PreavisRetraitePublicodes::class", () => {
   it("doit retourner le résultat", () => {
     expect(publicodes.data.result).toEqual({
       unit: "mois",
-      valid: true,
       value: 2,
       valueInDays: 60.833333333333336,
     });

--- a/packages/code-du-travail-modeles/src/publicodes/types.ts
+++ b/packages/code-du-travail-modeles/src/publicodes/types.ts
@@ -76,7 +76,6 @@ export enum PublicodesConvertedUnit {
 }
 
 export type PublicodesPreavisRetraiteResult = {
-  valid: boolean;
   value: number;
   unit: PublicodesConvertedUnit;
   valueInDays: number;

--- a/packages/code-du-travail-modeles/src/publicodes/utils/__tests__/preavis-retraite.test.ts
+++ b/packages/code-du-travail-modeles/src/publicodes/utils/__tests__/preavis-retraite.test.ts
@@ -27,7 +27,6 @@ describe("Testing the transformation of the unit from publicodes (in days) into 
     ({ input, expectedUnit, expectedValue }) => {
       expect(convertDaysIntoBetterUnit(input)).toEqual({
         unit: expectedUnit,
-        valid: true,
         value: expectedValue,
         valueInDays: parseFloat(input),
       });

--- a/packages/code-du-travail-modeles/src/publicodes/utils/preavis-retraite.ts
+++ b/packages/code-du-travail-modeles/src/publicodes/utils/preavis-retraite.ts
@@ -15,7 +15,6 @@ export const convertDaysIntoBetterUnit = (
       unit: isWeek
         ? PublicodesConvertedUnit.WEEK
         : PublicodesConvertedUnit.WEEKS,
-      valid: true,
       value: parsedWeek,
       valueInDays: parsedDay,
     };
@@ -27,14 +26,12 @@ export const convertDaysIntoBetterUnit = (
     const parsedMonth = Math.round(parsedDay / (365 / 12));
     return {
       unit: PublicodesConvertedUnit.MONTH,
-      valid: true,
       value: parsedMonth,
       valueInDays: parsedDay,
     };
   }
   return {
     unit: isDay ? PublicodesConvertedUnit.DAY : PublicodesConvertedUnit.DAYS,
-    valid: true,
     value: parsedDay,
     valueInDays: parsedDay,
   };


### PR DESCRIPTION
Rollback sur la gestion des CC où l'on ne doit pas appliquer le code du travail.

J'étais parti sur le fait que le résultat de publicodes est null si on n'a pas de règle. Du coup quand on désactive la règle du légal, on peut vérifier que le légal n'est pas à appliquer. Sauf que dans le null est également utilisé pour les cas où la CC ne prévoit pas de préavis. Du coup ça rentre en conflit. Comme pour finir, on ne l'utilise pas, je l'ai retiré.