### PR TITLE
fix: affichage du nom court de la CC sur la page de résultat des outils (fix des test e2e)

### DIFF
--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/a-propos.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/a-propos.test.tsx.snap
@@ -188,7 +188,7 @@ exports[`<About /> should render 1`] = `
             class="sc-ePDLzJ gBicpa"
           >
             <h1
-              class="sc-dPZUQH jWPXkw"
+              class="sc-dPZUQH jEsYKE"
             >
               <span
                 class="sc-gsFSXq djREvw"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/droit-du-travail.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/droit-du-travail.test.js.snap
@@ -188,7 +188,7 @@ exports[`<DroitDuTravail /> should render 1`] = `
             class="sc-ePDLzJ gBicpa"
           >
             <h1
-              class="sc-dPZUQH jWPXkw"
+              class="sc-dPZUQH jEsYKE"
             >
               <span
                 class="sc-gsFSXq djREvw"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/fiche-ministere-travail.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/fiche-ministere-travail.test.tsx.snap
@@ -269,7 +269,7 @@ exports[`<FicheMT /> should render 1`] = `
                       class="sc-ePDLzJ dXxftn sc-dGCmGc cEICQD"
                     >
                       <h1
-                        class="sc-dPZUQH doubLW"
+                        class="sc-dPZUQH gIWWuu"
                       >
                         <span
                           class="sc-gsFSXq ljkohw"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire-[slug].test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire-[slug].test.tsx.snap
@@ -188,7 +188,7 @@ exports[`<Term /> should render 1`] = `
             class="sc-ePDLzJ gBicpa"
           >
             <h1
-              class="sc-dPZUQH jWPXkw"
+              class="sc-dPZUQH jEsYKE"
             >
               <span
                 class="sc-gsFSXq djREvw"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire.test.tsx.snap
@@ -188,7 +188,7 @@ exports[`<Glossaire /> should render 1`] = `
             class="sc-ePDLzJ gBicpa"
           >
             <h1
-              class="sc-dPZUQH jWPXkw"
+              class="sc-dPZUQH jEsYKE"
             >
               <span
                 class="sc-gsFSXq djREvw"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/mentions-legales.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/mentions-legales.test.tsx.snap
@@ -188,7 +188,7 @@ exports[`<MentionLegales /> should render 1`] = `
             class="sc-ePDLzJ gBicpa"
           >
             <h1
-              class="sc-dPZUQH jWPXkw"
+              class="sc-dPZUQH jEsYKE"
             >
               <span
                 class="sc-gsFSXq djREvw"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers-[slug].test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers-[slug].test.tsx.snap
@@ -269,7 +269,7 @@ exports[`<ModelesDeCourrier /> should render 1`] = `
                       class="sc-ePDLzJ dXxftn sc-lfYzqA juRufr"
                     >
                       <h1
-                        class="sc-dPZUQH doubLW"
+                        class="sc-dPZUQH gIWWuu"
                       >
                         <span
                           class="sc-gsFSXq ljkohw"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers.test.tsx.snap
@@ -188,7 +188,7 @@ exports[`<ModelesDeCourriers /> should render 1`] = `
             class="sc-ePDLzJ gBicpa"
           >
             <h1
-              class="sc-dPZUQH jWPXkw"
+              class="sc-dPZUQH jEsYKE"
             >
               <span
                 class="sc-gsFSXq djREvw"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/recherche.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/recherche.test.js.snap
@@ -99,7 +99,7 @@ exports[`<Recherche /> should render 1`] = `
           class="sc-ePDLzJ gBicpa"
         >
           <h1
-            class="sc-dPZUQH jWPXkw"
+            class="sc-dPZUQH jEsYKE"
           >
             <span
               class="sc-gsFSXq djREvw"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/stats.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/stats.test.tsx.snap
@@ -188,7 +188,7 @@ exports[`<Stats /> should render 1`] = `
             class="sc-ePDLzJ gBicpa"
           >
             <h1
-              class="sc-dPZUQH jWPXkw"
+              class="sc-dPZUQH jEsYKE"
             >
               <span
                 class="sc-gsFSXq djREvw"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/themes.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/themes.test.tsx.snap
