### PR TITLE
fix(indemnite-licenciement): ne pas retirer les apostrophes dans les informations

### DIFF
--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/Resultat/components/FilledElements.tsx
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/Resultat/components/FilledElements.tsx
@@ -84,7 +84,8 @@ export default function FilledElements(props: Props) {
             <ul>
               {props.agreementInformations.map((info, index) => (
                 <li key={"agreement-" + index}>
-                  {info.label}&nbsp;:&nbsp;{info.value.replace(/'/g, "")}&nbsp;
+                  {info.label}&nbsp;:&nbsp;{info.value.replace(/^'|'$/g, "")}
+                  &nbsp;
                   {publicodesUnitTranslator(
                     info.value.replace(/'/g, ""),
                     info.unit

--- a/packages/code-du-travail-modeles/src/modeles/conventions/1486_bureaux_etudes_techniques/indemnite-licenciement.yaml
+++ b/packages/code-du-travail-modeles/src/modeles/conventions/1486_bureaux_etudes_techniques/indemnite-licenciement.yaml
@@ -22,7 +22,7 @@ contrat salarié . convention collective . bureaux études techniques . indemnit
     valeurs:
       ETAM: "'ETAM'"
       Ingénieurs et cadres: "'Ingénieurs et cadres'"
-      Chargés d'enquête intermittent: "'Chargés d'enquête intermittent'"
+      Chargés d'enquête intermittents: "'Chargés d'enquête intermittents'"
 
 # Formules
 contrat salarié . convention collective . bureaux études techniques . indemnité de licenciement . un cinquième du salaire de référence:
@@ -138,7 +138,7 @@ contrat salarié . convention collective . bureaux études techniques . indemnit
 
 # Chargés d'enquête intermittent
 contrat salarié . convention collective . bureaux études techniques . indemnité de licenciement . type de licenciement . autres . catégorie professionnelle . chargés d'enquête:
-  applicable si: catégorie professionnelle = 'Chargés d'enquête intermittent'
+  applicable si: catégorie professionnelle = 'Chargés d'enquête intermittents'
   valeur: oui
 
 contrat salarié . convention collective . bureaux études techniques . indemnité de licenciement . type de licenciement . autres . catégorie professionnelle . chargés d'enquête . résultat conventionnel:

--- a/packages/code-du-travail-modeles/src/modeles/conventions/1486_bureaux_etudes_techniques/salary.ts
+++ b/packages/code-du-travail-modeles/src/modeles/conventions/1486_bureaux_etudes_techniques/salary.ts
@@ -15,7 +15,7 @@ export enum TypeLicenciement1486 {
 export enum CatPro1486 {
   etam = "ETAM",
   ingeCadre = "Ingénieurs et cadres",
-  chargeEnquete = "Chargés d'enquête intermittent",
+  chargeEnquete = "Chargés d'enquête intermittents",
 }
 
 export type CC1486ReferenceSalaryProps = {


### PR DESCRIPTION
On a revu la regex avec @Viczei pour retirer les apostrophes en début et fin seulement :)