### PR TITLE
fix(accessibility): remove b and i tags

### DIFF
--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/droit-du-travail.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/droit-du-travail.test.js.snap
@@ -271,7 +271,7 @@ exports[`<DroitDuTravail /> should render 1`] = `
                       Le droit du travail, ce n’est pas…
                     </p>
                     <p
-                      class="sc-jGKxIK cNijme"
+                      class="sc-jGKxIK eoUrZA"
                     >
                       Le droit du travail ne concerne pas les travailleurs qui sont soumis au droit public (par exemple, les fonctionnaires), les travailleurs indépendants (artisan, commerçant, professions libérales…), les bénévoles et les dirigeants d’entreprise.
                     </p>

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/fiche-ministere-travail.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/fiche-ministere-travail.test.tsx.snap
@@ -409,7 +409,7 @@ exports[`<FicheMT /> should render 1`] = `
                   class="sc-dGCmGc eKMRHH"
                 >
                   <p
-                    class="sc-jGKxIK biFdvs"
+                    class="sc-jGKxIK ksIRLJ"
                   >
                     <span
                       class="sc-deXhhX cpCGcE"
@@ -448,7 +448,7 @@ exports[`<FicheMT /> should render 1`] = `
                   class="sc-iGgWBj sc-camqpD cWzIZL jhaGPC"
                 >
                   <p
-                    class="sc-jGKxIK cNijme"
+                    class="sc-jGKxIK eoUrZA"
                   >
                     lorem ipsum intro
                   </p>
@@ -581,7 +581,7 @@ exports[`<FicheMT /> should render 1`] = `
             class="sc-aXZVg sc-gweoQa gZgZQL dBuquk"
           >
             <p
-              class="sc-jGKxIK cNijme"
+              class="sc-jGKxIK eoUrZA"
             >
               Partager ce contenu : 
             </p>

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers-[slug].test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers-[slug].test.tsx.snap
@@ -409,7 +409,7 @@ exports[`<ModelesDeCourrier /> should render 1`] = `
                   class="sc-lfYzqA cUAqSf"
                 >
                   <p
-                    class="sc-jGKxIK biFdvs"
+                    class="sc-jGKxIK ksIRLJ"
                   >
                     <span
                       class="sc-bHnlcS fNuGBd"
@@ -428,7 +428,7 @@ exports[`<ModelesDeCourrier /> should render 1`] = `
                   class="sc-iGgWBj sc-iLWXdy cWzIZL gdxCJX"
                 >
                   <p
-                    class="sc-jGKxIK cNijme"
+                    class="sc-jGKxIK eoUrZA"
                   >
                     un description
                   </p>
@@ -562,7 +562,7 @@ exports[`<ModelesDeCourrier /> should render 1`] = `
             class="sc-aXZVg sc-huFNyZ gZgZQL hGRaJQ"
           >
             <p
-              class="sc-jGKxIK cNijme"
+              class="sc-jGKxIK eoUrZA"
             >
               Partager ce contenu : 
             </p>

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/stats.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/stats.test.tsx.snap
@@ -221,7 +221,7 @@ exports[`<Stats /> should render 1`] = `
                         Contenus référencés
                       </h2>
                       <p
-                        class="sc-jGKxIK jlhpER sc-cyRcrZ cAvSoG"
+                        class="sc-jGKxIK igvbLD sc-cyRcrZ cAvSoG"
                       >
                         16
                       </p>
@@ -240,7 +240,7 @@ exports[`<Stats /> should render 1`] = `
                         Visites
                       </h2>
                       <p
-                        class="sc-jGKxIK jlhpER sc-cyRcrZ cAvSoG"
+                        class="sc-jGKxIK igvbLD sc-cyRcrZ cAvSoG"
                       >
                         20
                       </p>
@@ -259,7 +259,7 @@ exports[`<Stats /> should render 1`] = `
                         Recherches
                       </h2>
                       <p
-                        class="sc-jGKxIK jlhpER sc-cyRcrZ cAvSoG"
+                        class="sc-jGKxIK igvbLD sc-cyRcrZ cAvSoG"
                       >
                         4
                       </p>
@@ -278,7 +278,7 @@ exports[`<Stats /> should render 1`] = `
                         Consultations
                       </h2>
                       <p
-                        class="sc-jGKxIK jlhpER sc-cyRcrZ cAvSoG"
+                        class="sc-jGKxIK igvbLD sc-cyRcrZ cAvSoG"
                       >
                         10
                       </p>

--- a/packages/code-du-travail-frontend/src/common/Feedback/__tests__/__snapshots__/Feedback.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/Feedback/__tests__/__snapshots__/Feedback.test.js.snap
@@ -149,7 +149,7 @@ exports[`<Feedback/> should render form once user answer no 1`] = `
           />
           <div>
             <span
-              class="sc-ibQAlb jWZTFp"
+              class="sc-ibQAlb eBJOHM"
             >
               150
                caractères restants
@@ -242,7 +242,7 @@ exports[`<Feedback/> should render form once user answer yes 1`] = `
           />
           <div>
             <span
-              class="sc-ibQAlb jWZTFp"
+              class="sc-ibQAlb eBJOHM"
             >
               150
                caractères restants

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/Answer.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/Answer.test.js.snap
@@ -165,7 +165,7 @@ exports[`<Answer /> should renders 1`] = `
               class="sc-dGCmGc eKMRHH"
             >
               <p
-                class="sc-jGKxIK biFdvs"
+                class="sc-jGKxIK ksIRLJ"
               >
                 <span
                   class="sc-deXhhX cpCGcE"
@@ -196,7 +196,7 @@ exports[`<Answer /> should renders 1`] = `
               class="sc-iGgWBj sc-camqpD cWzIZL jhaGPC"
             >
               <p
-                class="sc-jGKxIK cNijme"
+                class="sc-jGKxIK eoUrZA"
               >
                 intro de l'article
               </p>
@@ -223,7 +223,7 @@ exports[`<Answer /> should renders 1`] = `
         class="sc-aXZVg sc-gweoQa gZgZQL dBuquk"
       >
         <p
-          class="sc-jGKxIK cNijme"
+          class="sc-jGKxIK eoUrZA"
         >
           Partager ce contenu : 
         </p>
@@ -657,7 +657,7 @@ exports[`<Answer /> should renders a breadcrumbs 1`] = `
               class="sc-dGCmGc eKMRHH"
             >
               <p
-                class="sc-jGKxIK biFdvs"
+                class="sc-jGKxIK ksIRLJ"
               >
                 <span
                   class="sc-deXhhX cpCGcE"
@@ -688,7 +688,7 @@ exports[`<Answer /> should renders a breadcrumbs 1`] = `
               class="sc-iGgWBj sc-camqpD cWzIZL jhaGPC"
             >
               <p
-                class="sc-jGKxIK cNijme"
+                class="sc-jGKxIK eoUrZA"
               >
                 intro de l'article
               </p>
@@ -715,7 +715,7 @@ exports[`<Answer /> should renders a breadcrumbs 1`] = `
         class="sc-aXZVg sc-gweoQa gZgZQL dBuquk"
       >
         <p
-          class="sc-jGKxIK cNijme"
+          class="sc-jGKxIK eoUrZA"
         >
           Partager ce contenu : 
         </p>
@@ -1058,7 +1058,7 @@ exports[`<Answer /> should renders back to results link 1`] = `
               class="sc-dGCmGc eKMRHH"
             >
               <p
