### PR TITLE
fix(simulator): handle error when fetch `/api/idcc` and `/api/enterprise`

### DIFF
--- a/packages/code-du-travail-frontend/src/conventions/Search/api/agreement.service.ts
+++ b/packages/code-du-travail-frontend/src/conventions/Search/api/agreement.service.ts
@@ -26,8 +26,8 @@ const apiIdcc = function createFetcher(query: string): Promise<Agreement[]> {
             ) as Agreement[]
         );
     }
-    const errorMessage = await response.text();
-    return Promise.reject(new Error(errorMessage));
+    const errorMessage = (await response.json()).message;
+    return Promise.reject(errorMessage);
   });
 };
 

--- a/packages/code-du-travail-frontend/src/conventions/Search/api/agreement.service.ts
+++ b/packages/code-du-travail-frontend/src/conventions/Search/api/agreement.service.ts
@@ -26,8 +26,7 @@ const apiIdcc = function createFetcher(query: string): Promise<Agreement[]> {
             ) as Agreement[]
         );
     }
-    const errorMessage = (await response.json()).message;
-    return Promise.reject(errorMessage);
+    return Promise.reject("Ce service est momentanément indisponible.");
   });
 };
 

--- a/packages/code-du-travail-frontend/src/conventions/Search/api/agreements.service.ts
+++ b/packages/code-du-travail-frontend/src/conventions/Search/api/agreements.service.ts
@@ -38,8 +38,9 @@ const apiIdcc = function createFetcher(query) {
         ) as Agreement[];
       });
     }
-    const errorMessage = (await response.json()).message;
-    return Promise.reject(errorMessage);
+    return Promise.reject(
+      "Ce service est momentanément indisponible. Vous pouvez tout de même poursuivre la simulation pour obtenir le résultat prévu par le code du travail en sélectionnant l'option \"Je ne souhaite pas renseigner ma convention collective (je passe l'étape)\""
+    );
   });
 };
 

--- a/packages/code-du-travail-frontend/src/conventions/Search/api/agreements.service.ts
+++ b/packages/code-du-travail-frontend/src/conventions/Search/api/agreements.service.ts
@@ -38,8 +38,8 @@ const apiIdcc = function createFetcher(query) {
         ) as Agreement[];
       });
     }
-    const errorMessage = await response.text();
-    return Promise.reject(new Error(errorMessage));
+    const errorMessage = (await response.json()).message;
+    return Promise.reject(errorMessage);
   });
 };
 

--- a/packages/code-du-travail-frontend/src/conventions/Search/api/enterprises.service.ts
+++ b/packages/code-du-travail-frontend/src/conventions/Search/api/enterprises.service.ts
@@ -55,20 +55,17 @@ const apiEnterprises = function createFetcher(
     address ? `&a=${encodeURIComponent(address)}` : ""
   }`;
 
-  return fetch(url)
-    .then(async (response) => {
-      if (response.ok) {
-        return response.json();
-      }
-      if (response.status === 404) {
-        return { entreprises: [] };
-      }
-      const errorMessage = await response.text();
-      return Promise.reject(errorMessage);
-    })
-    .then((result: ApiEnterpriseData) => {
-      return result.entreprises;
-    });
+  return fetch(url).then(async (response) => {
+    if (response.ok) {
+      const res = await response.json();
+      return res.entreprises;
+    }
+    if (response.status === 404 || !response.ok) {
+      return { entreprises: [] };
+    }
+    const errorMessage = (await response.json()).message;
+    return Promise.reject(errorMessage);
+  });
 };
 
 const searchEnterprises = debounce(apiEnterprises, 300);

--- a/packages/code-du-travail-frontend/src/conventions/Search/api/enterprises.service.ts
+++ b/packages/code-du-travail-frontend/src/conventions/Search/api/enterprises.service.ts
@@ -63,8 +63,9 @@ const apiEnterprises = function createFetcher(
     if (response.status === 404 || !response.ok) {
       return { entreprises: [] };
     }
-    const errorMessage = (await response.json()).message;
-    return Promise.reject(errorMessage);
+    return Promise.reject(
+      "Ce service est momentanément indisponible. Vous pouvez tout de même poursuivre la simulation pour obtenir le résultat prévu par le code du travail en sélectionnant l'option \"Je ne souhaite pas renseigner ma convention collective (je passe l'étape)\""
+    );
   });
 };
 


### PR DESCRIPTION
fix #5094 

FROM : 
![Screenshot 2023-04-14 at 12 01 32](https://user-images.githubusercontent.com/25312957/232019256-5149527d-cdbc-4027-a820-bbe68c21d75e.png)


TO : 

![Screenshot 2023-04-14 at 12 18 47](https://user-images.githubusercontent.com/25312957/232019301-415ed7f8-e5af-4e40-9b81-44131f7fc6eb.png)

C'est plus sympa :)
