### PR TITLE
fix: glossary display page info

### DIFF
--- a/packages/code-du-travail-frontend/src/information/Components/Contents.tsx
+++ b/packages/code-du-travail-frontend/src/information/Components/Contents.tsx
@@ -66,9 +66,6 @@ export const Contents = ({
 };
 
 const TabStylesWrapper = styled.div`
-  & > div > div > div {
-    overflow-x: auto;
-  }
   img {
     max-width: 100%;
     height: auto;


### PR DESCRIPTION
[#4596](https://github.com/SocialGouv/code-du-travail-numerique/issues/4596)