-                class="sc-jGKxIK biFdvs"
+                class="sc-jGKxIK ksIRLJ"
               >
                 <span
                   class="sc-deXhhX cpCGcE"
@@ -1089,7 +1089,7 @@ exports[`<Answer /> should renders back to results link 1`] = `
               class="sc-iGgWBj sc-camqpD cWzIZL jhaGPC"
             >
               <p
-                class="sc-jGKxIK cNijme"
+                class="sc-jGKxIK eoUrZA"
               >
                 intro de l'article
               </p>
@@ -1116,7 +1116,7 @@ exports[`<Answer /> should renders back to results link 1`] = `
         class="sc-aXZVg sc-gweoQa gZgZQL dBuquk"
       >
         <p
-          class="sc-jGKxIK cNijme"
+          class="sc-jGKxIK eoUrZA"
         >
           Partager ce contenu : 
         </p>
@@ -1459,7 +1459,7 @@ exports[`<Answer /> should renders related content 1`] = `
               class="sc-dGCmGc eKMRHH"
             >
               <p
-                class="sc-jGKxIK biFdvs"
+                class="sc-jGKxIK ksIRLJ"
               >
                 <span
                   class="sc-deXhhX cpCGcE"
@@ -1490,7 +1490,7 @@ exports[`<Answer /> should renders related content 1`] = `
               class="sc-iGgWBj sc-camqpD cWzIZL jhaGPC"
             >
               <p
-                class="sc-jGKxIK cNijme"
+                class="sc-jGKxIK eoUrZA"
               >
                 intro de l'article
               </p>
@@ -1514,7 +1514,7 @@ exports[`<Answer /> should renders related content 1`] = `
         class="sc-aXZVg sc-gweoQa gZgZQL dBuquk"
       >
         <p
-          class="sc-jGKxIK cNijme"
+          class="sc-jGKxIK eoUrZA"
         >
           Partager ce contenu : 
         </p>
@@ -2021,7 +2021,7 @@ exports[`<Answer /> should renders tooltip 1`] = `
               class="sc-dGCmGc eKMRHH"
             >
               <p
-                class="sc-jGKxIK biFdvs"
+                class="sc-jGKxIK ksIRLJ"
               >
                 <span
                   class="sc-deXhhX cpCGcE"
@@ -2052,7 +2052,7 @@ exports[`<Answer /> should renders tooltip 1`] = `
               class="sc-iGgWBj sc-camqpD cWzIZL jhaGPC"
             >
               <p
-                class="sc-jGKxIK cNijme"
+                class="sc-jGKxIK eoUrZA"
               >
                 intro de l'article
               </p>
@@ -2080,7 +2080,7 @@ exports[`<Answer /> should renders tooltip 1`] = `
         class="sc-aXZVg sc-gweoQa gZgZQL dBuquk"
       >
         <p
-          class="sc-jGKxIK cNijme"
+          class="sc-jGKxIK eoUrZA"
         >
           Partager ce contenu : 
         </p>
