### PR TITLE
fix(kontinuous): set right limits and requests

### DIFF
--- a/.kontinuous/env/prod/values.yaml
+++ b/.kontinuous/env/prod/values.yaml
@@ -40,8 +40,8 @@ app:
     enabled: true
   resources:
     limits:
-      cpu: 600m
-      memory: 1024Mi
+      cpu: 700m
+      memory: 1536Mi
     requests:
-      cpu: 500m
-      memory: 896Mi
+      cpu: 600m
+      memory: 1280Mi


### PR DESCRIPTION
CPU
- requests : 600m (actuellement 500m)
- limits : 700m (actuellement 600m) Memory
- requests : 1280Mo (actuellement 896Mo)
- limits : 1536Mo (actuellement 1024Mo)