@@ -251,7 +251,7 @@ exports[`<Theme /> should render 1`] = `
             class="sc-ePDLzJ gBicpa"
           >
             <h1
-              class="sc-dPZUQH jWPXkw"
+              class="sc-dPZUQH jEsYKE"
             >
               <span
                 class="sc-gsFSXq djREvw"

--- a/packages/code-du-travail-frontend/cypress/integration/conventions-collectives.spec.ts
+++ b/packages/code-du-travail-frontend/cypress/integration/conventions-collectives.spec.ts
@@ -9,7 +9,7 @@ describe("Conventions collectives", () => {
       "contain",
       "Retrouvez les questions/réponses fréquentes organisées par thème"
     );
-    cy.get("#content li").should("have.length", 125);
+    cy.get("#content li").should("have.length", 126);
     cy.get("#content li").first().click();
     cy.url().should(
       "include",

--- a/packages/code-du-travail-frontend/pages/convention-collective/index.tsx
+++ b/packages/code-du-travail-frontend/pages/convention-collective/index.tsx
@@ -49,7 +49,11 @@ function Page({ ccs }) {
           </Toast>
           <p>
             Vous ne connaissez pas votre convention collective ?{" "}
-            <Link href={`/outils/convention-collective`} passHref>
+            <Link
+              href={`/outils/convention-collective`}
+              passHref
+              legacyBehavior
+            >
               <Button as="a" variant="link" hasText>
                 Trouvez la
               </Button>

--- a/packages/code-du-travail-frontend/pages/widgets/modeles-de-courriers/[id].tsx
+++ b/packages/code-du-travail-frontend/pages/widgets/modeles-de-courriers/[id].tsx
@@ -21,7 +21,7 @@ function Widgets(props: LetterModelProps): JSX.Element {
       />
       <StyledHeader>
         <StyledTitle stripe="left" variant="secondary">
-          {props.title} oo
+          {props.title}
         </StyledTitle>
         <LogoLink></LogoLink>
       </StyledHeader>

--- a/packages/code-du-travail-frontend/pages/widgets/modeles-de-courriers/[id].tsx
+++ b/packages/code-du-travail-frontend/pages/widgets/modeles-de-courriers/[id].tsx
@@ -7,7 +7,7 @@ import styled from "styled-components";
 import { theme, Paragraph, Wrapper, PageTitle } from "@socialgouv/cdtn-ui";
 import { LogoLink } from "../../../src/widgets";
 import Html from "../../../src/common/Html";
-import { isHTML } from "../../../src/lib/converter";
+import { isHTML } from "../../../src/lib";
 
 function Widgets(props: LetterModelProps): JSX.Element {
   useIframeResizer();
@@ -20,8 +20,8 @@ function Widgets(props: LetterModelProps): JSX.Element {
         overrideCanonical={SITE_URL + "/modeles-de-courriers"}
       />
       <StyledHeader>
-        <StyledTitle small stripe="left">
-          {props.title}
+        <StyledTitle stripe="left" variant="secondary">
+          {props.title} oo
         </StyledTitle>
         <LogoLink></LogoLink>
       </StyledHeader>
@@ -55,7 +55,7 @@ export const getServerSideProps = async ({ query }) => {
 
 export default Widgets;
 
-const { spacings } = theme;
+const { spacings, fonts } = theme;
 
 const IntroWrapper = styled(Wrapper)`
   margin: ${spacings.base} auto;
@@ -80,4 +80,7 @@ const StyledHeader = styled.div`
 
 const StyledTitle = styled(PageTitle)`
   flex: 1;
+  h1 {
+    font-size: ${fonts.sizes.headings.xmedium};
+  }
 `;

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/Answer.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/Answer.test.js.snap
@@ -25,7 +25,7 @@ exports[`<Answer /> should renders 1`] = `
                   class="sc-ePDLzJ dXxftn sc-dGCmGc cEICQD"
                 >
                   <h1
-                    class="sc-dPZUQH doubLW"
+                    class="sc-dPZUQH gIWWuu"
                   >
                     <span
                       class="sc-gsFSXq ljkohw"
@@ -527,7 +527,7 @@ exports[`<Answer /> should renders a breadcrumbs 1`] = `
                   class="sc-ePDLzJ dXxftn sc-dGCmGc cEICQD"
                 >
                   <h1
-                    class="sc-dPZUQH doubLW"
+                    class="sc-dPZUQH gIWWuu"
                   >
                     <span
                       class="sc-gsFSXq ljkohw"
@@ -938,7 +938,7 @@ exports[`<Answer /> should renders back to results link 1`] = `
                   class="sc-ePDLzJ dXxftn sc-dGCmGc cEICQD"
                 >
                   <h1
-                    class="sc-dPZUQH doubLW"
+                    class="sc-dPZUQH gIWWuu"
                   >
                     <span
                       class="sc-gsFSXq ljkohw"
@@ -1349,7 +1349,7 @@ exports[`<Answer /> should renders related content 1`] = `
                   class="sc-ePDLzJ dXxftn sc-dGCmGc cEICQD"
                 >
                   <h1
-                    class="sc-dPZUQH doubLW"
+                    class="sc-dPZUQH gIWWuu"
                   >
                     <span
                       class="sc-gsFSXq ljkohw"
@@ -1921,7 +1921,7 @@ exports[`<Answer /> should renders tooltip 1`] = `
                   class="sc-ePDLzJ dXxftn sc-dGCmGc cEICQD"
                 >
                   <h1
-                    class="sc-dPZUQH doubLW"
+                    class="sc-dPZUQH gIWWuu"
                   >
                     <span
                       class="sc-gsFSXq ljkohw"