@@ -2423,7 +2423,7 @@ exports[`<Answer /> should renders tooltip for words with diacritics without bre
               class="sc-dGCmGc eKMRHH"
             >
               <p
-                class="sc-jGKxIK biFdvs"
+                class="sc-jGKxIK ksIRLJ"
               >
                 <span
                   class="sc-deXhhX cpCGcE"
@@ -2454,7 +2454,7 @@ exports[`<Answer /> should renders tooltip for words with diacritics without bre
               class="sc-iGgWBj sc-camqpD cWzIZL jhaGPC"
             >
               <p
-                class="sc-jGKxIK cNijme"
+                class="sc-jGKxIK eoUrZA"
               >
                 intro de l'article
               </p>
@@ -2482,7 +2482,7 @@ exports[`<Answer /> should renders tooltip for words with diacritics without bre
         class="sc-aXZVg sc-gweoQa gZgZQL dBuquk"
       >
         <p
-          class="sc-jGKxIK cNijme"
+          class="sc-jGKxIK eoUrZA"
         >
           Partager ce contenu : 
         </p>
@@ -2825,7 +2825,7 @@ exports[`<Answer /> should renders tooltip without breaking a tag 1`] = `
               class="sc-dGCmGc eKMRHH"
             >
               <p
-                class="sc-jGKxIK biFdvs"
+                class="sc-jGKxIK ksIRLJ"
               >
                 <span
                   class="sc-deXhhX cpCGcE"
@@ -2856,7 +2856,7 @@ exports[`<Answer /> should renders tooltip without breaking a tag 1`] = `
               class="sc-iGgWBj sc-camqpD cWzIZL jhaGPC"
             >
               <p
-                class="sc-jGKxIK cNijme"
+                class="sc-jGKxIK eoUrZA"
               >
                 intro de l'article
               </p>
@@ -2885,7 +2885,7 @@ exports[`<Answer /> should renders tooltip without breaking a tag 1`] = `
         class="sc-aXZVg sc-gweoQa gZgZQL dBuquk"
       >
         <p
-          class="sc-jGKxIK cNijme"
+          class="sc-jGKxIK eoUrZA"
         >
           Partager ce contenu : 
         </p>
@@ -3228,7 +3228,7 @@ exports[`<Answer /> should renders tooltip without breaking previous word 1`] = 
               class="sc-dGCmGc eKMRHH"
             >
               <p
-                class="sc-jGKxIK biFdvs"
+                class="sc-jGKxIK ksIRLJ"
               >
                 <span
                   class="sc-deXhhX cpCGcE"
@@ -3259,7 +3259,7 @@ exports[`<Answer /> should renders tooltip without breaking previous word 1`] = 
               class="sc-iGgWBj sc-camqpD cWzIZL jhaGPC"
             >
               <p
-                class="sc-jGKxIK cNijme"
+                class="sc-jGKxIK eoUrZA"
               >
                 intro de l'article
               </p>
@@ -3283,7 +3283,7 @@ exports[`<Answer /> should renders tooltip without breaking previous word 1`] = 
         class="sc-aXZVg sc-gweoQa gZgZQL dBuquk"
       >
         <p
-          class="sc-jGKxIK cNijme"
+          class="sc-jGKxIK eoUrZA"
         >
           Partager ce contenu : 
         </p>

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/Article.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/Article.test.js.snap
@@ -159,7 +159,7 @@ exports[`<Article /> should render 1`] = `
           class="sc-fulCBj bbTwFm"
         >
           <p
-            class="sc-jGKxIK biFdvs"
+            class="sc-jGKxIK ksIRLJ"
           >
             <span
               class="sc-empnci fjeUKR"

--- a/packages/code-du-travail-frontend/src/contributions/Contribution.tsx
+++ b/packages/code-du-travail-frontend/src/contributions/Contribution.tsx
@@ -8,6 +8,7 @@ import {
   InsertTitle,
   Paragraph,
   Section,
+  Text,
   theme,
   Title,
   Toast,
@@ -127,7 +128,8 @@ const Contribution = ({ answers, content }) => {
             >
               {isConventionalAnswer ? (
                 <>
-                  Que dit la convention <i>{conventionAnswer.shortName}</i>
+                  Que dit la convention{" "}
+                  <Text italic>{conventionAnswer.shortName}</Text>
                   &nbsp;?
                 </>
               ) : (

--- a/packages/code-du-travail-frontend/src/contributions/ContributionCC.tsx
+++ b/packages/code-du-travail-frontend/src/contributions/ContributionCC.tsx
@@ -7,6 +7,7 @@ import {
   icons,
   Paragraph,
   Section,
+  Text,
   theme,
   Title,
   Toast,
@@ -61,7 +62,8 @@ const ContributionCC = ({ answers, content, slug }) => {
               <Title shift={spacings.xmedium} variant="primary">
                 {isConventionalAnswer ? (
                   <>
-                    Que dit la convention <i>{conventionAnswer.shortName}</i>
+                    Que dit la convention{" "}
+                    <Text italic>{conventionAnswer.shortName}</Text>
                     &nbsp;?
                   </>
                 ) : (

--- a/packages/code-du-travail-frontend/src/contributions/__tests__/__snapshots__/Contribution.test.tsx.snap
+++ b/packages/code-du-travail-frontend/src/contributions/__tests__/__snapshots__/Contribution.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`<Contribution /> should NOT render invalid preselected convention 1`] =
           Page personnalisable
         </p>
         <p
-          class="sc-jGKxIK cNijme"
+          class="sc-jGKxIK eoUrZA"
         >
           Le contenu de cette page peut être personnalisé en fonction de votre situation.
           <br />
@@ -265,7 +265,7 @@ exports[`<Contribution /> should render answer references 1`] = `
           Page personnalisable
         </p>
         <p
-          class="sc-jGKxIK cNijme"
+          class="sc-jGKxIK eoUrZA"
         >
           Le contenu de cette page peut être personnalisé en fonction de votre situation.
           <br />
@@ -447,7 +447,7 @@ exports[`<Contribution /> should render preselected convention 1`] = `
           Page personnalisable
         </p>
         <p
-          class="sc-jGKxIK cNijme"
+          class="sc-jGKxIK eoUrZA"
         >
           Le contenu de cette page peut être personnalisé en fonction de votre situation.
           <br />
@@ -629,7 +629,7 @@ exports[`<Contribution /> should render with both answers 1`] = `
           Page personnalisable
         </p>
         <p
-          class="sc-jGKxIK cNijme"
+          class="sc-jGKxIK eoUrZA"
         >
           Le contenu de cette page peut être personnalisé en fonction de votre situation.
           <br />
@@ -811,7 +811,7 @@ exports[`<Contribution /> should render with conventions answer 1`] = `
           Page personnalisable
         </p>
         <p
-          class="sc-jGKxIK cNijme"
+          class="sc-jGKxIK eoUrZA"
         >
           Le contenu de cette page peut être personnalisé en fonction de votre situation.
           <br />

--- a/packages/code-du-travail-frontend/src/conventions/Search/__tests__/__snapshots__/Search.test.js.snap
+++ b/packages/code-du-travail-frontend/src/conventions/Search/__tests__/__snapshots__/Search.test.js.snap
@@ -65,7 +65,7 @@ exports[`<Search /> should show no results when no result 1`] = `
     class="sc-dycYrt lbBSWD"
   >
     <p
-      class="sc-jGKxIK cNijme"
+      class="sc-jGKxIK eoUrZA"
     >
       Aucun résultat n’a été trouvé.
     </p>
@@ -115,7 +115,7 @@ exports[`<Search /> should show spinner when loading 1`] = `
     class="sc-dycYrt lbBSWD"
   >
     <p
-      class="sc-jGKxIK cNijme"
+      class="sc-jGKxIK eoUrZA"
     >
       <svg
         aria-labelledby="title desc"
@@ -386,7 +386,7 @@ exports[`<Search /> when searching by text, should use enterprise API 1`] = `
     class="sc-dycYrt lbBSWD"
   >
     <p
-      class="sc-jGKxIK cNijme"
+      class="sc-jGKxIK eoUrZA"
     >
       Le service de recherche est indisponible.
     </p>

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisDemission/steps/__tests__/__snapshots__/Result.test.tsx.snap
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisDemission/steps/__tests__/__snapshots__/Result.test.tsx.snap
@@ -178,7 +178,7 @@ exports[`<StepResult /> should render CC answer 1`] = `
         class="sc-dSCufp gAzXIi"
       >
         <p
-          class="sc-jGKxIK chnJmR sc-lnPyaJ dsXzGD"
+          class="sc-jGKxIK iOBtQr sc-lnPyaJ dsXzGD"
         >
           Attention il peut exister une autre durée de préavis
         </p>

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisLicenciement/steps/__tests__/__snapshots__/Result.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisLicenciement/steps/__tests__/__snapshots__/Result.test.js.snap
@@ -182,7 +182,7 @@ exports[`<StepResult /> should render with O duration 1`] = `
         class="sc-dSCufp gAzXIi"
       >
         <p
-          class="sc-jGKxIK chnJmR sc-gvZAcH erbkqm"
+          class="sc-jGKxIK iOBtQr sc-gvZAcH erbkqm"
         >
           Attention il peut exister une durée plus favorable
         </p>
@@ -372,7 +372,7 @@ exports[`<StepResult /> should render with both CC duration and CDT duration 1`]
         class="sc-dSCufp gAzXIi"
       >
         <p
-          class="sc-jGKxIK chnJmR sc-gvZAcH erbkqm"
+          class="sc-jGKxIK iOBtQr sc-gvZAcH erbkqm"
         >
           Attention il peut exister une durée plus favorable
         </p>
@@ -535,7 +535,7 @@ exports[`<StepResult /> should render with only CC duration 1`] = `
         class="sc-dSCufp gAzXIi"
       >
         <p
-          class="sc-jGKxIK chnJmR sc-gvZAcH erbkqm"
+          class="sc-jGKxIK iOBtQr sc-gvZAcH erbkqm"
         >
           Attention il peut exister une durée plus favorable
         </p>
@@ -724,7 +724,7 @@ exports[`<StepResult /> should render with when no CC 1`] = `
         class="sc-dSCufp gAzXIi"
       >
         <p
-          class="sc-jGKxIK chnJmR sc-gvZAcH erbkqm"
+          class="sc-jGKxIK iOBtQr sc-gvZAcH erbkqm"
         >
           Attention il peut exister une durée plus favorable
         </p>
@@ -914,7 +914,7 @@ exports[`<StepResult /> should render with when unhandled CC 1`] = `
         class="sc-dSCufp gAzXIi"
       >
         <p
-          class="sc-jGKxIK chnJmR sc-gvZAcH erbkqm"
+          class="sc-jGKxIK iOBtQr sc-gvZAcH erbkqm"
         >
           Attention il peut exister une durée plus favorable
         </p>

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisLicenciement/steps/__tests__/__snapshots__/Status.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisLicenciement/steps/__tests__/__snapshots__/Status.test.js.snap
@@ -7,11 +7,11 @@ exports[`<StepStatus /> should render 1`] = `
     data-testid="question-label"
   >
     <span
-      class="sc-ibQAlb iORupB"
+      class="sc-ibQAlb iRaavs"
     >
       Le licenciement est-il dû à une faute grave (ou lourde) ?
       <span
-        class="sc-ibQAlb iapAQd"
+        class="sc-ibQAlb TTAtT"
       >
          (obligatoire)
       </span>
@@ -67,11 +67,11 @@ exports[`<StepStatus /> should render coefficient 1`] = `
     data-testid="question-label"
   >
     <span
-      class="sc-ibQAlb iORupB"
+      class="sc-ibQAlb iRaavs"
     >
       Le licenciement est-il dû à une faute grave (ou lourde) ?
       <span
-        class="sc-ibQAlb iapAQd"
+        class="sc-ibQAlb TTAtT"
       >
          (obligatoire)
       </span>
@@ -123,11 +123,11 @@ exports[`<StepStatus /> should render coefficient 1`] = `
     data-testid="question-label"
   >
     <span
-      class="sc-ibQAlb iORupB"
+      class="sc-ibQAlb iRaavs"
     >
       Le salarié concerné est-il reconnu en tant que travailleur handicapé ?
       <span
-        class="sc-ibQAlb iapAQd"
+        class="sc-ibQAlb TTAtT"
       >
          (obligatoire)
       </span>
@@ -183,11 +183,11 @@ exports[`<StepStatus /> should render coefficient 1`] = `
       for="input-cdt.ancienneté"
     >
       <span
-        class="sc-ibQAlb iORupB"
+        class="sc-ibQAlb iRaavs"
       >
         Quelle est l'ancienneté du salarié ?
         <span
-          class="sc-ibQAlb iapAQd"
+          class="sc-ibQAlb TTAtT"
         >
            (obligatoire)
         </span>
@@ -308,11 +308,11 @@ exports[`<StepStatus /> should render seriousMisconduct 1`] = `
     data-testid="question-label"
   >
     <span
-      class="sc-ibQAlb iORupB"
+      class="sc-ibQAlb iRaavs"
     >
       Le licenciement est-il dû à une faute grave (ou lourde) ?
       <span
-        class="sc-ibQAlb iapAQd"
+        class="sc-ibQAlb TTAtT"
       >
          (obligatoire)
       </span>
@@ -364,11 +364,11 @@ exports[`<StepStatus /> should render seriousMisconduct 1`] = `
     data-testid="question-label"
   >
     <span
-      class="sc-ibQAlb iORupB"
+      class="sc-ibQAlb iRaavs"
     >
       Le salarié concerné est-il reconnu en tant que travailleur handicapé ?
       <span
-        class="sc-ibQAlb iapAQd"
+        class="sc-ibQAlb TTAtT"
       >
          (obligatoire)
       </span>

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/Components/PreavisRetraiteSimulator/steps.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/Components/PreavisRetraiteSimulator/steps.tsx
@@ -10,7 +10,6 @@ import {
 import IntroAnnotation from "../../steps/component/IntroAnnotation";
 import React from "react";
 import { Step } from "../../../Simulator";
-import { PreavisRetraiteFormState } from "../../form";
 
 export const steps: Step<StepName>[] = [
   {

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/ResultStep/Components/DecryptedResult.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/ResultStep/Components/DecryptedResult.tsx
@@ -218,11 +218,9 @@ const DecryptedResult: React.FC<Props> = ({
       </Paragraph>
       {description && <Paragraph>{description}</Paragraph>}
       {rootData.handicap && (
-        <Paragraph>
-          <i>
-            Ce résultat tient compte de la majoration pour les travailleurs
-            handicapés.
-          </i>
+        <Paragraph italic>
+          Ce résultat tient compte de la majoration pour les travailleurs
+          handicapés.
         </Paragraph>
       )}
     </>

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/component/IntroAnnotation.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisRetraite/steps/component/IntroAnnotation.tsx
@@ -1,11 +1,12 @@
 import React from "react";
+import { Text } from "@socialgouv/cdtn-ui";
 
 const IntroAnnotation = (): JSX.Element => {
   return (
-    <i>
+    <Text italic>
       Attention&nbsp;: Le résultat affiché correspond à la durée légale ou
       conventionnelle, en fonction des informations renseignées.
-    </i>
+    </Text>
   );
 };
 

--- a/packages/code-du-travail-frontend/src/outils/HeuresRechercheEmploi/steps/__tests__/__snapshots__/Result.test.tsx.snap
+++ b/packages/code-du-travail-frontend/src/outils/HeuresRechercheEmploi/steps/__tests__/__snapshots__/Result.test.tsx.snap
@@ -129,7 +129,7 @@ exports[`<StepResult /> should render no results 1`] = `
         class="sc-dSCufp gAzXIi"
       >
         <p
-          class="sc-jGKxIK chnJmR sc-lnPyaJ dsXzGD"
+          class="sc-jGKxIK iOBtQr sc-lnPyaJ dsXzGD"
         >
           Attention il peut exister une durée plus favorable
         </p>
@@ -287,7 +287,7 @@ exports[`<StepResult /> should render with duration 1`] = `
         class="sc-dSCufp gAzXIi"
       >
         <p
-          class="sc-jGKxIK chnJmR sc-lnPyaJ dsXzGD"
+          class="sc-jGKxIK iOBtQr sc-lnPyaJ dsXzGD"
         >
           Attention il peut exister une durée plus favorable
         </p>

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/Resultat/components/FilledElements.tsx
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/Resultat/components/FilledElements.tsx
@@ -1,7 +1,7 @@
 import { Absence, SalaryPeriods } from "@socialgouv/modeles-social";
 import { SectionTitle } from "../../../../common/stepStyles";
 import { AgreementInformation } from "../../../common";
-import { Table, theme, Paragraph } from "@socialgouv/cdtn-ui";
+import { Paragraph, Table, theme } from "@socialgouv/cdtn-ui";
 import styled from "styled-components";
 import { publicodesUnitTranslator } from "../../../../publicodes";
 import AbsenceTable from "./AbsenceTable";
@@ -56,15 +56,12 @@ export default function FilledElements(props: Props) {
                 !props.isAgreementBetter &&
                 "*"}
               {props.isLicenciementInaptitude && !props.isAgreementBetter && (
-                <>
-                  <br />
-                  <i>
-                    * Le salarié ayant été licencié pour inaptitude suite à un
-                    accident du travail ou une maladie professionnelle reconnue,
-                    le montant de l&apos;indemnité de licenciement légale est
-                    doublé
-                  </i>
-                </>
+                <Paragraph italic noMargin>
+                  * Le salarié ayant été licencié pour inaptitude suite à un
+                  accident du travail ou une maladie professionnelle reconnue,
+                  le montant de l&apos;indemnité de licenciement légale est
+                  doublé
+                </Paragraph>
               )}
               <li>
                 Arrêt de travail au moment du licenciement&nbsp;:&nbsp;
@@ -122,15 +119,13 @@ export default function FilledElements(props: Props) {
               {!props.disableParentalNotice && <sup>*</sup>}&nbsp;:&nbsp;
               {props.absencesPeriods.length > 0 ? "Oui" : "Non"}
               {!props.disableParentalNotice && (
-                <Paragraph fontSize="small" noMargin>
-                  <i>
-                    <sup>*</sup> Depuis le 11 mars 2023 les périodes d’absence
-                    pour congé paternité ne sont plus retirées de l’ancienneté
-                    du salarié. Si le salarié a pris un congé paternité avant
-                    cette date, il peut être décompté de son ancienneté et de ce
-                    fait, donner lieu à un montant d’indemnité moins favorable
-                    que celui de notre simulateur.
-                  </i>
+                <Paragraph fontSize="small" noMargin italic>
+                  <sup>*</sup> Depuis le 11 mars 2023 les périodes d’absence
+                  pour congé paternité ne sont plus retirées de l’ancienneté du
+                  salarié. Si le salarié a pris un congé paternité avant cette
+                  date, il peut être décompté de son ancienneté et de ce fait,
+                  donner lieu à un montant d’indemnité moins favorable que celui
+                  de notre simulateur.
                 </Paragraph>
               )}
             </li>
@@ -228,6 +223,7 @@ export const StyledFilledElementTable = styled(Table)`
   th {
     vertical-align: top;
   }
+
   tbody {
     th {
       font-weight: normal;

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/Resultat/components/ForMoreInfo.tsx
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/Resultat/components/ForMoreInfo.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
-import styled from "styled-components";
-import { theme } from "@socialgouv/cdtn-ui";
+import { Paragraph } from "@socialgouv/cdtn-ui/lib";
 
 type Props = {
   message?: string;
@@ -24,12 +23,9 @@ export default function ForMoreInfo({ message = defaultMessage }: Props) {
         </Link>
         .
       </p>
-      <StyledI>{message}</StyledI>
+      <Paragraph italic fontSize="small">
+        {message}
+      </Paragraph>
     </>
   );
 }
-const { fonts } = theme;
-
-const StyledI = styled.i`
-  font-size: ${fonts.sizes.small};
-`;

--- a/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/components/__tests__/__snapshots__/Salaires.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/components/__tests__/__snapshots__/Salaires.test.js.snap
@@ -7,11 +7,11 @@ exports[`<Salaires /> should add a salaire 1`] = `
     data-testid="question-label"
   >
     <span
-      class="sc-ibQAlb iORupB"
+      class="sc-ibQAlb iRaavs"
     >
       Quels sont les salaires mensuels bruts perçus durant le contrat de travail ?
       <span
-        class="sc-ibQAlb iapAQd"
+        class="sc-ibQAlb TTAtT"
       >
          (obligatoire)
       </span>
@@ -107,11 +107,11 @@ exports[`<Salaires /> should delete a salaires 1`] = `
     data-testid="question-label"
   >
     <span
-      class="sc-ibQAlb iORupB"
+      class="sc-ibQAlb iRaavs"
     >
       Quels sont les salaires mensuels bruts perçus durant le contrat de travail ?
       <span
-        class="sc-ibQAlb iapAQd"
+        class="sc-ibQAlb TTAtT"
       >
          (obligatoire)
       </span>
@@ -147,11 +147,11 @@ exports[`<Salaires /> should render 1`] = `
     data-testid="question-label"
   >
     <span
-      class="sc-ibQAlb iORupB"
+      class="sc-ibQAlb iRaavs"
     >
       Quels sont les salaires mensuels bruts perçus durant le contrat de travail ?
       <span
-        class="sc-ibQAlb iapAQd"
+        class="sc-ibQAlb TTAtT"
       >
          (obligatoire)
       </span>

--- a/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/components/__tests__/__snapshots__/TypeContrat.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/components/__tests__/__snapshots__/TypeContrat.test.js.snap
@@ -7,11 +7,11 @@ exports[`<TypeContrat /> should render 1`] = `
     data-testid="question-label"
   >
     <span
-      class="sc-ibQAlb iORupB"
+      class="sc-ibQAlb iRaavs"
     >
       Quel est le type du contrat de travail ?
       <span
-        class="sc-ibQAlb iapAQd"
+        class="sc-ibQAlb TTAtT"
       >
          (obligatoire)
       </span>

--- a/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/components/__tests__/__snapshots__/TypeRemuneration.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/components/__tests__/__snapshots__/TypeRemuneration.test.js.snap
@@ -7,11 +7,11 @@ exports[`<TypeRemuneration /> should render 1`] = `
     data-testid="question-label"
   >
     <span
-      class="sc-ibQAlb iORupB"
+      class="sc-ibQAlb iRaavs"
     >
       Comment souhaitez-vous indiquer la rémunération perçue pendant le contrat de travail ?
       <span
-        class="sc-ibQAlb iapAQd"
+        class="sc-ibQAlb TTAtT"
       >
          (obligatoire)
       </span>

--- a/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/steps/__tests__/__snapshots__/CDD.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/steps/__tests__/__snapshots__/CDD.test.js.snap
@@ -8,11 +8,11 @@ exports[`<StepCDD /> should render 1`] = `
       data-testid="question-label"
     >
       <span
-        class="sc-ibQAlb iORupB"
+        class="sc-ibQAlb iRaavs"
       >
         Le CDD a-t-il été rompu pendant la période d’essai du salarié ?
         <span
-          class="sc-ibQAlb iapAQd"
+          class="sc-ibQAlb TTAtT"
         >
            (obligatoire)
         </span>
@@ -64,11 +64,11 @@ exports[`<StepCDD /> should render 1`] = `
       data-testid="question-label"
     >
       <span
-        class="sc-ibQAlb iORupB"
+        class="sc-ibQAlb iRaavs"
       >
         À la fin du CDD, le salarié a-t-il été immédiatement embauché en CDI, sans interruption, sur un même poste ou sur un poste différent ?
         <span
-          class="sc-ibQAlb iapAQd"
+          class="sc-ibQAlb TTAtT"
         >
            (obligatoire)
         </span>
@@ -120,11 +120,11 @@ exports[`<StepCDD /> should render 1`] = `
       data-testid="question-label"
     >
       <span
-        class="sc-ibQAlb iORupB"
+        class="sc-ibQAlb iRaavs"
       >
         Le CDD a-t-il été rompu avant la fin prévue pour une des raisons suivantes : la propre initiative du salarié, la faute grave ou faute lourde du salarié, cas de force majeure ?
         <span
-          class="sc-ibQAlb iapAQd"
+          class="sc-ibQAlb TTAtT"
         >
            (obligatoire)
         </span>
@@ -176,11 +176,11 @@ exports[`<StepCDD /> should render 1`] = `
       data-testid="question-label"
     >
       <span
-        class="sc-ibQAlb iORupB"
+        class="sc-ibQAlb iRaavs"
       >
         Le salarié a-t-il refusé de renouveler le CDD alors que le renouvellement et ses modalités étaient prévus dès l’origine dans son contrat ?
         <span
-          class="sc-ibQAlb iapAQd"
+          class="sc-ibQAlb TTAtT"
         >
            (obligatoire)
         </span>

--- a/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/steps/__tests__/__snapshots__/CTT.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/steps/__tests__/__snapshots__/CTT.test.js.snap
@@ -8,11 +8,11 @@ exports[`<StepCTT /> should render 1`] = `
       data-testid="question-label"
     >
       <span
-        class="sc-ibQAlb iORupB"
+        class="sc-ibQAlb iRaavs"
       >
         S’agit-il d’un contrat de mission-formation ?
         <span
-          class="sc-ibQAlb iapAQd"
+          class="sc-ibQAlb TTAtT"
         >
            (obligatoire)
         </span>
@@ -64,11 +64,11 @@ exports[`<StepCTT /> should render 1`] = `
       data-testid="question-label"
     >
       <span
-        class="sc-ibQAlb iORupB"
+        class="sc-ibQAlb iRaavs"
       >
         Le contrat d'intérim a-t-il été rompu avant la fin prévue pour une des raisons suivantes : la propre initiative du salarié, la faute grave du salarié, cas de force majeure ?
         <span
-          class="sc-ibQAlb iapAQd"
+          class="sc-ibQAlb TTAtT"
         >
            (obligatoire)
         </span>
@@ -120,11 +120,11 @@ exports[`<StepCTT /> should render 1`] = `
       data-testid="question-label"
     >
       <span
-        class="sc-ibQAlb iORupB"
+        class="sc-ibQAlb iRaavs"
       >
         À la fin du contrat d'intérim, le salarié a-t-il été immédiatement embauché en CDI au sein de l'entreprise dans laquelle il effectuait sa mission ?
         <span
-          class="sc-ibQAlb iapAQd"
+          class="sc-ibQAlb TTAtT"
         >
            (obligatoire)
         </span>
@@ -176,11 +176,11 @@ exports[`<StepCTT /> should render 1`] = `
       data-testid="question-label"
     >
       <span
-        class="sc-ibQAlb iORupB"
+        class="sc-ibQAlb iRaavs"
       >
         Le salarié a-t-il refusé la mise en œuvre de la souplesse prévue dans le contrat d’intérim ?
         <span
-          class="sc-ibQAlb iapAQd"
+          class="sc-ibQAlb TTAtT"
         >
            (obligatoire)
         </span>

--- a/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/steps/__tests__/__snapshots__/Indemnite.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/steps/__tests__/__snapshots__/Indemnite.test.js.snap
@@ -421,7 +421,7 @@ exports[`<StepIndemnite /> should render cdd indemnite with conventional provisi
         class="sc-dSCufp gAzXIi"
       >
         <p
-          class="sc-jGKxIK chnJmR sc-dNsVcS klvPyc"
+          class="sc-jGKxIK iOBtQr sc-dNsVcS klvPyc"
         >
           Attention il peut exister un montant plus favorable
         </p>
@@ -857,7 +857,7 @@ exports[`<StepIndemnite /> should render cdd indemnite with no ccn message 1`] =
         class="sc-dSCufp gAzXIi"
       >
         <p
-          class="sc-jGKxIK chnJmR sc-dNsVcS klvPyc"
+          class="sc-jGKxIK iOBtQr sc-dNsVcS klvPyc"
         >
           Attention il peut exister un montant plus favorable
         </p>
@@ -1306,7 +1306,7 @@ exports[`<StepIndemnite /> should render cdd indemnite with no conventional prov
         class="sc-dSCufp gAzXIi"
       >
         <p
-          class="sc-jGKxIK chnJmR sc-dNsVcS klvPyc"
+          class="sc-jGKxIK iOBtQr sc-dNsVcS klvPyc"
         >
           Attention il peut exister un montant plus favorable
         </p>
@@ -1745,7 +1745,7 @@ exports[`<StepIndemnite /> should render cdd indemnite with unhandled cc message
         class="sc-dSCufp gAzXIi"
       >
         <p
-          class="sc-jGKxIK chnJmR sc-dNsVcS klvPyc"
+          class="sc-jGKxIK iOBtQr sc-dNsVcS klvPyc"
         >
           Attention il peut exister un montant plus favorable
         </p>
@@ -2184,7 +2184,7 @@ exports[`<StepIndemnite /> should render ctt indemnite 1`] = `
         class="sc-dSCufp gAzXIi"
       >
         <p
-          class="sc-jGKxIK chnJmR sc-dNsVcS klvPyc"
+          class="sc-jGKxIK iOBtQr sc-dNsVcS klvPyc"
         >
           Attention il peut exister un montant plus favorable
         </p>

--- a/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/steps/__tests__/__snapshots__/InfosGenerales.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/steps/__tests__/__snapshots__/InfosGenerales.test.js.snap
@@ -8,11 +8,11 @@ exports[`<StepInfosGenerales /> should render 1`] = `
       data-testid="question-label"
     >
       <span
-        class="sc-ibQAlb iORupB"
+        class="sc-ibQAlb iRaavs"
       >
         Quel est le type du contrat de travail ?
         <span
-          class="sc-ibQAlb iapAQd"
+          class="sc-ibQAlb TTAtT"
         >
            (obligatoire)
         </span>
@@ -69,11 +69,11 @@ exports[`<StepInfosGenerales /> should render with CDD 1`] = `
       data-testid="question-label"
     >
       <span
-        class="sc-ibQAlb iORupB"
+        class="sc-ibQAlb iRaavs"
       >
         Quel est le type du contrat de travail ?
         <span
-          class="sc-ibQAlb iapAQd"
+          class="sc-ibQAlb TTAtT"
         >
            (obligatoire)
         </span>
@@ -123,11 +123,11 @@ exports[`<StepInfosGenerales /> should render with CDD 1`] = `
         for="input-criteria.cddType"
       >
         <span
-          class="sc-ibQAlb iORupB"
+          class="sc-ibQAlb iRaavs"
         >
           Quel est le type de CDD ?
           <span
-            class="sc-ibQAlb iapAQd"
+            class="sc-ibQAlb TTAtT"
           >
              (obligatoire)
           </span>
@@ -246,11 +246,11 @@ exports[`<StepInfosGenerales /> should render with CDD and not handled ccn 1`] =
       data-testid="question-label"
     >
       <span
-        class="sc-ibQAlb iORupB"
+        class="sc-ibQAlb iRaavs"
       >
         Quel est le type du contrat de travail ?
         <span
-          class="sc-ibQAlb iapAQd"
+          class="sc-ibQAlb TTAtT"
         >
            (obligatoire)
         </span>
@@ -300,11 +300,11 @@ exports[`<StepInfosGenerales /> should render with CDD and not handled ccn 1`] =
         for="input-criteria.cddType"
       >
         <span
-          class="sc-ibQAlb iORupB"
+          class="sc-ibQAlb iRaavs"
         >
           Quel est le type de CDD ?
           <span
-            class="sc-ibQAlb iapAQd"
+            class="sc-ibQAlb TTAtT"
           >
              (obligatoire)
           </span>
@@ -423,11 +423,11 @@ exports[`<StepInfosGenerales /> should render with CTT 1`] = `
       data-testid="question-label"
     >
       <span
-        class="sc-ibQAlb iORupB"
+        class="sc-ibQAlb iRaavs"
       >
         Quel est le type du contrat de travail ?
         <span
-          class="sc-ibQAlb iapAQd"
+          class="sc-ibQAlb TTAtT"
         >
            (obligatoire)
         </span>
@@ -473,11 +473,11 @@ exports[`<StepInfosGenerales /> should render with CTT 1`] = `
       data-testid="question-label"
     >
       <span
-        class="sc-ibQAlb iORupB"
+        class="sc-ibQAlb iRaavs"
       >
         S’agit-il d’un contrat de mission-formation ?
         <span
-          class="sc-ibQAlb iapAQd"
+          class="sc-ibQAlb TTAtT"
         >
            (obligatoire)
         </span>
@@ -529,11 +529,11 @@ exports[`<StepInfosGenerales /> should render with CTT 1`] = `
       data-testid="question-label"
     >
       <span
-        class="sc-ibQAlb iORupB"
+        class="sc-ibQAlb iRaavs"
       >
         Le contrat d'intérim a-t-il été rompu avant la fin prévue pour une des raisons suivantes : la propre initiative du salarié, la faute grave du salarié, cas de force majeure ?
         <span
-          class="sc-ibQAlb iapAQd"
+          class="sc-ibQAlb TTAtT"
         >
            (obligatoire)
         </span>
@@ -585,11 +585,11 @@ exports[`<StepInfosGenerales /> should render with CTT 1`] = `
       data-testid="question-label"
     >
       <span
-        class="sc-ibQAlb iORupB"
+        class="sc-ibQAlb iRaavs"
       >
         À la fin du contrat d'intérim, le salarié a-t-il été immédiatement embauché en CDI au sein de l'entreprise dans laquelle il effectuait sa mission ?
         <span
-          class="sc-ibQAlb iapAQd"
+          class="sc-ibQAlb TTAtT"
         >
            (obligatoire)
         </span>
@@ -641,11 +641,11 @@ exports[`<StepInfosGenerales /> should render with CTT 1`] = `
       data-testid="question-label"
     >
       <span
-        class="sc-ibQAlb iORupB"
+        class="sc-ibQAlb iRaavs"
       >
         Le salarié a-t-il refusé la mise en œuvre de la souplesse prévue dans le contrat d’intérim ?
         <span
-          class="sc-ibQAlb iapAQd"
+          class="sc-ibQAlb TTAtT"
         >
            (obligatoire)
         </span>

--- a/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/steps/__tests__/__snapshots__/Remuneration.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/IndemnitePrecarite/steps/__tests__/__snapshots__/Remuneration.test.js.snap
@@ -7,11 +7,11 @@ exports[`<StepRemuneration /> should render multiple inputs 1`] = `
     data-testid="question-label"
   >
     <span
-      class="sc-ibQAlb iORupB"
+      class="sc-ibQAlb iRaavs"
     >
       Comment souhaitez-vous indiquer la rémunération perçue pendant le contrat de travail ?
       <span
-        class="sc-ibQAlb iapAQd"
+        class="sc-ibQAlb TTAtT"
       >
          (obligatoire)
       </span>
@@ -69,11 +69,11 @@ exports[`<StepRemuneration /> should render multiple inputs 1`] = `
     data-testid="question-label"
   >
     <span
-      class="sc-ibQAlb iORupB"
+      class="sc-ibQAlb iRaavs"
     >
       Quels sont les salaires mensuels bruts perçus durant le contrat de travail ?
       <span
-        class="sc-ibQAlb iapAQd"
+        class="sc-ibQAlb TTAtT"
       >
          (obligatoire)
       </span>
@@ -234,11 +234,11 @@ exports[`<StepRemuneration /> should render one input 1`] = `
     data-testid="question-label"
   >
     <span
-      class="sc-ibQAlb iORupB"
+      class="sc-ibQAlb iRaavs"
     >
       Comment souhaitez-vous indiquer la rémunération perçue pendant le contrat de travail ?
       <span
-        class="sc-ibQAlb iapAQd"
+        class="sc-ibQAlb TTAtT"
       >
          (obligatoire)
       </span>
@@ -297,11 +297,11 @@ exports[`<StepRemuneration /> should render one input 1`] = `
     for="currency-1"
   >
     <span
-      class="sc-ibQAlb iORupB"
+      class="sc-ibQAlb iRaavs"
     >
       Quelle est la rémunération totale brute perçue durant le contrat de travail ?
       <span
-        class="sc-ibQAlb iapAQd"
+        class="sc-ibQAlb TTAtT"
       >
          (obligatoire)
       </span>

--- a/packages/code-du-travail-frontend/src/outils/common/Feedback/QuestionnaireItem.tsx
+++ b/packages/code-du-travail-frontend/src/outils/common/Feedback/QuestionnaireItem.tsx
@@ -40,7 +40,7 @@ export const QuestionnaireItem = ({
   const [status, setStatus] = useState<Status>();
   return (
     <div className={className} data-testId={dataTestId}>
-      {title && <b>{title}</b>}
+      {title && <strong>{title}</strong>}
       <ButtonContainer>
         <StyledButton
           variant={status === Status.BAD ? "light" : "naked"}

--- a/packages/code-du-travail-frontend/src/outils/common/Feedback/QuestionnaireText.tsx
+++ b/packages/code-du-travail-frontend/src/outils/common/Feedback/QuestionnaireText.tsx
@@ -19,7 +19,7 @@ export const QuestionnaireText = ({
   const maxCharacters = 200;
   return (
     <StyledContainer className={className}>
-      {title && <b>{title}</b>}
+      {title && <strong>{title}</strong>}
       <StyledTextarea
         placeholder={placeholder}
         maxLength={maxCharacters}

--- a/packages/code-du-travail-frontend/src/outils/common/PubliSituation.tsx
+++ b/packages/code-du-travail-frontend/src/outils/common/PubliSituation.tsx
@@ -56,8 +56,8 @@ const PubliSituation = ({
     </ul>
     {annotations &&
       annotations.map((annotation, index) => (
-        <Paragraph key={index}>
-          <i>*&nbsp;{annotation}</i>
+        <Paragraph italic key={index}>
+          *&nbsp;{annotation}
         </Paragraph>
       ))}
   </>

--- a/packages/code-du-travail-frontend/src/outils/common/__tests__/__snapshots__/SelectQuestion.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/common/__tests__/__snapshots__/SelectQuestion.test.js.snap
@@ -11,11 +11,11 @@ exports[`<SelectQuestion /> should render with default value 1`] = `
       for="input-foo"
     >
       <span
-        class="sc-ibQAlb iORupB"
+        class="sc-ibQAlb iRaavs"
       >
         Une question ?
         <span
-          class="sc-ibQAlb iapAQd"
+          class="sc-ibQAlb TTAtT"
         >
            (obligatoire)
         </span>
@@ -95,11 +95,11 @@ exports[`<SelectQuestion /> should render with selectedValue value 1`] = `
       for="input-foo"
     >
       <span
-        class="sc-ibQAlb iORupB"
+        class="sc-ibQAlb iRaavs"
       >
         Une question ?
         <span
-          class="sc-ibQAlb iapAQd"
+          class="sc-ibQAlb TTAtT"
         >
            (obligatoire)
         </span>

--- a/packages/code-du-travail-frontend/src/outils/common/__tests__/__snapshots__/YesNoQuestion.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/common/__tests__/__snapshots__/YesNoQuestion.test.js.snap
@@ -7,11 +7,11 @@ exports[`<YesNoQuestion /> should render 1`] = `
     data-testid="question-label"
   >
     <span
-      class="sc-ibQAlb iORupB"
+      class="sc-ibQAlb iRaavs"
     >
       lorem ipsum ?
       <span
-        class="sc-ibQAlb iapAQd"
+        class="sc-ibQAlb TTAtT"
       >
          (obligatoire)
       </span>

--- a/packages/code-du-travail-frontend/src/questionnaire/Components/Question/Question.tsx
+++ b/packages/code-du-travail-frontend/src/questionnaire/Components/Question/Question.tsx
@@ -42,11 +42,17 @@ export const Question = ({ widgetMode }: QuestionProps) => {
           index={index}
         ></Response>
       ))}
-      <Paragraph italic>{currentQuestion?.description}</Paragraph>
+      <Description>{currentQuestion?.description}</Description>
     </Fieldset>
   );
 };
 
 const StyledInfoBulle = styled(InfoBulle)`
   padding: 0;
+`;
+
+const Description = styled.p`
+  margin-top: 7px;
+  margin-bottom: 0;
+  font-style: italic;
 `;

--- a/packages/code-du-travail-frontend/src/questionnaire/Components/Question/Question.tsx
+++ b/packages/code-du-travail-frontend/src/questionnaire/Components/Question/Question.tsx
@@ -6,6 +6,7 @@ import { Fieldset, Legend, Text } from "@socialgouv/cdtn-ui";
 import { InfoBulle } from "../../../outils/common/InfoBulle";
 import { trackClickHelp } from "../../tracking";
 import React, { useContext } from "react";
+import { Paragraph } from "@socialgouv/cdtn-ui/lib";
 
 type QuestionProps = {
   widgetMode: boolean;
@@ -41,16 +42,11 @@ export const Question = ({ widgetMode }: QuestionProps) => {
           index={index}
         ></Response>
       ))}
