### PR TITLE
fix(preavis-retraite): ne supporte pas les espaces insécables

### DIFF
--- a/packages/code-du-travail-modeles/src/modeles/conventions/16_transports_routiers/preavis-retraite.yaml
+++ b/packages/code-du-travail-modeles/src/modeles/conventions/16_transports_routiers/preavis-retraite.yaml
@@ -34,7 +34,7 @@ contrat salarié . convention collective . transports routiers . catégorie prof
   valeur: oui
 
 contrat salarié . convention collective . transports routiers . catégorie professionnelle . TAM . groupe:
-  question: Quel est le groupe du salarié&nbsp;?
+  question: Quel est le groupe du salarié ?
   titre: Groupe
   description: Le groupe du salarié est habituellement mentionné sur le <strong>bulletin de salaire</strong>.
   cdtn:


### PR DESCRIPTION
Régression liée à l'implémentation de l'outil d'indemnité de licenciement.

Fix #4927 