### PR TITLE
fix(k8s): optimization of `requests` / `limits` in dev and production mode

### DIFF
--- a/.k8s/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/.k8s/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -358,7 +358,7 @@ spec:
               cpu: 250m
               memory: 512Mi
             requests:
-              cpu: 100m
+              cpu: 50m
               memory: 256Mi
           startupProbe:
             failureThreshold: 12

--- a/.k8s/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/.k8s/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -95,11 +95,11 @@ spec:
             timeoutSeconds: 3
           resources:
             limits:
-              cpu: 500m
-              memory: 1Gi
-            requests:
-              cpu: 150m
+              cpu: 100m
               memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi
           startupProbe:
             failureThreshold: 12
             httpGet:
@@ -355,11 +355,11 @@ spec:
             timeoutSeconds: 3
           resources:
             limits:
-              cpu: 500m
-              memory: 1Gi
-            requests:
               cpu: 250m
               memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
           startupProbe:
             failureThreshold: 12
             httpGet:

--- a/.k8s/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
@@ -94,11 +94,11 @@ spec:
             timeoutSeconds: 3
           resources:
             limits:
-              cpu: 500m
-              memory: 1Gi
-            requests:
-              cpu: 150m
+              cpu: 100m
               memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi
           startupProbe:
             failureThreshold: 12
             httpGet:
@@ -354,11 +354,11 @@ spec:
             timeoutSeconds: 3
           resources:
             limits:
-              cpu: 500m
-              memory: 1Gi
-            requests:
               cpu: 250m
               memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
           startupProbe:
             failureThreshold: 12
             httpGet:

--- a/.k8s/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
@@ -357,7 +357,7 @@ spec:
               cpu: 250m
               memory: 512Mi
             requests:
-              cpu: 100m
+              cpu: 50m
               memory: 256Mi
           startupProbe:
             failureThreshold: 12

--- a/.k8s/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -68,10 +68,10 @@ spec:
             timeoutSeconds: 3
           resources:
             limits:
-              cpu: 500m
-              memory: 1Gi
+              cpu: 300m
+              memory: 768Mi
             requests:
-              cpu: 150m
+              cpu: 100m
               memory: 256Mi
           startupProbe:
             failureThreshold: 12
@@ -254,7 +254,7 @@ metadata:
   namespace: cdtn
 spec:
   minReplicas: 2
-  maxReplicas: 15
+  maxReplicas: 20
   metrics:
     - resource:
         name: cpu
@@ -364,7 +364,7 @@ spec:
               memory: 1Gi
             requests:
               cpu: 250m
-              memory: 512Mi
+              memory: 768Mi
           startupProbe:
             failureThreshold: 12
             httpGet:
@@ -515,7 +515,7 @@ metadata:
   namespace: cdtn
 spec:
   minReplicas: 2
-  maxReplicas: 15
+  maxReplicas: 20
   metrics:
     - resource:
         name: cpu

--- a/.k8s/components/api.ts
+++ b/.k8s/components/api.ts
@@ -38,16 +38,8 @@ export default async () => {
           initialDelaySeconds: 0,
           timeoutSeconds: 15,
         },
-        resources: {
-          requests: {
-            cpu: "150m",
-            memory: "256Mi",
-          },
-          limits: {
-            cpu: "500m",
-            memory: "1Gi",
-          },
-        },
+        resources:
+          env.env === "prod" ? ressourcesConfigProd : ressourcesConfigDev,
         env: [
           {
             name: "ELASTIC_APM_ENVIRONMENT",
@@ -77,7 +69,7 @@ export default async () => {
     metadata: deployment.metadata,
     spec: {
       minReplicas: 2,
-      maxReplicas: 15,
+      maxReplicas: 20,
 
       metrics: [
         {
@@ -117,4 +109,26 @@ export default async () => {
   }
 
   return manifests;
+};
+
+const ressourcesConfigDev = {
+  requests: {
+    cpu: "50m",
+    memory: "128Mi",
+  },
+  limits: {
+    cpu: "100m",
+    memory: "256Mi",
+  },
+};
+
+const ressourcesConfigProd = {
+  requests: {
+    cpu: "100m",
+    memory: "256Mi",
+  },
+  limits: {
+    cpu: "300m",
+    memory: "768Mi",
+  },
 };

--- a/.k8s/components/www.ts
+++ b/.k8s/components/www.ts
@@ -54,16 +54,8 @@ export default async () => {
           initialDelaySeconds: 10,
           timeoutSeconds: 15,
         },
-        resources: {
-          requests: {
-            cpu: "250m",
-            memory: "512Mi",
-          },
-          limits: {
-            cpu: "500m",
-            memory: "1Gi",
-          },
-        },
+        resources:
+          env.env === "prod" ? ressourcesConfigProd : ressourcesConfigDev,
         env: [
           {
             name: "API_URL",
@@ -104,7 +96,7 @@ export default async () => {
     metadata: deployment.metadata,
     spec: {
       minReplicas: 2,
-      maxReplicas: 15,
+      maxReplicas: 20,
 
       metrics: [
         {
@@ -144,4 +136,26 @@ export default async () => {
   }
 
   return manifests;
+};
+
+const ressourcesConfigProd = {
+  requests: {
+    cpu: "250m",
+    memory: "768Mi",
+  },
+  limits: {
+    cpu: "500m",
+    memory: "1Gi",
+  },
+};
+
+const ressourcesConfigDev = {
+  requests: {
+    cpu: "100m",
+    memory: "256Mi",
+  },
+  limits: {
+    cpu: "250m",
+    memory: "512Mi",
+  },
 };

--- a/.k8s/components/www.ts
+++ b/.k8s/components/www.ts
@@ -151,7 +151,7 @@ const ressourcesConfigProd = {
 
 const ressourcesConfigDev = {
   requests: {
-    cpu: "100m",
+    cpu: "50m",
     memory: "256Mi",
   },
   limits: {


### PR DESCRIPTION
Bonjour,

J'ai essayé d'optimiser les requests et limites en fonction de l'environnement de dev ou prod : 

Ici voici l'existant pour la dev :

<img width="1615" alt="Screenshot 2022-11-10 at 16 32 23" src="https://user-images.githubusercontent.com/25312957/201138379-b365ed92-7882-4ae1-92be-553c49ba7c08.png">

<img width="1609" alt="Screenshot 2022-11-10 at 16 32 29" src="https://user-images.githubusercontent.com/25312957/201138404-2b3205f3-b3f3-47b4-bc12-9f593da57306.png">

Et voici pour la prod : 

<img width="1622" alt="Screenshot 2022-11-10 at 16 34 46" src="https://user-images.githubusercontent.com/25312957/201138448-33aee752-5b3a-4b15-9bbf-b1b653478db2.png">


<img width="1625" alt="Screenshot 2022-11-10 at 16 34 52" src="https://user-images.githubusercontent.com/25312957/201138465-887daf8e-7fa4-47fe-8041-b7713813cb26.png">
