### PR TITLE
fix: ne pas trim car on a des balises contenant un simple espace par moment

### DIFF
--- a/packages/code-du-travail-frontend/src/contributions/DisplayContentContribution.tsx
+++ b/packages/code-du-travail-frontend/src/contributions/DisplayContentContribution.tsx
@@ -123,7 +123,7 @@ const options = (titleLevel: number): HTMLReactParserOptions => ({
       }
     }
   },
-  trim: true,
+  trim: false,
 });
 
 type Props = {

--- a/packages/code-du-travail-frontend/src/contributions/DisplayContentContribution.tsx
+++ b/packages/code-du-travail-frontend/src/contributions/DisplayContentContribution.tsx
@@ -121,9 +121,17 @@ const options = (titleLevel: number): HTMLReactParserOptions => ({
       if (domNode.name === "p" && !domNode.children.length) {
         return <></>;
       }
+      if (domNode.name === 'strong') {
+        // Disable trim on strong
+        return <strong>{domToReact(domNode.children as DOMNode[], { trim: false })}</strong>;
+      }
+      if (domNode.name === 'em') {
+        // Disable trim on em
+        return <em>{domToReact(domNode.children as DOMNode[], { trim: false })}</em>;
+      }
     }
   },
-  trim: false,
+  trim: true,
 });
 
 type Props = {

--- a/packages/code-du-travail-frontend/src/contributions/__tests__/DisplayContentContribution.test.tsx
+++ b/packages/code-du-travail-frontend/src/contributions/__tests__/DisplayContentContribution.test.tsx
@@ -326,4 +326,38 @@ describe("DisplayContentContribution", () => {
       </table>
     `);
   });
+
+  it(`should keep whitespace in specific tag`, () => {
+    const { asFragment } = render(
+      <DisplayContentContribution
+        content={`<p>Ceci est un<strong> </strong>texte généré<strong> </strong>par <em>tiptap </em>avec des<em> </em>résidus<em> </em>de balise</p>`}
+      ></DisplayContentContribution>
+    );
+
+    expect(asFragment().firstChild).toMatchInlineSnapshot(`
+      <p>
+        Ceci est un
+        <strong>
+           
+        </strong>
+        texte généré
+        <strong>
+           
+        </strong>
+        par 
+        <em>
+          tiptap 
+        </em>
+        avec des
+        <em>
+           
+        </em>
+        résidus
+        <em>
+           
+        </em>
+        de balise
+      </p>
+    `);
+  });
 });


### PR DESCRIPTION
Sur l'admin, on a des reliquats de strong :

![CleanShot 2023-12-19 at 18 10 29@2x](https://github.com/SocialGouv/code-du-travail-numerique/assets/992514/5fabafae-7d72-4b84-82de-2e786039e988)

Du coup quand on trim sur le front, on enlève les espaces :

![image](https://github.com/SocialGouv/code-du-travail-numerique/assets/992514/9ffc21c5-5a7c-4eb6-aa0a-cb879a5e810d)

Il reste également logique de ne pas trim ce que l'on traduit pour rester iso à ce que l'on a sur l'admin.