### PR TITLE
fix(indemnite-licenciement): ne pas afficher la partie variable sur le résultat pour la CC 16

### DIFF
--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/__tests__/cc16.test.tsx
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/__tests__/cc16.test.tsx
@@ -84,9 +84,23 @@ describe("Indemnité licenciement - CC 16", () => {
           "Les salaires indiqués comportent-ils une partie variable ?"
         )
       ).toBeInTheDocument();
+      expect(ui.salary.variablePart.oui.query()).toBeInTheDocument();
+      expect(ui.salary.variablePart.non.query()).toBeInTheDocument();
+
+      userAction
+        .setInput(ui.salary.salaries.getAll()[0], "2500")
+        .click(ui.salary.variablePart.oui.get())
+        .click(ui.next.get());
+
+      expect(
+        rendering.queryByText(
+          /Les salaires indiqués comportent une partie variable/
+        )
+      ).toBeInTheDocument();
 
       // vérification que l'on demande si le salaire a eu des primes pour un TAM
       userAction
+        .click(ui.previous.get())
         .click(ui.previous.get())
         .click(ui.previous.get())
         .changeInputList(
@@ -109,9 +123,23 @@ describe("Indemnité licenciement - CC 16", () => {
           "Les salaires indiqués comportent-ils une partie variable ?"
         )
       ).toBeInTheDocument();
+      expect(ui.salary.variablePart.oui.query()).toBeInTheDocument();
+      expect(ui.salary.variablePart.non.query()).toBeInTheDocument();
+
+      userAction
+        .setInput(ui.salary.salaries.getAll()[0], "2500")
+        .click(ui.salary.variablePart.oui.get())
+        .click(ui.next.get());
+
+      expect(
+        rendering.queryByText(
+          /Les salaires indiqués comportent une partie variable/
+        )
+      ).toBeInTheDocument();
 
       // vérification que l'on demande si le salaire a eu des primes pour un employé
       userAction
+        .click(ui.previous.get())
         .click(ui.previous.get())
         .click(ui.previous.get())
         .changeInputList(
@@ -134,9 +162,22 @@ describe("Indemnité licenciement - CC 16", () => {
           "Les salaires indiqués comportent-ils une partie variable ?"
         )
       ).not.toBeInTheDocument();
+      expect(ui.salary.variablePart.oui.query()).not.toBeInTheDocument();
+      expect(ui.salary.variablePart.non.query()).not.toBeInTheDocument();
+
+      userAction
+        .setInput(ui.salary.salaries.getAll()[0], "2500")
+        .click(ui.next.get());
+
+      expect(
+        rendering.queryByText(
+          /Les salaires indiqués comportent une partie variable/
+        )
+      ).not.toBeInTheDocument();
 
       // vérification que l'on demande si le salaire a eu des primes pour un ouvrier
       userAction
+        .click(ui.previous.get())
         .click(ui.previous.get())
         .click(ui.previous.get())
         .changeInputList(
@@ -158,6 +199,18 @@ describe("Indemnité licenciement - CC 16", () => {
       expect(
         rendering.queryByText(
           "Les salaires indiqués comportent-ils une partie variable ?"
+        )
+      ).not.toBeInTheDocument();
+      expect(ui.salary.variablePart.oui.query()).not.toBeInTheDocument();
+      expect(ui.salary.variablePart.non.query()).not.toBeInTheDocument();
+
+      userAction
+        .setInput(ui.salary.salaries.getAll()[0], "2500")
+        .click(ui.next.get());
+
+      expect(
+        rendering.queryByText(
+          /Les salaires indiqués comportent une partie variable/
         )
       ).not.toBeInTheDocument();
     });

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/__tests__/ui.ts
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/__tests__/ui.ts
@@ -155,8 +155,8 @@ export const ui = {
     },
     sameSalaryValue: byTestId("same-salary-value"),
     variablePart: {
-      oui: byTestId("hasVariablePart - Oui"),
-      non: byTestId("hasVariablePart - Non"),
+      oui: byTestId("hasVariablePay - Oui"),
+      non: byTestId("hasVariablePay - Non"),
     },
     salaries: byTestId("salary-input"),
     primes: byTestId("prime-input"),

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/agreements/16-transports-routiers/Informations.tsx
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/agreements/16-transports-routiers/Informations.tsx
@@ -1,16 +1,16 @@
 import { useIndemniteLicenciementStore } from "../../store";
 
 export default function Agreement16Informations() {
-  const { hasSameSalary, hasVariablePay } = useIndemniteLicenciementStore(
+  const { showVariablePay, hasVariablePay } = useIndemniteLicenciementStore(
     (state) => ({
-      hasSameSalary: state.salairesData.input.hasSameSalary,
+      showVariablePay: state.agreement16Data.input.showVariablePay,
       hasVariablePay: state.agreement16Data.input.hasVariablePay,
     })
   );
 
   return (
     <>
-      {hasSameSalary === "non" && (
+      {showVariablePay && (
         <li>
           Les salaires indiqués comportent une partie variable &nbsp;:&nbsp;
           {hasVariablePay === "oui" ? "Oui" : "Non"}


### PR DESCRIPTION
closes #4774