-      <Description>{currentQuestion?.description}</Description>
+      <Paragraph italic>{currentQuestion?.description}</Paragraph>
     </Fieldset>
   );
 };
 
 const StyledInfoBulle = styled(InfoBulle)`
   padding: 0;
-`;
-
-const Description = styled.i`
-  display: block;
-  margin-top: 7px;
 `;

--- a/packages/code-du-travail-frontend/src/search/__tests__/__snapshots__/SearchResults.test.js.snap
+++ b/packages/code-du-travail-frontend/src/search/__tests__/__snapshots__/SearchResults.test.js.snap
@@ -54,7 +54,7 @@ exports[`<SearchResults/> should render results 1`] = `
               class="sc-dxcDKg jfRleH"
             >
               <p
-                class="sc-jGKxIK cNijme"
+                class="sc-jGKxIK eoUrZA"
               >
                 description
               </p>
@@ -127,7 +127,7 @@ exports[`<SearchResults/> should render results 1`] = `
                 class="sc-dxcDKg jfRleH"
               >
                 <p
-                  class="sc-jGKxIK cNijme"
+                  class="sc-jGKxIK eoUrZA"
                 >
                   description
                 </p>
@@ -197,7 +197,7 @@ exports[`<SearchResults/> should render results 1`] = `
                 class="sc-dxcDKg jfRleH"
               >
                 <p
-                  class="sc-jGKxIK cNijme"
+                  class="sc-jGKxIK eoUrZA"
                 >
                   description
                 </p>
@@ -291,7 +291,7 @@ exports[`<SearchResults/> should render results 1`] = `
                 class="sc-dxcDKg jfRleH"
               >
                 <p
