### PR TITLE
fix(console warning): react error in console

### DIFF
--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/droit-du-travail.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/droit-du-travail.test.js.snap
@@ -2242,7 +2242,7 @@ exports[`<DroitDuTravail /> should render 1`] = `
                             Ce principe ne s’applique pas dans
                              
                             <button
-                              class="sc-kOPcWz gELDTc"
+                              class="sc-kOPcWz gACNan"
                             >
                               13 matières
                               <svg
@@ -2261,7 +2261,7 @@ exports[`<DroitDuTravail /> should render 1`] = `
                             où la loi reconnaît la primauté à la convention collective de branche et
                              
                             <button
-                              class="sc-kOPcWz gELDTc"
+                              class="sc-kOPcWz gACNan"
                             >
                               4 matières
                               <svg

--- a/packages/code-du-travail-frontend/pages/convention-collective/index.tsx
+++ b/packages/code-du-travail-frontend/pages/convention-collective/index.tsx
@@ -11,7 +11,6 @@ import React from "react";
 
 import Metas from "../../src/common/Metas";
 import { Layout } from "../../src/layout/Layout";
-import { handleError } from "../../src/lib/fetch-error";
 import { ListLink } from "../../src/search/SearchResults/Results";
 import styled from "styled-components";
 import Link from "next/link";
@@ -55,7 +54,7 @@ function Page({ ccs }) {
               passHref
               legacyBehavior
             >
-              <Button as="a" variant="link" hasText>
+              <Button as="a" variant="link">
                 Trouvez la
               </Button>
             </Link>
@@ -95,6 +94,7 @@ export async function getStaticProps() {
     return { props: { ccs: [] }, revalidate: REVALIDATE_TIME };
   }
 }
+
 const ListItem = styled.li`
   margin-top: ${theme.spacings.medium};
 `;

--- a/packages/code-du-travail-frontend/src/common/Feedback/__tests__/__snapshots__/Feedback.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/Feedback/__tests__/__snapshots__/Feedback.test.js.snap
@@ -176,7 +176,7 @@ exports[`<Feedback/> should render form once user answer no 1`] = `
           Pour obtenir une réponse à votre question de droit du travail, nous vous invitons à joindre
            
           <button
-            class="sc-kOPcWz gELDTc"
+            class="sc-kOPcWz gACNan"
             type="button"
           >
             les services du ministère du Travail en région

--- a/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/ContactModal.test.js.snap
+++ b/packages/code-du-travail-frontend/src/common/__tests__/__snapshots__/ContactModal.test.js.snap
@@ -52,7 +52,7 @@ exports[`<ContactModal /> renders a popup when click on button 1`] = `
                 Si vous souhaitez nous interroger sur vos droits ou sur des dispositions en droit du travail, nous vous invitons à contacter
                  
                 <button
-                  class="sc-kOPcWz gELDTc"
+                  class="sc-kOPcWz gACNan"
                 >
                   les services du ministère du Travail
                   <svg

--- a/packages/code-du-travail-frontend/src/outils/ConventionCollective/common/NoEnterprise.tsx
+++ b/packages/code-du-travail-frontend/src/outils/ConventionCollective/common/NoEnterprise.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Heading, theme, Button } from "@socialgouv/cdtn-ui";
+import { Button, Heading, theme } from "@socialgouv/cdtn-ui";
 import styled from "styled-components";
 import { push as matopush } from "@socialgouv/matomo-next";
 import {
@@ -49,7 +49,7 @@ export function NoEnterprise(props: Props): JSX.Element {
           <strong>Vous n&apos;avez pas d&apos;entreprise</strong> (votre
           recherche concerne les assistants maternels, employés de maison) ?
         </Heading>
-        <StyledButton variant="link" hasText onClick={onClick}>
+        <StyledButton variant="link" onClick={onClick}>
           Consultez votre convention collective
         </StyledButton>
       </FeedbackWrapper>

--- a/packages/code-du-travail-frontend/src/questionnaire/Components/Summary/Summary.tsx
+++ b/packages/code-du-travail-frontend/src/questionnaire/Components/Summary/Summary.tsx
@@ -43,7 +43,6 @@ export const Summary = ({
         <LinkWrapper>
           <Button
             variant="link"
-            hasText
             onClick={async () => {
               await router.push(`/outils/${toolSlug}`);
             }}

--- a/packages/react-ui/src/Button/__snapshots__/test.js.snap
+++ b/packages/react-ui/src/Button/__snapshots__/test.js.snap
@@ -29,7 +29,7 @@ exports[`<Button /> it renders a Button flat 1`] = `
 exports[`<Button /> it renders a Button link 1`] = `
 <div>
   <button
-    class="sc-aXZVg WRhGo"
+    class="sc-aXZVg doMvpz"
   >
     this is a Button 
     link
@@ -47,7 +47,7 @@ exports[`<Button /> it renders a Button link 1`] = `
     </svg>
   </button>
   <button
-    class="sc-aXZVg WRhGo"
+    class="sc-aXZVg doMvpz"
   >
     this is a small Button 
     link
@@ -65,7 +65,7 @@ exports[`<Button /> it renders a Button link 1`] = `
     </svg>
   </button>
   <button
-    class="sc-aXZVg WRhGo"
+    class="sc-aXZVg doMvpz"
   >
     this is a narrow Button 
     link

--- a/packages/react-ui/src/Button/index.js
+++ b/packages/react-ui/src/Button/index.js
@@ -54,8 +54,7 @@ export const StyledButton = styled.button`
         svg {
           width: 2.6rem;
           height: 1.4rem;
-          margin: ${({ hasText }) =>
-            hasText ? `0 ${spacings.tiny} 0 ${spacings.small}` : "0"};
+          margin: 0 ${spacings.small};
           transition: transform ${animations.transitionTiming} linear;
           /* stylelint-disable-next-line */
           fill: ${theme.primary};
@@ -207,9 +206,7 @@ export const Button = React.forwardRef(
     return (
       <StyledButton {...props} ref={ref}>
         {children}
-        {props.variant === "link" && (
-          <StyledCustomIcon hasText={Boolean(children)} />
-        )}
+        {props.variant === "link" && <StyledCustomIcon />}
       </StyledButton>
     );
   }
@@ -218,7 +215,6 @@ Button.displayName = "Button";
 
 Button.propTypes = {
   children: PropTypes.node,
-  hasText: PropTypes.bool,
   icon: PropTypes.elementType,
   narrow: PropTypes.bool,
   onClick: PropTypes.func,


### PR DESCRIPTION
Petite PR pour enlever le warning qu'on voit en dev :

`Warning: React does not recognize the `hasText` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `hastext` instead. If you accidentally passed it from a parent component, remove it from the DOM element.`