### PR TITLE
fix(ci): deprecated `set-output` fixed

### DIFF
--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Restore cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Restore cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: false
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Restore cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           RAW_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
           BRANCH=$(npx @socialgouv/env-slug "${RAW_BRANCH}")
-          echo "branch=(echo ${BRANCH})" >> $GITHUB_OUTPUT
+          echo "branch=$(echo ${BRANCH})" >> $GITHUB_OUTPUT
       - name: Use k8s manifests generation
         uses: SocialGouv/actions/k8s-manifests@v1
         with:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           RAW_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
           BRANCH=$(npx @socialgouv/env-slug "${RAW_BRANCH}")
-          echo "::set-output name=branch::$(echo ${BRANCH})"
+          echo "branch=(echo ${BRANCH})" >> $GITHUB_OUTPUT
       - name: Use k8s manifests generation
         uses: SocialGouv/actions/k8s-manifests@v1
         with:
@@ -84,7 +84,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Restore cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Restore cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
cf : [github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)