### PR TITLE
feat(contribution): ajout de h1 uniques pour les contributions personnalisées qui ont un titre court et pour les CC avec un nom court

### DIFF
--- a/packages/code-du-travail-frontend/__tests__/contributions.test.tsx
+++ b/packages/code-du-travail-frontend/__tests__/contributions.test.tsx
@@ -1,0 +1,34 @@
+import { render } from "@testing-library/react";
+import React from "react";
+
+import PageContribution from "../pages/contribution/[slug]";
+
+const contribution = {
+  source: "contributions",
+  linkedContent: [],
+  references: [],
+  idcc: "",
+  ccnShortTitle: "Métallurgie",
+  title: "La période d’essai peut-elle être renouvelée ?",
+};
+describe("<PageContribution />", () => {
+  it("should render title with only question", () => {
+    const { getByRole } = render(
+      <PageContribution isNewContribution={true} contribution={contribution} />
+    );
+    const titreH1 = getByRole("heading", { level: 1 });
+    expect(titreH1.textContent).toBe(
+      "La période d’essai peut-elle être renouvelée ?"
+    );
+  });
+  it("should render title with cc name in it", () => {
+    contribution.idcc = "3248";
+    const { getByRole } = render(
+      <PageContribution isNewContribution={true} contribution={contribution} />
+    );
+    const titreH1 = getByRole("heading", { level: 1 });
+    expect(titreH1.textContent).toBe(
+      "Métallurgie: La période d’essai peut-elle être renouvelée ?"
+    );
+  });
+});

--- a/packages/code-du-travail-frontend/__tests__/contributions.test.tsx
+++ b/packages/code-du-travail-frontend/__tests__/contributions.test.tsx
@@ -12,23 +12,24 @@ const contribution = {
   title: "La période d’essai peut-elle être renouvelée ?",
 };
 describe("<PageContribution />", () => {
-  it("should render title with only question", () => {
-    const { getByRole } = render(
-      <PageContribution isNewContribution={true} contribution={contribution} />
-    );
-    const titreH1 = getByRole("heading", { level: 1 });
-    expect(titreH1.textContent).toBe(
-      "La période d’essai peut-elle être renouvelée ?"
-    );
-  });
   it("should render title with cc name in it", () => {
-    contribution.idcc = "3248";
+
     const { getByRole } = render(
       <PageContribution isNewContribution={true} contribution={contribution} />
     );
     const titreH1 = getByRole("heading", { level: 1 });
     expect(titreH1.textContent).toBe(
       "Métallurgie: La période d’essai peut-elle être renouvelée ?"
+    );
+  });
+  it("should render title with only question", () => {
+    contribution.ccnShortTitle = "Ce short title fait plus de 15 caractères";
+    const { getByRole } = render(
+      <PageContribution isNewContribution={true} contribution={contribution} />
+    );
+    const titreH1 = getByRole("heading", { level: 1 });
+    expect(titreH1.textContent).toBe(
+      "La période d’essai peut-elle être renouvelée ?"
     );
   });
 });

--- a/packages/code-du-travail-frontend/pages/contribution/[slug].tsx
+++ b/packages/code-du-travail-frontend/pages/contribution/[slug].tsx
@@ -57,7 +57,7 @@ const buildTitleAndDescription = (
   };
 };
 const getTitleFromNewContrib = (contribution) => {
-  if (contribution.ccnShortTitle.length > 14 || contribution.title.length > 50) {
+  if (!contribution.ccnShortTitle || contribution.ccnShortTitle.length > 14 || contribution.title.length > 50) {
     return contribution.title;
   }
 

--- a/packages/code-du-travail-frontend/pages/contribution/[slug].tsx
+++ b/packages/code-du-travail-frontend/pages/contribution/[slug].tsx
@@ -56,6 +56,17 @@ const buildTitleAndDescription = (
     title,
   };
 };
+const IDCC_WITH_SHORT_NAMES = ["2120", "1480", "3248", "292", "2511", "2148"];
+const getTitleFromNewContrib = (contribution) => {
+  if (
+    !IDCC_WITH_SHORT_NAMES.includes(contribution.idcc) ||
+    contribution.title.length > 50
+  ) {
+    return contribution.title;
+  }
+
+  return `${contribution.ccnShortTitle}: ${contribution.title}`;
+};
 
 function PageContribution(props: Props): React.ReactElement {
   let metas: any = {};
@@ -82,7 +93,7 @@ function PageContribution(props: Props): React.ReactElement {
         <>
           <Metas title={metas.title} description={metas.description} />
           <Answer
-            title={props.contribution.title}
+            title={getTitleFromNewContrib(props.contribution)}
             breadcrumbs={props.contribution.breadcrumbs}
           >
             {props.contribution.idcc === "0000" ? (

--- a/packages/code-du-travail-frontend/pages/contribution/[slug].tsx
+++ b/packages/code-du-travail-frontend/pages/contribution/[slug].tsx
@@ -56,12 +56,8 @@ const buildTitleAndDescription = (
     title,
   };
 };
-const IDCC_WITH_SHORT_NAMES = ["2120", "1480", "3248", "292", "2511", "2148"];
 const getTitleFromNewContrib = (contribution) => {
-  if (
-    !IDCC_WITH_SHORT_NAMES.includes(contribution.idcc) ||
-    contribution.title.length > 50
-  ) {
+  if (contribution.ccnShortTitle.length > 14 || contribution.title.length > 50) {
     return contribution.title;
   }
 


### PR DESCRIPTION
Fix [#5592](https://github.com/SocialGouv/code-du-travail-numerique/issues/5592)

Exemple : https://code-du-travail-numerique-carolinebda-test-unique-nam-u1p3tyoj.dev.fabrique.social.gouv.fr/contribution/3248-les-conges-pour-evenements-familiaux