@@ -2333,7 +2333,7 @@ exports[`<Answer /> should renders tooltip for words with diacritics without bre
                   class="sc-ePDLzJ dXxftn sc-dGCmGc cEICQD"
                 >
                   <h1
-                    class="sc-dPZUQH doubLW"
+                    class="sc-dPZUQH gIWWuu"
                   >
                     <span
                       class="sc-gsFSXq ljkohw"
@@ -2745,7 +2745,7 @@ exports[`<Answer /> should renders tooltip without breaking a tag 1`] = `
                   class="sc-ePDLzJ dXxftn sc-dGCmGc cEICQD"
                 >
                   <h1
-                    class="sc-dPZUQH doubLW"
+                    class="sc-dPZUQH gIWWuu"
                   >
                     <span
                       class="sc-gsFSXq ljkohw"
@@ -3158,7 +3158,7 @@ exports[`<Answer /> should renders tooltip without breaking previous word 1`] = 
                   class="sc-ePDLzJ dXxftn sc-dGCmGc cEICQD"
                 >
                   <h1
-                    class="sc-dPZUQH doubLW"
+                    class="sc-dPZUQH gIWWuu"
                   >
                     <span
                       class="sc-gsFSXq ljkohw"

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/Article.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/Article.test.js.snap
@@ -19,7 +19,7 @@ exports[`<Article /> should render 1`] = `
               class="sc-ePDLzJ dXxftn sc-fulCBj kAfkKO"
             >
               <h1
-                class="sc-dPZUQH doubLW"
+                class="sc-dPZUQH gIWWuu"
               >
                 <span
                   class="sc-gsFSXq ljkohw"

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/ContactModal.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/ContactModal.test.js.snap
@@ -37,7 +37,7 @@ exports[`<ContactModal /> renders a popup when click on button 1`] = `
               class="sc-ePDLzJ gBicpa"
             >
               <h1
-                class="sc-dPZUQH jWPXkw"
+                class="sc-dPZUQH jEsYKE"
               >
                 <span
                   class="sc-gsFSXq djREvw"

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/ServiceRenseignement.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/ServiceRenseignement.test.js.snap
@@ -6,7 +6,7 @@ exports[`<ServiceRenseignement /> should render suggestions 1`] = `
     class="sc-ePDLzJ gBicpa"
   >
     <h1
-      class="sc-dPZUQH jWPXkw"
+      class="sc-dPZUQH jEsYKE"
     >
       <span
         class="sc-gsFSXq djREvw"

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/ServiceRenseignementModal.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/ServiceRenseignementModal.test.js.snap
@@ -37,7 +37,7 @@ exports[`<ServiceRenseignementModal /> renders a popup when click on button 1`] 
               class="sc-ePDLzJ gBicpa"
             >
               <h1
-                class="sc-dPZUQH jWPXkw"
+                class="sc-dPZUQH jEsYKE"
               >
                 <span
                   class="sc-gsFSXq djREvw"

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisDemission/steps/Result.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisDemission/steps/Result.tsx
@@ -129,7 +129,7 @@ function StepResult({ form }: WizardStepProps): JSX.Element {
       <ShowDetails>
         <SectionTitle>Éléments saisis</SectionTitle>
         {recapSituation({
-          "Convention collective": `${ccn?.selected?.title} (${idcc})`,
+          "Convention collective": `${ccn?.selected?.shortTitle} (${idcc})`,
           ...situation.criteria,
         })}
         <PubliReferences references={formatRefs(refs)} />

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisDemission/steps/__tests__/Result.test.tsx
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisDemission/steps/__tests__/Result.test.tsx
@@ -4,7 +4,7 @@ import { StepResult } from "../Result";
 describe("<StepResult />", () => {
   it("should render CC answer", () => {
     const { container } = renderForm(StepResult, {
-      ccn: { selected: { num: 292, title: "Plasturgie" } },
+      ccn: { selected: { num: 292, shortTitle: "Plasturgie" } },
       criteria: {
         "catégorie professionnelle": "42| Collaborateurs",
         coefficient: "28| 800 à 830 inclus",

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisLicenciement/steps/Result/utils/buildRecap.ts
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisLicenciement/steps/Result/utils/buildRecap.ts
@@ -36,7 +36,7 @@ export const buildRecap = (
         "Ancienneté selon la convention collective": seniorityCC,
       }),
       ...(ccn?.selected && {
-        "Convention collective": ccn.selected.title,
+        "Convention collective": ccn.selected.shortTitle,
       }),
     };
   }
@@ -46,7 +46,7 @@ export const buildRecap = (
     ...defaultRecap,
     ...agreementRecap,
     ...(ccn?.selected && {
-      "Convention collective": ccn.selected.title,
+      "Convention collective": ccn.selected.shortTitle,
     }),
   };
 };

--- a/packages/code-du-travail-frontend/src/outils/DureePreavisLicenciement/steps/__tests__/__snapshots__/Result.test.js.snap
+++ b/packages/code-du-travail-frontend/src/outils/DureePreavisLicenciement/steps/__tests__/__snapshots__/Result.test.js.snap
@@ -119,7 +119,7 @@ exports[`<StepResult /> should render with O duration 1`] = `
           Convention collective
            : 
           <strong>
-            Convention collective nationale des transports routiers et activités auxiliaires du transport du 21 décembre 1950
+            Transports routiers et activités auxiliaires du transport
           </strong>
         </li>
       </ul>
@@ -336,7 +336,7 @@ exports[`<StepResult /> should render with both CC duration and CDT duration 1`]
           Convention collective
            : 
           <strong>
-            Convention collective nationale des transports routiers et activités auxiliaires du transport du 21 décembre 1950
+            Transports routiers et activités auxiliaires du transport
           </strong>
         </li>
       </ul>
@@ -499,7 +499,7 @@ exports[`<StepResult /> should render with only CC duration 1`] = `
           Convention collective
            : 
           <strong>
-            Convention collective nationale des transports routiers et activités auxiliaires du transport du 21 décembre 1950
+            Transports routiers et activités auxiliaires du transport
           </strong>
         </li>
       </ul>
@@ -878,7 +878,7 @@ exports[`<StepResult /> should render with when unhandled CC 1`] = `
           Convention collective
            : 
           <strong>
-            Convention collective nationale de la cordonnerie multiservice du 7 août 1989. Elargie au secteur des cordonniers industriels
+            Cordonnerie multiservice
           </strong>
         </li>
       </ul>

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/__tests__/indemnite-licenciement-cc-select.test.tsx
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/__tests__/indemnite-licenciement-cc-select.test.tsx
@@ -23,7 +23,7 @@ describe("Indemnité licenciement - Sélection de CC", () => {
     userAction
       .click(ui.agreement.agreement.get())
       .setInput(ui.agreement.agreementInput.get(), "16")
-      .click(await waitFor(() => ui.agreement.searchItem.agreement16.get()))
+      .click(await waitFor(() => ui.agreement.ccChoice.transport.get()))
       .click(ui.next.get());
 
     fireEvent.click(ui.previous.get());

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/__tests__/information.test.tsx
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/__tests__/information.test.tsx
@@ -1,7 +1,7 @@
 import { render, RenderResult, waitFor } from "@testing-library/react";
 import { UserAction } from "../../../common";
 import React from "react";
-import { CalculateurIndemnite } from "../../../../src/outils";
+import { CalculateurIndemnite } from "../index";
 import { ui } from "./ui";
 
 jest.spyOn(Storage.prototype, "setItem");
@@ -194,7 +194,9 @@ describe("Indemnité licenciement - Validation de la page information", () => {
         .setInput(ui.agreement.agreementInput.get(), "3239")
         .click(
           await waitFor(() =>
-            rendering.getByText("Particuliers employeurs et emploi à domicile")
+            rendering.getByText(
+              "Particuliers employeurs et emploi à domicile (IDCC 3239)"
+            )
           )
         )
         .click(ui.next.get());

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/__tests__/tracking.test.tsx
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/__tests__/tracking.test.tsx
@@ -173,7 +173,7 @@ describe("Indemnité licenciement - Tracking", () => {
       .click(ui.agreement.noAgreement.get())
       .click(ui.agreement.agreement.get())
       .setInput(ui.agreement.agreementInput.get(), "16")
-      .click(await waitFor(() => ui.agreement.searchItem.agreement16.get()));
+      .click(await waitFor(() => ui.agreement.ccChoice.transport.get()));
 
     expect(push).toHaveBeenCalledWith([
       "trackEvent",
@@ -194,7 +194,7 @@ describe("Indemnité licenciement - Tracking", () => {
       .click(ui.agreement.noAgreement.get())
       .click(ui.agreement.agreement.get())
       .setInput(ui.agreement.agreementInput.get(), "16")
-      .click(await waitFor(() => ui.agreement.searchItem.agreement16.get()))
+      .click(await waitFor(() => ui.agreement.ccChoice.transport.get()))
       .click(ui.next.get());
 
     expect(push).toHaveBeenCalledWith([

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/__tests__/ui.ts
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/__tests__/ui.ts
@@ -71,6 +71,9 @@ export const ui = {
       commerce: byText(
         "Commerce de détail et de gros à prédominance alimentaire (IDCC 2216)"
       ),
+      transport: byText(
+        "Transports routiers et activités auxiliaires du transport (IDCC 0016)"
+      ),
       bureau: byText(
         "Bureaux d'études techniques, cabinets d'ingénieurs-conseils et sociétés de conseils (IDCC 1486)"
       ),

--- a/packages/code-du-travail-frontend/src/outils/common/Agreement/AgreementSearch/AgreementInput/SearchAgreementInput.tsx
+++ b/packages/code-du-travail-frontend/src/outils/common/Agreement/AgreementSearch/AgreementInput/SearchAgreementInput.tsx
@@ -118,7 +118,7 @@ const renderSuggestion = (suggestion: Agreement) => {
   return (
     <SuggestionContainer>
       <Paragraph noMargin>
-        {suggestion.shortTitle} <IDCC>(IDCC {formatIdcc(suggestion.num)})</IDCC>
+        {suggestion.shortTitle} (IDCC {formatIdcc(suggestion.num)})
       </Paragraph>
       {suggestion.highlight?.searchInfo && (
         <Paragraph noMargin variant="secondary">
@@ -128,10 +128,6 @@ const renderSuggestion = (suggestion: Agreement) => {
     </SuggestionContainer>
   );
 };
-
-const IDCC = styled.span`
-  font-weight: normal;
-`;
 
 const SuggestionContainer = styled.div`
   display: flex;

--- a/packages/code-du-travail-frontend/src/outils/common/Agreement/AgreementSearch/AgreementInput/SearchAgreementInput.tsx
+++ b/packages/code-du-travail-frontend/src/outils/common/Agreement/AgreementSearch/AgreementInput/SearchAgreementInput.tsx
@@ -117,7 +117,9 @@ const SuggestionsContainer = styled.div`
 const renderSuggestion = (suggestion: Agreement) => {
   return (
     <SuggestionContainer>
-      {suggestion.shortTitle} <IDCC>(IDCC {formatIdcc(suggestion.num)})</IDCC>
+      <Paragraph noMargin>
+        {suggestion.shortTitle} <IDCC>(IDCC {formatIdcc(suggestion.num)})</IDCC>
+      </Paragraph>
       {suggestion.highlight?.searchInfo && (
         <Paragraph noMargin variant="secondary">
           (${suggestion.highlight?.searchInfo})

--- a/packages/code-du-travail-frontend/src/outils/common/Agreement/AgreementSearch/AgreementInput/SearchAgreementInput.tsx
+++ b/packages/code-du-travail-frontend/src/outils/common/Agreement/AgreementSearch/AgreementInput/SearchAgreementInput.tsx
@@ -1,4 +1,4 @@
-import { Input, Label, Text, theme, Paragraph } from "@socialgouv/cdtn-ui";
+import { Input, Label, Paragraph, Text, theme } from "@socialgouv/cdtn-ui";
 import React, { useState } from "react";
 import styled from "styled-components";
 import Autosuggest from "react-autosuggest";
@@ -118,10 +118,11 @@ const renderSuggestion = (suggestion: Agreement) => {
   return (
     <SuggestionContainer>
       {suggestion.shortTitle} <IDCC>(IDCC {formatIdcc(suggestion.num)})</IDCC>
-      <Paragraph noMargin variant="secondary">
-        {suggestion.highlight?.searchInfo &&
-          `(${suggestion.highlight?.searchInfo})`}
-      </Paragraph>
+      {suggestion.highlight?.searchInfo && (
+        <Paragraph noMargin variant="secondary">
+          (${suggestion.highlight?.searchInfo})
+        </Paragraph>
+      )}
     </SuggestionContainer>
   );
 };

--- a/packages/code-du-travail-frontend/src/outils/common/Agreement/EnterpriseSearch/EntrepriseSearchResult.tsx
+++ b/packages/code-du-travail-frontend/src/outils/common/Agreement/EnterpriseSearch/EntrepriseSearchResult.tsx
@@ -51,7 +51,7 @@ const EntrepriseSearchResults = ({
     if (typeof state.error === "string") {
       return <Error>{state.error}</Error>;
     }
-    return <Section>{state.error}</Section>;
+    return <Section>{JSON.stringify(state.error)}</Section>;
   }
   if (!state.data) {
     return <></>;

--- a/packages/code-du-travail-frontend/src/outils/common/__tests__/__snapshots__/Wizard.test.tsx.snap
+++ b/packages/code-du-travail-frontend/src/outils/common/__tests__/__snapshots__/Wizard.test.tsx.snap
@@ -6,35 +6,35 @@ exports[`<Wizard /> should call navigate the previous step when click on précé
     class="sc-iGgWBj biWgIW"
   >
     <form
-      class="sc-camqpD hZvLtm"
+      class="sc-kbdlSk CXQkJ"
     >
       <div
-        class="sc-bOQTJJ dHEPea"
+        class="sc-hYmls jKkoYJ"
       >
         <div
-          class="sc-gEkIjz dDsXGK"
+          class="sc-eXsaLi bdWhoM"
         >
           <h1
-            class="sc-eXsaLi jcPJdF"
+            class="sc-bOQTJJ hoVrPf"
           >
             test H1
           </h1>
         </div>
       </div>
       <div
-        class="sc-iGgWBj sc-kgOKUu cWzIZL dTskMB"
+        class="sc-iGgWBj sc-fKWMtX cWzIZL bcBkxu"
       >
         <span
-          class="sc-bfhvDw jnggxr"
+          class="sc-kgOKUu bjvUoK"
         >
           Étape
           <span
-            class="sc-cMa-dbN byVUiP"
+            class="sc-bfhvDw kYFtQY"
           >
             s
           </span>
           <span
-            class="sc-fUBkdm fFFpEK"
+            class="sc-cMa-dbN gAIJdP"
           >
              
             1/2
@@ -45,21 +45,21 @@ exports[`<Wizard /> should call navigate the previous step when click on précé
         >
           <li
             aria-live="polite"
-            class="sc-hBtRBD eGwkwu"
+            class="sc-fUBkdm kTxRgT"
             title="onglet actif"
           >
             <span
-              class="sc-hYmls jVGokf"
+              class="sc-hBtRBD bUvebq"
             >
               1
             </span>
             First Step
           </li>
           <li
-            class="sc-hBtRBD ccHFNw"
+            class="sc-fUBkdm jQjOBp"
           >
             <span
-              class="sc-hYmls kGneDw"
+              class="sc-hBtRBD zIbRN"
             >
               2
             </span>
@@ -71,15 +71,15 @@ exports[`<Wizard /> should call navigate the previous step when click on précé
         Premiere Etape
       </p>
       <div
-        class="sc-lbJcrp fsWMsG"
+        class="sc-iLsKjm eOFMyx"
       >
         <button
-          class="sc-kOPcWz cefBoA sc-iLsKjm sc-eifrsQ eQYdHK ehoSxM"
+          class="sc-kOPcWz cefBoA sc-epALIP sc-lbJcrp dyTjwR innUxH"
         >
           Commencer
           <svg
             aria-hidden="true"
-            class="sc-fKWMtX bKjPaG"
+            class="sc-eifrsQ dsvLPn"
             fill="none"
             viewBox="0 0 28 15"
             xmlns="http://www.w3.org/2000/svg"
@@ -102,35 +102,35 @@ exports[`<Wizard /> should handle initialState.stepIndex 1`] = `
     class="sc-iGgWBj biWgIW"
   >
     <form
-      class="sc-camqpD hZvLtm"
+      class="sc-kbdlSk CXQkJ"
     >
       <div
-        class="sc-bOQTJJ dHEPea"
+        class="sc-hYmls jKkoYJ"
       >
         <div
-          class="sc-gEkIjz dDsXGK"
+          class="sc-eXsaLi bdWhoM"
         >
           <h1
-            class="sc-eXsaLi jcPJdF"
+            class="sc-bOQTJJ hoVrPf"
           >
             test H1
           </h1>
         </div>
       </div>
       <div
-        class="sc-iGgWBj sc-kgOKUu cWzIZL dTskMB"
+        class="sc-iGgWBj sc-fKWMtX cWzIZL bcBkxu"
       >
         <span
-          class="sc-bfhvDw jnggxr"
+          class="sc-kgOKUu bjvUoK"
         >
           Étape
           <span
-            class="sc-cMa-dbN byVUiP"
+            class="sc-bfhvDw kYFtQY"
           >
             s
           </span>
           <span
-            class="sc-fUBkdm fFFpEK"
+            class="sc-cMa-dbN gAIJdP"
           >
              
             2/2
@@ -140,10 +140,10 @@ exports[`<Wizard /> should handle initialState.stepIndex 1`] = `
           class="sc-cfxfcM kMmTaI"
         >
           <li
-            class="sc-hBtRBD ccHFNw"
+            class="sc-fUBkdm jQjOBp"
           >
             <span
-              class="sc-hYmls kGneDw"
+              class="sc-hBtRBD zIbRN"
             >
               1
             </span>
@@ -151,11 +151,11 @@ exports[`<Wizard /> should handle initialState.stepIndex 1`] = `
           </li>
           <li
             aria-live="polite"
-            class="sc-hBtRBD eGwkwu"
+            class="sc-fUBkdm kTxRgT"
             title="onglet actif"
           >
             <span
-              class="sc-hYmls jVGokf"
+              class="sc-hBtRBD bUvebq"
             >
               2
             </span>
@@ -178,16 +178,16 @@ exports[`<Wizard /> should handle initialState.stepIndex 1`] = `
         />
       </label>
       <div
-        class="sc-lbJcrp fsWMsG"
+        class="sc-iLsKjm eOFMyx"
       >
         <button
-          class="sc-kOPcWz dSQWfG sc-iLsKjm eQYdHK"
+          class="sc-kOPcWz dSQWfG sc-epALIP dyTjwR"
           type="button"
         >
           Précédent
         </button>
         <button
-          class="sc-kOPcWz gWtlVM sc-iLsKjm eQYdHK"
+          class="sc-kOPcWz gWtlVM sc-epALIP dyTjwR"
           type="button"
         >
           Imprimer le résultat
@@ -204,35 +204,35 @@ exports[`<Wizard /> should handle initialValues 1`] = `
     class="sc-iGgWBj biWgIW"
   >
     <form
-      class="sc-camqpD hZvLtm"
+      class="sc-kbdlSk CXQkJ"
     >
       <div
-        class="sc-bOQTJJ dHEPea"
+        class="sc-hYmls jKkoYJ"
       >
         <div
-          class="sc-gEkIjz dDsXGK"
+          class="sc-eXsaLi bdWhoM"
         >
           <h1
-            class="sc-eXsaLi jcPJdF"
+            class="sc-bOQTJJ hoVrPf"
           >
             test H1
           </h1>
         </div>
       </div>
       <div
-        class="sc-iGgWBj sc-kgOKUu cWzIZL dTskMB"
+        class="sc-iGgWBj sc-fKWMtX cWzIZL bcBkxu"
       >
         <span
-          class="sc-bfhvDw jnggxr"
+          class="sc-kgOKUu bjvUoK"
         >
           Étape
           <span
-            class="sc-cMa-dbN byVUiP"
+            class="sc-bfhvDw kYFtQY"
           >
             s
           </span>
           <span
-            class="sc-fUBkdm fFFpEK"
+            class="sc-cMa-dbN gAIJdP"
           >
              
             1/3
@@ -243,31 +243,31 @@ exports[`<Wizard /> should handle initialValues 1`] = `
         >
           <li
             aria-live="polite"
-            class="sc-hBtRBD eGwkwu"
+            class="sc-fUBkdm kTxRgT"
             title="onglet actif"
           >
             <span
-              class="sc-hYmls jVGokf"
+              class="sc-hBtRBD bUvebq"
             >
               1
             </span>
             First Step
           </li>
           <li
-            class="sc-hBtRBD ccHFNw"
+            class="sc-fUBkdm jQjOBp"
           >
             <span
-              class="sc-hYmls kGneDw"
+              class="sc-hBtRBD zIbRN"
             >
               2
             </span>
             Second Step
           </li>
           <li
-            class="sc-hBtRBD ccHFNw"
+            class="sc-fUBkdm jQjOBp"
           >
             <span
-              class="sc-hYmls kGneDw"
+              class="sc-hBtRBD zIbRN"
             >
               3
             </span>
@@ -279,15 +279,15 @@ exports[`<Wizard /> should handle initialValues 1`] = `
         Premiere Etape
       </p>
       <div
-        class="sc-lbJcrp fsWMsG"
+        class="sc-iLsKjm eOFMyx"
       >
         <button
-          class="sc-kOPcWz cefBoA sc-iLsKjm sc-eifrsQ eQYdHK ehoSxM"
+          class="sc-kOPcWz cefBoA sc-epALIP sc-lbJcrp dyTjwR innUxH"
         >
           Commencer
           <svg
             aria-hidden="true"
-            class="sc-fKWMtX bKjPaG"
+            class="sc-eifrsQ dsvLPn"
             fill="none"
             viewBox="0 0 28 15"
             xmlns="http://www.w3.org/2000/svg"
@@ -310,35 +310,35 @@ exports[`<Wizard /> should navigate to the second step when click on Commencer 1
     class="sc-iGgWBj biWgIW"
   >
     <form
-      class="sc-camqpD hZvLtm"
+      class="sc-kbdlSk CXQkJ"
     >
       <div
-        class="sc-bOQTJJ dHEPea"
+        class="sc-hYmls jKkoYJ"
       >
         <div
-          class="sc-gEkIjz dDsXGK"
+          class="sc-eXsaLi bdWhoM"
         >
           <h1
-            class="sc-eXsaLi jcPJdF"
+            class="sc-bOQTJJ hoVrPf"
           >
             test H1
           </h1>
         </div>
       </div>
       <div
-        class="sc-iGgWBj sc-kgOKUu cWzIZL dTskMB"
+        class="sc-iGgWBj sc-fKWMtX cWzIZL bcBkxu"
       >
         <span
-          class="sc-bfhvDw jnggxr"
+          class="sc-kgOKUu bjvUoK"
         >
           Étape
           <span
-            class="sc-cMa-dbN byVUiP"
+            class="sc-bfhvDw kYFtQY"
           >
             s
           </span>
           <span
-            class="sc-fUBkdm fFFpEK"
+            class="sc-cMa-dbN gAIJdP"
           >
              
             2/2
@@ -348,10 +348,10 @@ exports[`<Wizard /> should navigate to the second step when click on Commencer 1
           class="sc-cfxfcM kMmTaI"
         >
           <li
-            class="sc-hBtRBD ccHFNw"
+            class="sc-fUBkdm jQjOBp"
           >
             <span
-              class="sc-hYmls kGneDw"
+              class="sc-hBtRBD zIbRN"
             >
               1
             </span>
@@ -359,11 +359,11 @@ exports[`<Wizard /> should navigate to the second step when click on Commencer 1
           </li>
           <li
             aria-live="polite"
-            class="sc-hBtRBD eGwkwu"
+            class="sc-fUBkdm kTxRgT"
             title="onglet actif"
           >
             <span
-              class="sc-hYmls jVGokf"
+              class="sc-hBtRBD bUvebq"
             >
               2
             </span>
@@ -386,16 +386,16 @@ exports[`<Wizard /> should navigate to the second step when click on Commencer 1
         />
       </label>
       <div
-        class="sc-lbJcrp fsWMsG"
+        class="sc-iLsKjm eOFMyx"
       >
         <button
-          class="sc-kOPcWz dSQWfG sc-iLsKjm eQYdHK"
+          class="sc-kOPcWz dSQWfG sc-epALIP dyTjwR"
           type="button"
         >
           Précédent
         </button>
         <button
-          class="sc-kOPcWz gWtlVM sc-iLsKjm eQYdHK"
+          class="sc-kOPcWz gWtlVM sc-epALIP dyTjwR"
           type="button"
         >
           Imprimer le résultat
@@ -412,35 +412,35 @@ exports[`<Wizard /> should render a step 1`] = `
     class="sc-iGgWBj biWgIW"
   >
     <form
-      class="sc-camqpD hZvLtm"
+      class="sc-kbdlSk CXQkJ"
     >
       <div
-        class="sc-bOQTJJ dHEPea"
+        class="sc-hYmls jKkoYJ"
       >
         <div
-          class="sc-gEkIjz dDsXGK"
+          class="sc-eXsaLi bdWhoM"
         >
           <h1
-            class="sc-eXsaLi jcPJdF"
+            class="sc-bOQTJJ hoVrPf"
           >
             test H1
           </h1>
         </div>
       </div>
       <div
-        class="sc-iGgWBj sc-kgOKUu cWzIZL dTskMB"
+        class="sc-iGgWBj sc-fKWMtX cWzIZL bcBkxu"
       >
         <span
-          class="sc-bfhvDw jnggxr"
+          class="sc-kgOKUu bjvUoK"
         >
           Étape
           <span
-            class="sc-cMa-dbN byVUiP"
+            class="sc-bfhvDw kYFtQY"
           >
             s
           </span>
           <span
-            class="sc-fUBkdm fFFpEK"
+            class="sc-cMa-dbN gAIJdP"
           >
              
             1/2
@@ -451,21 +451,21 @@ exports[`<Wizard /> should render a step 1`] = `
         >
           <li
             aria-live="polite"
-            class="sc-hBtRBD eGwkwu"
+            class="sc-fUBkdm kTxRgT"
             title="onglet actif"
           >
             <span
-              class="sc-hYmls jVGokf"
+              class="sc-hBtRBD bUvebq"
             >
               1
             </span>
             First Step
           </li>
           <li
-            class="sc-hBtRBD ccHFNw"
+            class="sc-fUBkdm jQjOBp"
           >
             <span
-              class="sc-hYmls kGneDw"
+              class="sc-hBtRBD zIbRN"
             >
               2
             </span>
@@ -477,15 +477,15 @@ exports[`<Wizard /> should render a step 1`] = `
         Premiere Etape
       </p>
       <div
-        class="sc-lbJcrp fsWMsG"
+        class="sc-iLsKjm eOFMyx"
       >
         <button
-          class="sc-kOPcWz cefBoA sc-iLsKjm sc-eifrsQ eQYdHK ehoSxM"
+          class="sc-kOPcWz cefBoA sc-epALIP sc-lbJcrp dyTjwR innUxH"
         >
           Commencer
           <svg
             aria-hidden="true"
-            class="sc-fKWMtX bKjPaG"
+            class="sc-eifrsQ dsvLPn"
             fill="none"
             viewBox="0 0 28 15"
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/react-ui/src/Text/index.js
+++ b/packages/react-ui/src/Text/index.js
@@ -31,6 +31,7 @@ const spanPropTypes = {
     "tiny",
     "small",
     "medium",
+    "inherit",
     "hsmall",
     "hmedium",
     "hmobileMedium",

--- a/packages/react-ui/src/Titles/PageTitle/__snapshots__/test.js.snap
+++ b/packages/react-ui/src/Titles/PageTitle/__snapshots__/test.js.snap
@@ -6,7 +6,7 @@ exports[`<PageTitle /> renders a H1 page title 1`] = `
     class="sc-gEvEer iwWTzJ"
   >
     <h1
-      class="sc-fqkvVR jQMLfU"
+      class="sc-fqkvVR hZWjIQ"
     >
       <span
         class="sc-aXZVg ebuZrC"
@@ -23,7 +23,7 @@ exports[`<PageTitle /> renders a left striped shifted H1 page title 1`] = `
     class="sc-gEvEer bKmRPt"
   >
     <h1
-      class="sc-fqkvVR hDtvKt"
+      class="sc-fqkvVR cshUl"
     >
       <span
         class="sc-aXZVg jHdfHu"

--- a/packages/react-ui/src/Titles/PageTitle/index.js
+++ b/packages/react-ui/src/Titles/PageTitle/index.js
@@ -14,11 +14,10 @@ export const PageTitle = ({
   shift = "",
   subtitle,
   variant,
-  small,
   ...props
 }) => (
   <Header pageTitle stripe={stripe} shift={shift} {...props}>
-    <StyledPageTitle stripe={stripe} as={as} shift={shift} small={small}>
+    <StyledPageTitle stripe={stripe} as={as} shift={shift}>
       <Stripe
         rounded={variant !== "primary"}
         variant={variant}
@@ -38,14 +37,12 @@ PageTitle.propTypes = {
   as: PropTypes.string,
   children: PropTypes.node,
   shift: PropTypes.string,
-  small: PropTypes.boolean,
   stripe: PropTypes.oneOf(["left", "top"]),
   subtitle: PropTypes.node,
   variant: PropTypes.string,
 };
 
 PageTitle.defaultProps = {
-  small: false,
   stripe: "top",
   variant: "secondary",
 };
@@ -55,13 +52,7 @@ const StyledPageTitle = styled.h1`
   margin: 0;
   color: ${({ theme }) => theme.title};
   font-weight: normal;
-  ${({ small }) => {
-    return css`
-      font-size: ${small
-        ? fonts.sizes.headings.xmedium
-        : fonts.sizes.headings.large};
-    `;
-  }}
+  font-size: ${fonts.sizes.headings.large};
   font-family: "Merriweather", serif;
   line-height: ${fonts.lineHeightTitle};
   ${({ stripe, shift }) => {


### PR DESCRIPTION
  - affichage du bon nom de la CC dans les drop down de recherche (ça fix 2 e2e)
  - fix de plusieurs erreurs JS qui faisaient ausi planter les test e2e
  - fix d'une petite regression ui sur le drop down search CC 
  - retrait de warnings dans la console (en dev)

La regression
![Screenshot from 2023-12-19 16-40-16](https://github.com/SocialGouv/code-du-travail-numerique/assets/4971715/9c1acb31-5547-48ae-a217-e7d3b353a6fe)

Avec le fix
![Screenshot from 2023-12-19 16-41-28](https://github.com/SocialGouv/code-du-travail-numerique/assets/4971715/d3567d72-36ef-4688-a025-0589c9070344)
