### PR TITLE
fix(footer): retrait des headings inutiles du footer

### DIFF
--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/a-propos.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/a-propos.test.tsx.snap
@@ -424,10 +424,8 @@ exports[`<About /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Code du travail numérique
                 </strong>
@@ -482,10 +480,8 @@ exports[`<About /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Outils populaires
                 </strong>
@@ -520,10 +516,8 @@ exports[`<About /> should render 1`] = `
               </div>
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Modèles populaires
                 </strong>
@@ -562,10 +556,8 @@ exports[`<About /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Fiches pratiques populaires
                 </strong>
@@ -600,10 +592,8 @@ exports[`<About /> should render 1`] = `
               </div>
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Conventions collectives populaires
                 </strong>

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/droit-du-travail.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/droit-du-travail.test.js.snap
@@ -2711,10 +2711,8 @@ exports[`<DroitDuTravail /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-hBtRBD bwfYKB sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Code du travail numérique
                 </strong>
@@ -2769,10 +2767,8 @@ exports[`<DroitDuTravail /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-hBtRBD bwfYKB sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Outils populaires
                 </strong>
@@ -2807,10 +2803,8 @@ exports[`<DroitDuTravail /> should render 1`] = `
               </div>
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-hBtRBD bwfYKB sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Modèles populaires
                 </strong>
@@ -2849,10 +2843,8 @@ exports[`<DroitDuTravail /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-hBtRBD bwfYKB sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Fiches pratiques populaires
                 </strong>
@@ -2887,10 +2879,8 @@ exports[`<DroitDuTravail /> should render 1`] = `
               </div>
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-hBtRBD bwfYKB sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Conventions collectives populaires
                 </strong>

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/fiche-ministere-travail.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/fiche-ministere-travail.test.tsx.snap
@@ -834,10 +834,8 @@ exports[`<FicheMT /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-gplwa-d eDkOmv sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Code du travail numérique
                 </strong>
@@ -892,10 +890,8 @@ exports[`<FicheMT /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-gplwa-d eDkOmv sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Outils populaires
                 </strong>
@@ -930,10 +926,8 @@ exports[`<FicheMT /> should render 1`] = `
               </div>
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-gplwa-d eDkOmv sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Modèles populaires
                 </strong>
@@ -972,10 +966,8 @@ exports[`<FicheMT /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-gplwa-d eDkOmv sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Fiches pratiques populaires
                 </strong>
@@ -1010,10 +1002,8 @@ exports[`<FicheMT /> should render 1`] = `
               </div>
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-gplwa-d eDkOmv sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Conventions collectives populaires
                 </strong>

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire-[slug].test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire-[slug].test.tsx.snap
@@ -301,10 +301,8 @@ exports[`<Term /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-lbJcrp kpWXOu sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Code du travail numérique
                 </strong>
@@ -359,10 +357,8 @@ exports[`<Term /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-lbJcrp kpWXOu sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Outils populaires
                 </strong>
@@ -397,10 +393,8 @@ exports[`<Term /> should render 1`] = `
               </div>
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-lbJcrp kpWXOu sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Modèles populaires
                 </strong>
@@ -439,10 +433,8 @@ exports[`<Term /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-lbJcrp kpWXOu sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Fiches pratiques populaires
                 </strong>
@@ -477,10 +469,8 @@ exports[`<Term /> should render 1`] = `
               </div>
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-lbJcrp kpWXOu sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Conventions collectives populaires
                 </strong>

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire.test.tsx.snap
@@ -485,10 +485,8 @@ exports[`<Glossaire /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Code du travail numérique
                 </strong>
@@ -543,10 +541,8 @@ exports[`<Glossaire /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Outils populaires
                 </strong>
@@ -581,10 +577,8 @@ exports[`<Glossaire /> should render 1`] = `
               </div>
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Modèles populaires
                 </strong>
@@ -623,10 +617,8 @@ exports[`<Glossaire /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Fiches pratiques populaires
                 </strong>
@@ -661,10 +653,8 @@ exports[`<Glossaire /> should render 1`] = `
               </div>
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Conventions collectives populaires
                 </strong>

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/mentions-legales.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/mentions-legales.test.tsx.snap
@@ -406,10 +406,8 @@ exports[`<MentionLegales /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Code du travail numérique
                 </strong>
@@ -464,10 +462,8 @@ exports[`<MentionLegales /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Outils populaires
                 </strong>
@@ -502,10 +498,8 @@ exports[`<MentionLegales /> should render 1`] = `
               </div>
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Modèles populaires
                 </strong>
@@ -544,10 +538,8 @@ exports[`<MentionLegales /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Fiches pratiques populaires
                 </strong>
@@ -582,10 +574,8 @@ exports[`<MentionLegales /> should render 1`] = `
               </div>
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Conventions collectives populaires
                 </strong>

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers-[slug].test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers-[slug].test.tsx.snap
@@ -815,10 +815,8 @@ exports[`<ModelesDeCourrier /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Code du travail numérique
                 </strong>
@@ -873,10 +871,8 @@ exports[`<ModelesDeCourrier /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Outils populaires
                 </strong>
@@ -911,10 +907,8 @@ exports[`<ModelesDeCourrier /> should render 1`] = `
               </div>
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Modèles populaires
                 </strong>
@@ -953,10 +947,8 @@ exports[`<ModelesDeCourrier /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Fiches pratiques populaires
                 </strong>
@@ -991,10 +983,8 @@ exports[`<ModelesDeCourrier /> should render 1`] = `
               </div>
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Conventions collectives populaires
                 </strong>

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers.test.tsx.snap
@@ -450,10 +450,8 @@ exports[`<ModelesDeCourriers /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Code du travail numérique
                 </strong>
@@ -508,10 +506,8 @@ exports[`<ModelesDeCourriers /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Outils populaires
                 </strong>
@@ -546,10 +542,8 @@ exports[`<ModelesDeCourriers /> should render 1`] = `
               </div>
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Modèles populaires
                 </strong>
@@ -588,10 +582,8 @@ exports[`<ModelesDeCourriers /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Fiches pratiques populaires
                 </strong>
@@ -626,10 +618,8 @@ exports[`<ModelesDeCourriers /> should render 1`] = `
               </div>
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Conventions collectives populaires
                 </strong>

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/recherche.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/recherche.test.js.snap
@@ -277,10 +277,8 @@ exports[`<Recherche /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-gEkIjz frSzbn sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Code du travail numérique
                 </strong>
@@ -335,10 +333,8 @@ exports[`<Recherche /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-gEkIjz frSzbn sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Outils populaires
                 </strong>
@@ -373,10 +369,8 @@ exports[`<Recherche /> should render 1`] = `
               </div>
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-gEkIjz frSzbn sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Modèles populaires
                 </strong>
@@ -415,10 +409,8 @@ exports[`<Recherche /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-gEkIjz frSzbn sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Fiches pratiques populaires
                 </strong>
@@ -453,10 +445,8 @@ exports[`<Recherche /> should render 1`] = `
               </div>
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-gEkIjz frSzbn sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Conventions collectives populaires
                 </strong>

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/stats.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/stats.test.tsx.snap
@@ -357,10 +357,8 @@ exports[`<Stats /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Code du travail numérique
                 </strong>
@@ -415,10 +413,8 @@ exports[`<Stats /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Outils populaires
                 </strong>
@@ -453,10 +449,8 @@ exports[`<Stats /> should render 1`] = `
               </div>
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Modèles populaires
                 </strong>
@@ -495,10 +489,8 @@ exports[`<Stats /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Fiches pratiques populaires
                 </strong>
@@ -533,10 +525,8 @@ exports[`<Stats /> should render 1`] = `
               </div>
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-iLsKjm bHyFYd sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Conventions collectives populaires
                 </strong>

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/themes.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/themes.test.tsx.snap
@@ -364,10 +364,8 @@ exports[`<Theme /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-cMa-dbN kZEcPx sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Code du travail numérique
                 </strong>
@@ -422,10 +420,8 @@ exports[`<Theme /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-cMa-dbN kZEcPx sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Outils populaires
                 </strong>
@@ -460,10 +456,8 @@ exports[`<Theme /> should render 1`] = `
               </div>
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-cMa-dbN kZEcPx sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Modèles populaires
                 </strong>
@@ -502,10 +496,8 @@ exports[`<Theme /> should render 1`] = `
             >
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-cMa-dbN kZEcPx sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Fiches pratiques populaires
                 </strong>
@@ -540,10 +532,8 @@ exports[`<Theme /> should render 1`] = `
               </div>
               <div>
                 <strong
-                  aria-level="2"
                   class="sc-cMa-dbN kZEcPx sc-kAyceB jIzQpS"
                   data-testid="heading"
-                  role="heading"
                 >
                   Conventions collectives populaires
                 </strong>

--- a/packages/code-du-travail-frontend/src/layout/Footer.tsx
+++ b/packages/code-du-travail-frontend/src/layout/Footer.tsx
@@ -326,10 +326,7 @@ const StyledList = styled(FlatList)`
   }
 `;
 
-const StyledHeading = styled.strong.attrs({
-  "aria-level": "2",
-  role: "heading",
-})`
+const StyledHeading = styled.strong`
   margin-top: ${spacings.base};
   margin-bottom: ${spacings.xsmall};
   font-size: ${fonts.sizes.default};


### PR DESCRIPTION
Sur toutes nos pages nous avons en h2 dans le footer ceci :
![Screenshot from 2024-01-30 14-54-48](https://github.com/SocialGouv/code-du-travail-numerique/assets/4971715/8ff29e64-3dd2-49c5-8b91-40251e2a6f35)


Je penses que ça n'amène rien en terme de contenu ni au niveau SEO ni au niveau accessibilité.

Je propose de les supprimer