### PR TITLE
fix(error): "undefined is not an object (evaluating 't.input.focus')" seen on sentry

### DIFF
--- a/packages/code-du-travail-frontend/src/outils/common/Agreement/AgreementSearch/AgreementInput/SearchAgreementInput.tsx
+++ b/packages/code-du-travail-frontend/src/outils/common/Agreement/AgreementSearch/AgreementInput/SearchAgreementInput.tsx
@@ -41,11 +41,7 @@ export const SearchAgreementInput = ({
   const onSearch = async ({ value }) => {
     setQuery(value);
   };
-  const focusInput = (autoSuggest) => {
-    if (autoSuggest) {
-      autoSuggest.input?.focus();
-    }
-  };
+
   const onSelect = async (event, data) => {
     event.preventDefault();
     onSelectAgreement(data.suggestion);
@@ -86,7 +82,6 @@ export const SearchAgreementInput = ({
       </InfoBulle>
 
       <Autosuggest
-        ref={focusInput}
         theme={suggesterTheme}
         suggestions={state.data ?? []}
         alwaysRenderSuggestions={false}

--- a/packages/code-du-travail-frontend/src/search/SearchBar/DocumentSuggester.js
+++ b/packages/code-du-travail-frontend/src/search/SearchBar/DocumentSuggester.js
@@ -10,12 +10,6 @@ import { suggesterGlobalSearchTheme } from "./DocumentSuggesterTheme";
 const { colors } = theme;
 
 export class DocumentSuggester extends React.Component {
-  focusInput = (autoSuggest) => {
-    if (autoSuggest && this.props.hasFocus) {
-      autoSuggest.input?.focus();
-    }
-  };
-
   onSuggestionSelected = (event, data) => {
     this.props.onSelect(data.suggestion, event);
   };
@@ -74,7 +68,6 @@ export class DocumentSuggester extends React.Component {
     };
     return (
       <Autosuggest
-        ref={this.focusInput}
         theme={suggesterGlobalSearchTheme}
         suggestions={suggestions}
         alwaysRenderSuggestions={false}


### PR DESCRIPTION
The [previous attempt](https://github.com/SocialGouv/code-du-travail-numerique/commit/03b22b184dc497db2f2a68c52ecfad8c6d32f3e6#diff-d1ff85eaf69833216a671a762cb02b17a7c381a59969905fb42b66c07af7040dR44) to fix this error has introduce a new similar error the day of its deployement 
![Screenshot from 2023-05-03 14-46-30](https://user-images.githubusercontent.com/4971715/235920130-878319cf-77bc-43bb-a5e6-517b9981416b.png)

So I try to remove it all as it seems un-needed
