### PR TITLE
feat: placer les références sans url à la fin de la liste

### DIFF
--- a/packages/code-du-travail-frontend/src/contributions/References.tsx
+++ b/packages/code-du-travail-frontend/src/contributions/References.tsx
@@ -11,7 +11,7 @@ export const ReferencesJuridiques = (props: Props) => {
     return null;
   }
   const refs = props.references
-    .flatMap(({ title, url }) => {
+    .map(({ title, url }) => {
       return { title, type: SOURCES.EXTERNALS, url };
     })
     .sort((a, b) => (a.url && !b.url ? -1 : !a.url && b.url ? 1 : 0));

--- a/packages/code-du-travail-frontend/src/contributions/References.tsx
+++ b/packages/code-du-travail-frontend/src/contributions/References.tsx
@@ -10,9 +10,11 @@ export const ReferencesJuridiques = (props: Props) => {
   if (!props.references || props.references.length === 0) {
     return null;
   }
-  const refs = props.references.flatMap(({ title, url }) => {
-    return { title, type: SOURCES.EXTERNALS, url };
-  });
+  const refs = props.references
+    .flatMap(({ title, url }) => {
+      return { title, type: SOURCES.EXTERNALS, url };
+    })
+    .sort((a, b) => (a.url && !b.url ? -1 : !a.url && b.url ? 1 : 0));
 
   return <References label="Références" references={refs} accordionList="3" />;
 };

--- a/packages/code-du-travail-frontend/src/contributions/__tests__/ReferencesJuridique.test.tsx
+++ b/packages/code-du-travail-frontend/src/contributions/__tests__/ReferencesJuridique.test.tsx
@@ -1,0 +1,156 @@
+import { render } from "@testing-library/react";
+import DisplayContentContribution from "../DisplayContentContribution";
+import { ReferencesJuridiques } from "../References";
+
+describe("ReferencesJuridiques", () => {
+  it(`doit retourner null si pas de références`, () => {
+    const { asFragment } = render(
+      <ReferencesJuridiques references={[]}></ReferencesJuridiques>
+    );
+
+    expect(asFragment().firstChild).toBeNull();
+  });
+  it(`doit mettre les références sans lien à la fin`, () => {
+    const { asFragment } = render(
+      <ReferencesJuridiques
+        references={[
+          {
+            url: null,
+            title: "Titre 1",
+          },
+          {
+            title: "Titre 2",
+            url: "http://lien2",
+          },
+          {
+            url: undefined,
+            title: "Titre 3",
+          },
+          {
+            title: "Titre 4",
+          },
+          {
+            title: "Titre 5",
+            url: "http://lien4",
+          },
+        ]}
+      ></ReferencesJuridiques>
+    );
+
+    expect(asFragment().firstChild).toMatchInlineSnapshot(`
+      <div
+        class="sc-iGgWBj cRLRjd"
+      >
+        <div>
+          <button
+            aria-expanded="false"
+            class="sc-kOPcWz ezOCpB sc-bbSZdi jpCDWv"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="sc-imWYAI gTeNha"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <polyline
+                points="9 18 15 12 9 6"
+              />
+            </svg>
+            <span
+              aria-level="2"
+              class="sc-fBWQRz lqUBb"
+              font-size="hsmall"
+              font-weight="600"
+              role="heading"
+            >
+              Références
+            </span>
+          </button>
+          <div
+            class="sc-fjvvzt gtrYRc"
+          >
+            <ul
+              class="sc-cfxfcM sc-lnPyaJ kMmTaI iUscuO"
+            >
+              <li>
+                <a
+                  aria-label="Titre 2 (Nouvelle fenêtre)"
+                  class="sc-bmzYkS hFAanY sc-iXzfSG dyqFrk no-after"
+                  href="http://lien2"
+                  target="_blank"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="sc-dtBdUo hpIOmX"
+                    fill="none"
+                    viewBox="0 0 28 15"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="m27.875 7.153-6-6.284a.526.526 0 0 0-.711-.023.496.496 0 0 0-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 0 0 .024.687.52.52 0 0 0 .711-.023l6-6.284a.506.506 0 0 0 0-.665z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <p
+                    class="sc-iHGNWf hQSWKy"
+                  >
+                    Titre 2
+                  </p>
+                </a>
+              </li>
+              <li>
+                <a
+                  aria-label="Titre 5 (Nouvelle fenêtre)"
+                  class="sc-bmzYkS hFAanY sc-iXzfSG dyqFrk no-after"
+                  href="http://lien4"
+                  target="_blank"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="sc-dtBdUo hpIOmX"
+                    fill="none"
+                    viewBox="0 0 28 15"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="m27.875 7.153-6-6.284a.526.526 0 0 0-.711-.023.496.496 0 0 0-.024.688l5.204 5.468H.5c-.276 0-.5.217-.5.484s.224.483.5.483h25.844l-5.204 5.469a.493.493 0 0 0 .024.687.52.52 0 0 0 .711-.023l6-6.284a.506.506 0 0 0 0-.665z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <p
+                    class="sc-iHGNWf hQSWKy"
+                  >
+                    Titre 5
+                  </p>
+                </a>
+              </li>
+              <li>
+                <div>
+                  Titre 1
+                </div>
+              </li>
+              <li>
+                <div>
+                  Titre 3
+                </div>
+              </li>
+              <li>
+                <div>
+                  Titre 4
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    `);
+  });
+});

--- a/packages/code-du-travail-utils/src/types.ts
+++ b/packages/code-du-travail-utils/src/types.ts
@@ -180,7 +180,7 @@ type ContributionLinkedContent = {
 };
 
 type ContributionRef = {
-  url: string;
+  url?: string | null;
   title: string;
 };
 


### PR DESCRIPTION
On place les références sans lien à la fin. Ce n'est toujours pas très sexy, il faudrait revoir le design ici...

Avant :

![CleanShot 2023-12-20 at 11 57 47@2x](https://github.com/SocialGouv/code-du-travail-numerique/assets/992514/22d29529-24cc-4275-8838-de71c3424b79)

Après :

![CleanShot 2023-12-20 at 11 56 24@2x](https://github.com/SocialGouv/code-du-travail-numerique/assets/992514/ece0c333-ad7e-43a3-aff5-7805da02aa0f)