-                  class="sc-jGKxIK cNijme"
+                  class="sc-jGKxIK eoUrZA"
                 >
                   description
                 </p>
@@ -382,7 +382,7 @@ exports[`<SearchResults/> should render results 1`] = `
               class="sc-dxcDKg jfRleH"
             >
               <p
-                class="sc-jGKxIK cNijme"
+                class="sc-jGKxIK eoUrZA"
               >
                 description
               </p>

--- a/packages/react-ui/src/Tag/__snapshots__/test.js.snap
+++ b/packages/react-ui/src/Tag/__snapshots__/test.js.snap
@@ -3,7 +3,7 @@
 exports[`<Tag /> renders text 1`] = `
 <div>
   <span
-    class="sc-aXZVg gTwHaC sc-eqUAAy clFqmf"
+    class="sc-aXZVg fsQJDj sc-eqUAAy clFqmf"
   >
     A simple text
   </span>

--- a/packages/react-ui/src/Text/__snapshots__/test.js.snap
+++ b/packages/react-ui/src/Text/__snapshots__/test.js.snap
@@ -3,7 +3,7 @@
 exports[`<Text /> renders text 1`] = `
 <div>
   <span
-    class="sc-aXZVg kjTYXy"
+    class="sc-aXZVg jdzwbA"
   >
     A simple text
   </span>
@@ -13,7 +13,7 @@ exports[`<Text /> renders text 1`] = `
 exports[`<Text /> renders text with fontSize 1`] = `
 <div>
   <span
-    class="sc-aXZVg dLruZo"
+    class="sc-aXZVg ftKqel"
   >
     A large text
   </span>
@@ -23,7 +23,7 @@ exports[`<Text /> renders text with fontSize 1`] = `
 exports[`<Text /> renders text with fontWeight 1`] = `
 <div>
   <span
-    class="sc-aXZVg guVrFZ"
+    class="sc-aXZVg ciAQGT"
   >
     A bold text
   </span>
@@ -33,7 +33,7 @@ exports[`<Text /> renders text with fontWeight 1`] = `
 exports[`<Text /> renders text with variant 1`] = `
 <div>
   <span
-    class="sc-aXZVg fygWxK"
+    class="sc-aXZVg cFJopM"
   >
     A colored text
   </span>

--- a/packages/react-ui/src/Text/index.js
+++ b/packages/react-ui/src/Text/index.js
@@ -18,6 +18,7 @@ const sharedStyle = css`
           ? fonts.sizes.headings[props.$fontSize.replace("h", "")]
           : fonts.sizes[props.$fontSize]};
       font-weight: ${(props) => props.$fontWeight};
