### PR TITLE
fix(null error): when input is undefined

### DIFF
--- a/packages/code-du-travail-frontend/src/outils/common/Agreement/AgreementSearch/AgreementInput/SearchAgreementInput.tsx
+++ b/packages/code-du-travail-frontend/src/outils/common/Agreement/AgreementSearch/AgreementInput/SearchAgreementInput.tsx
@@ -41,7 +41,11 @@ export const SearchAgreementInput = ({
   const onSearch = async ({ value }) => {
     setQuery(value);
   };
-
+  const focusInput = (autoSuggest) => {
+    if (autoSuggest) {
+      autoSuggest.input?.focus();
+    }
+  };
   const onSelect = async (event, data) => {
     event.preventDefault();
     onSelectAgreement(data.suggestion);
@@ -82,6 +86,7 @@ export const SearchAgreementInput = ({
       </InfoBulle>
 
       <Autosuggest
+        ref={focusInput}
         theme={suggesterTheme}
         suggestions={state.data ?? []}
         alwaysRenderSuggestions={false}

--- a/packages/code-du-travail-frontend/src/search/SearchBar/DocumentSuggester.js
+++ b/packages/code-du-travail-frontend/src/search/SearchBar/DocumentSuggester.js
@@ -11,8 +11,8 @@ const { colors } = theme;
 
 export class DocumentSuggester extends React.Component {
   focusInput = (autoSuggest) => {
-    if (autoSuggest !== null && this.props.hasFocus) {
-      autoSuggest.input.focus();
+    if (autoSuggest && this.props.hasFocus) {
+      autoSuggest.input?.focus();
     }
   };
 


### PR DESCRIPTION
Tentative de fixer l'erreur :
```
TypeError
undefined is not an object (evaluating 't.input.focus')
```

c'est notre erreur la plus fréquente sur Sentry