### PR TITLE
fix(k8s): fix resources limits

### DIFF
--- a/.k8s/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/.k8s/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -98,8 +98,8 @@ spec:
               cpu: 500m
               memory: 1Gi
             requests:
-              cpu: 100m
-              memory: 320Mi
+              cpu: 50m
+              memory: 128Mi
           startupProbe:
             failureThreshold: 12
             httpGet:
@@ -356,10 +356,10 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 768Mi
+              memory: 1Gi
             requests:
-              cpu: 300m
-              memory: 512Mi
+              cpu: 50m
+              memory: 256Mi
           startupProbe:
             failureThreshold: 12
             httpGet:

--- a/.k8s/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
@@ -97,8 +97,8 @@ spec:
               cpu: 500m
               memory: 1Gi
             requests:
-              cpu: 100m
-              memory: 320Mi
+              cpu: 50m
+              memory: 128Mi
           startupProbe:
             failureThreshold: 12
             httpGet:
@@ -355,10 +355,10 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 768Mi
+              memory: 1Gi
             requests:
-              cpu: 300m
-              memory: 512Mi
+              cpu: 50m
+              memory: 256Mi
           startupProbe:
             failureThreshold: 12
             httpGet:

--- a/.k8s/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -71,8 +71,8 @@ spec:
               cpu: 500m
               memory: 1Gi
             requests:
-              cpu: 100m
-              memory: 320Mi
+              cpu: 50m
+              memory: 128Mi
           startupProbe:
             failureThreshold: 12
             httpGet:
@@ -361,10 +361,10 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 768Mi
+              memory: 1Gi
             requests:
-              cpu: 300m
-              memory: 512Mi
+              cpu: 50m
+              memory: 256Mi
           startupProbe:
             failureThreshold: 12
             httpGet:

--- a/.k8s/components/api.ts
+++ b/.k8s/components/api.ts
@@ -40,8 +40,8 @@ export default async () => {
         },
         resources: {
           requests: {
-            cpu: "100m",
-            memory: "320Mi",
+            cpu: "50m",
+            memory: "128Mi",
           },
           limits: {
             cpu: "500m",

--- a/.k8s/components/www.ts
+++ b/.k8s/components/www.ts
@@ -56,12 +56,12 @@ export default async () => {
         },
         resources: {
           requests: {
-            cpu: "300m",
-            memory: "512Mi",
+            cpu: "50m",
+            memory: "256Mi",
           },
           limits: {
             cpu: "500m",
-            memory: "768Mi",
+            memory: "1Gi",
           },
         },
         env: [


### PR DESCRIPTION
Adjust resources requests and limits based on [grafana (prod)](https://grafana.fabrique.social.gouv.fr/d/85a562078cdf77779eaa1add43ccec1eV2/kubernetes-compute-resources-namespace-pods?orgId=1&refresh=10s&var-datasource=Thanos%20-%20Prod&var-cluster=prod2&var-namespace=cdtn&from=now-3d&to=now) :

<img width="1979" alt="Capture d’écran 2022-10-17 à 08 27 15" src="https://user-images.githubusercontent.com/124937/196104459-3b2eb017-e0b6-41fb-954f-476708334c76.png">

 - **requests** : whats permanently reserved on the clusters
 - **limits** : 
   - CPU : CPU is capped when it reach the limit
   - memory : process is killed when it reach the limit

More details on [kube docs](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)