### PR TITLE
fix: mise à jour du sous-titre de la page convention collective

### DIFF
--- a/packages/code-du-travail-frontend/pages/convention-collective/[slug].tsx
+++ b/packages/code-du-travail-frontend/pages/convention-collective/[slug].tsx
@@ -68,7 +68,7 @@ function ConventionCollective(props: Props): JSX.Element {
         }
         subtitle={
           <Text fontSize="small">
-            {convention.shortTitle} (IDCC {formatIdcc(convention.num)})
+            {title} (IDCC {formatIdcc(convention.num)})
           </Text>
         }
         suptitle="CONVENTION COLLECTIVE"

--- a/packages/code-du-travail-frontend/src/contributions/ContributionGeneric.tsx
+++ b/packages/code-du-travail-frontend/src/contributions/ContributionGeneric.tsx
@@ -286,7 +286,7 @@ const ContributionGeneric = ({ contribution }: Props) => {
           Que dit le code du travail&nbsp;?
         </Title>
         {convention && !isSupported(convention) && (
-          <Paragraph>
+          <Paragraph italic>
             Cette réponse correspond à ce que prévoit le code du travail, elle
             ne tient pas compte des spécificités de la convention collective{" "}
             {convention.shortTitle}


### PR DESCRIPTION
Fix [Amélioration design new contrib#5470](https://github.com/SocialGouv/code-du-travail-numerique/issues/5470)
Fix [Afficher en sous titre le longTitle sur la page CC#5497](https://github.com/SocialGouv/code-du-travail-numerique/issues/5497) 