+      ${(props) => (props.$italic ? "font-style: italic" : "")};
     `;
   }}
 `;
@@ -36,13 +37,13 @@ const spanPropTypes = {
     "hlarge",
   ]),
   fontWeight: PropTypes.oneOf(["300", "400", "500", "600", "700"]),
-  noMargin: PropTypes.bool,
+  italic: PropTypes.bool,
   role: PropTypes.string,
   variant: PropTypes.oneOf(["primary", "secondary", "error", "placeholder"]),
 };
 
 const defaultSpanPropTypes = {
-  fontSize: "default",
+  fontSize: "inherit",
   fontWeight: "400",
 };
 
@@ -61,12 +62,20 @@ Text.defaultProps = defaultSpanPropTypes;
 Paragraph.propTypes = paragraphPropTypes;
 Paragraph.defaultProps = defaultParagraphPropTypes;
 
-export function Text({ children, fontSize, fontWeight, variant, ...props }) {
+export function Text({
+  children,
+  fontSize,
+  italic,
+  fontWeight,
+  variant,
+  ...props
+}) {
   return (
     <Span
       {...props}
-      $fontWeight={fontWeight}
       $fontSize={fontSize}
+      $fontWeight={fontWeight}
+      $italic={italic}
       $variant={variant}
     >
       {children}
@@ -78,6 +87,7 @@ export function Paragraph({
   children,
   fontSize,
   fontWeight,
+  italic,
   noMargin,
   variant,
   ...props
@@ -85,8 +95,9 @@ export function Paragraph({
   return (
     <P
       {...props}
-      $fontWeight={fontWeight}
       $fontSize={fontSize}
+      $italic={italic}
+      $fontWeight={fontWeight}
       $noMargin={noMargin}
       $variant={variant}
     >


### PR DESCRIPTION
On ne devrait pas les utiliser : https://developer.mozilla.org/fr/docs/Web/HTML/Element/b
=> Il ne faut pas confondre l'élément `<b>` avec les éléments [`<strong>`](https://developer.mozilla.org/fr/docs/Web/HTML/Element/strong), [`<em>`](https://developer.mozilla.org/fr/docs/Web/HTML/Element/em), ou [`<mark>`](https://developer.mozilla.org/fr/docs/Web/HTML/Element/mark). L'élément [`<strong>`](https://developer.mozilla.org/fr/docs/Web/HTML/Element/strong) représente un texte d'une certaine importance, [`<em>`](https://developer.mozilla.org/fr/docs/Web/HTML/Element/em) met une emphase sur le texte et [`<mark>`](https://developer.mozilla.org/fr/docs/Web/HTML/Element/mark) représente un texte avec une certaine pertinence. L'élément `<b>` ne porte aucune information sémantique particulière ; utilisez-le lorsque qu'aucun autre ne convient.

https://developer.mozilla.org/fr/docs/Web/HTML/Element/i