### PR TITLE
fix(seo): "Contributions" renomé en "Fiches pratiques" + disallow /recherche in robots.txt

### DIFF
--- a/packages/code-du-travail-frontend/scripts/__tests__/prebuild.test.ts
+++ b/packages/code-du-travail-frontend/scripts/__tests__/prebuild.test.ts
@@ -12,6 +12,7 @@ describe("robots.txt", () => {
       "User-agent: *",
       "Disallow: /assets/",
       "Disallow: /images/",
+      "Disallow: /recherche",
       "",
       `Sitemap: https://code.travail.gouv.fr/sitemap.xml`,
     ].join("\n");

--- a/packages/code-du-travail-frontend/scripts/prebuild.ts
+++ b/packages/code-du-travail-frontend/scripts/prebuild.ts
@@ -8,6 +8,7 @@ export const generateRobotsTxt = (isOnProduction: boolean, host: string) => {
     "User-agent: *",
     "Disallow: /assets/",
     "Disallow: /images/",
+    "Disallow: /recherche",
     "",
     `Sitemap: ${host}/sitemap.xml`,
   ].join("\n");

--- a/packages/code-du-travail-utils/src/sources.ts
+++ b/packages/code-du-travail-utils/src/sources.ts
@@ -40,7 +40,7 @@ export const routeBySource = {
 export const labelBySource = {
   [SOURCES.CCN]: "Conventions collectives",
   [SOURCES.CDT]: "Code du travail",
-  [SOURCES.CONTRIBUTIONS]: "Contributions",
+  [SOURCES.CONTRIBUTIONS]: "Fiches pratiques",
   [SOURCES.EDITORIAL_CONTENT]: "Information",
   [SOURCES.EXTERNALS]: "Outils externes",
   [SOURCES.LABOUR_LAW]: "Le droit du travail",


### PR DESCRIPTION
Fix https://github.com/orgs/SocialGouv/projects/100?pane=issue&itemId=45785799