### PR TITLE
feat(test): supprimer les balises data-testid en production

### DIFF
--- a/packages/code-du-travail-frontend/next.config.js
+++ b/packages/code-du-travail-frontend/next.config.js
@@ -61,6 +61,10 @@ const nextConfig = {
   },
   swcMinify: true,
   compiler: {
+    reactRemoveProperties:
+      process.env.NODE_ENV === "production"
+        ? { properties: ["data-testid"] }
+        : false,
     styledComponents: true,
   },
 };


### PR DESCRIPTION
On supprime les balises data-testid en production. On les laisse en dev pour faciliter l'implémentation des tests.