### PR TITLE
fix(indemnite-licenciement): message pour une CC non traité

### DIFF
--- a/packages/code-du-travail-frontend-e2e/e2e/dossier.spec.ts
+++ b/packages/code-du-travail-frontend-e2e/e2e/dossier.spec.ts
@@ -1,7 +1,7 @@
 describe("Dossiers", () => {
   it("je vois une page dossier", () => {
     cy.visit("/dossiers/ministere-du-travail-notre-dossier-sur-le-coronavirus");
-    cy.get("h1").should("have.text", "Covid-19 : fin du protocole sanitaire");
+    cy.get("h1").should("have.text", "Covid-19");
     cy.get("body").should("contain", "Sommaire");
 
     cy.contains(

--- a/packages/code-du-travail-frontend-e2e/e2e/dossier.spec.ts
+++ b/packages/code-du-travail-frontend-e2e/e2e/dossier.spec.ts
@@ -4,13 +4,14 @@ describe("Dossiers", () => {
     cy.get("h1").should("have.text", "Covid-19");
     cy.get("body").should("contain", "Sommaire");
 
-    cy.contains(
-      "Covid-19 : le régime post-crise sanitaire à compter du 14 mars 2022"
-    ).click();
-    cy.get("h1").should("have.text", "Covid-19 : fin du protocole sanitaire");
+    cy.contains("Covid-19 : le régime post-crise sanitaire").click();
+    cy.get("h1").should(
+      "have.text",
+      "Covid-19 : le régime post-crise sanitaire."
+    );
     cy.get("body").should(
       "contain",
-      "Un allègement des mesures à partir du 14 mars 2022"
+      "Le ministère du Travail a mis fin à ses recommandations telles qu’elles figuraient dans le protocole national en entreprise"
     );
   });
 });

--- a/packages/code-du-travail-frontend/src/outils/CommonSteps/Agreement/components/EnterpriseSearch.tsx
+++ b/packages/code-du-travail-frontend/src/outils/CommonSteps/Agreement/components/EnterpriseSearch.tsx
@@ -14,6 +14,7 @@ import ShowAgreement from "../../../common/Agreement/EnterpriseSearch/ShowAgreem
 import SelectedEnterprise from "../../../common/Agreement/EnterpriseSearch/SelectedEnterprise";
 import { SearchEnterpriseInput } from "../../../common/Agreement/EnterpriseSearch/EntrepriseSearchInput/SearchEnterpriseInput";
 import { renderResults } from "../../../common/Agreement/EnterpriseSearch/EntrepriseSearchResult";
+import { PublicodesSimulator } from "@socialgouv/modeles-social";
 
 export type Props = {
   supportedAgreements: AgreementSupportInfo[];
@@ -21,6 +22,7 @@ export type Props = {
   selectedAgreement?: Agreement;
   onSelectAgreement: OnSelectAgreementFn;
   alertAgreementNotSupported?: (string) => JSX.Element;
+  simulator: PublicodesSimulator;
 } & TrackingProps;
 
 const EnterpriseSearch = ({
@@ -30,6 +32,7 @@ const EnterpriseSearch = ({
   onSelectAgreement,
   onUserAction,
   alertAgreementNotSupported,
+  simulator,
 }: Props): JSX.Element => {
   const [enterprise, setEnterprise] = useState<Enterprise | undefined>(
     selectedEnterprise
@@ -54,6 +57,7 @@ const EnterpriseSearch = ({
             agreement={enterprise.conventions[0]}
             supportedAgreements={supportedAgreements}
             alertAgreementNotSupported={alertAgreementNotSupported}
+            simulator={simulator}
           />
         ) : (
           <ShowAgreements
@@ -64,6 +68,7 @@ const EnterpriseSearch = ({
             }}
             supportedAgreements={supportedAgreements}
             alertAgreementNotSupported={alertAgreementNotSupported}
+            simulator={simulator}
           />
         )}
       </>
@@ -99,6 +104,7 @@ export default EnterpriseSearch;
 
 const Section = styled(SectionUi)`
   padding-top: 0;
+
   label {
     font-weight: 400;
   }

--- a/packages/code-du-travail-frontend/src/outils/CommonSteps/Agreement/components/ShowAgreements.tsx
+++ b/packages/code-du-travail-frontend/src/outils/CommonSteps/Agreement/components/ShowAgreements.tsx
@@ -1,4 +1,4 @@
-import { formatIdcc } from "@socialgouv/modeles-social";
+import { formatIdcc, PublicodesSimulator } from "@socialgouv/modeles-social";
 import React from "react";
 
 import { Enterprise } from "../../../../conventions/Search/api/enterprises.service";
@@ -14,6 +14,7 @@ type Props = {
   supportedAgreements: AgreementSupportInfo[];
   error?: string;
   alertAgreementNotSupported?: (string) => JSX.Element;
+  simulator: PublicodesSimulator;
 };
 
 const ShowAgreements = ({
@@ -23,6 +24,7 @@ const ShowAgreements = ({
   supportedAgreements,
   error,
   alertAgreementNotSupported,
+  simulator,
 }: Props): JSX.Element => {
   const onAgreementChange = (idcc: string) => {
     const agreement = enterprise.conventions.find(
@@ -50,6 +52,7 @@ const ShowAgreements = ({
           currentAgreement={agreement}
           supportedAgreements={supportedAgreements}
           alertAgreementNotSupported={alertAgreementNotSupported}
+          simulator={simulator}
         />
       )}
     </>

--- a/packages/code-du-travail-frontend/src/outils/CommonSteps/Agreement/index.tsx
+++ b/packages/code-du-travail-frontend/src/outils/CommonSteps/Agreement/index.tsx
@@ -11,7 +11,7 @@ import { Enterprise } from "../../../conventions/Search/api/enterprises.service"
 import { InlineError } from "../../common/ErrorField";
 import { PublicodesSimulator } from "@socialgouv/modeles-social";
 import ShowAlert from "../../common/Agreement/RouteSelection/ShowAlert";
-import { AgreementSearchValue } from "./store/types";
+import { AgreementSearchValue } from "./store";
 
 type Props = {
   selectedRoute?: Route;
@@ -112,6 +112,7 @@ function AgreementStep({
             onUserAction={(action, value: AgreementSearchValue) =>
               onEnterpriseSearch(value)
             }
+            simulator={simulator}
           />
           {error?.enterprise && <InlineError>{error.enterprise}</InlineError>}
         </>

--- a/packages/code-du-travail-frontend/src/outils/common/Agreement/EnterpriseSearch/EnterpriseSearch.tsx
+++ b/packages/code-du-travail-frontend/src/outils/common/Agreement/EnterpriseSearch/EnterpriseSearch.tsx
@@ -1,13 +1,6 @@
 import React, { useState } from "react";
 import { Field } from "react-final-form";
-import {
-  Input,
-  Label,
-  Paragraph,
-  Section as SectionUi,
-  Text,
-  theme,
-} from "@socialgouv/cdtn-ui";
+import { Paragraph, Section as SectionUi } from "@socialgouv/cdtn-ui";
 import { Enterprise } from "../../../../conventions/Search/api/enterprises.service";
 import { Agreement } from "../../../../conventions/Search/api/type";
 import { SearchParams } from "../../../ConventionCollective/common/NavContext";
@@ -22,6 +15,7 @@ import ShowAgreements from "./ShowAgreements";
 import { renderResults } from "./EntrepriseSearchResult";
 import { SearchEnterpriseInput } from "./EntrepriseSearchInput/SearchEnterpriseInput";
 import styled from "styled-components";
+import { PublicodesSimulator } from "@socialgouv/modeles-social";
 
 export type Props = {
   supportedAgreements: AgreementSupportInfo[];
@@ -61,6 +55,7 @@ const EnterpriseSearch = ({
             agreement={enterprise.conventions[0]}
             supportedAgreements={supportedAgreements}
             alertAgreementNotSupported={alertAgreementNotSupported}
+            simulator={PublicodesSimulator.PREAVIS_RETRAITE}
           />
         ) : (
           <ShowAgreements
@@ -116,6 +111,7 @@ export default EnterpriseSearch;
 
 const Section = styled(SectionUi)`
   padding-top: 0;
+
   label {
     font-weight: 400;
   }

--- a/packages/code-du-travail-frontend/src/outils/common/Agreement/EnterpriseSearch/ShowAgreement.tsx
+++ b/packages/code-du-travail-frontend/src/outils/common/Agreement/EnterpriseSearch/ShowAgreement.tsx
@@ -1,4 +1,4 @@
-import { formatIdcc } from "@socialgouv/modeles-social";
+import { formatIdcc, PublicodesSimulator } from "@socialgouv/modeles-social";
 import { Text } from "@socialgouv/cdtn-ui";
 import React from "react";
 
@@ -11,12 +11,14 @@ type Props = {
   agreement: Agreement;
   supportedAgreements: AgreementSupportInfo[];
   alertAgreementNotSupported?: (string) => JSX.Element;
+  simulator: PublicodesSimulator;
 };
 
 const ShowAgreement = ({
   agreement,
   supportedAgreements,
   alertAgreementNotSupported,
+  simulator,
 }: Props): JSX.Element => {
   return (
     <>
@@ -30,6 +32,7 @@ const ShowAgreement = ({
         currentAgreement={agreement}
         supportedAgreements={supportedAgreements}
         alertAgreementNotSupported={alertAgreementNotSupported}
+        simulator={simulator}
       />
     </>
   );


### PR DESCRIPTION
Je n'ai pas ajouté de TU sur ce bug car ce ne sera pas fiable. En effet, il concerne des CCs en cours d'implémentation. Du coup, si je prend la boulangerie par exemple, le test ne marchera plus dès que l'on aura implémenté la boulangerie. Et à la fin, on n'aura plus de CC à traité et donc plus besoin de ce code. Je pense que l'importance de la feature n'est pas critique et que le coût de dev et maintenance de ce TU n'en vaut pas la chandelle. Dites moi si ça vous va, sinon je peux en implémenter un.

Fix #4919 

