### PR TITLE
fix(indemnite-licenciement): valider les absences seulement si les dates en amont sont valides

### DIFF
--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/Anciennete/store/__tests__/validator.test.ts
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/Anciennete/store/__tests__/validator.test.ts
@@ -265,4 +265,38 @@ describe("Ancienneté store", () => {
       expect(result.isValid).toBe(true);
     });
   });
+
+  it("ne doit pas retourner une erreur sur l'absence si la date de l'embauche est après la date de sortie", () => {
+    const result = validateStep(
+      {
+        dateEntree: "01/01/2020",
+        dateSortie: "01/03/2019",
+        dateNotification: "01/01/2019",
+        motifs: [],
+        absencePeriods: [
+          {
+            motif: {
+              label: "",
+              startAt: () => true,
+              key: MotifKeys.maladieNonPro,
+              value: 1,
+            },
+            startedAt: "01/01/2021",
+            durationInMonth: 2,
+          },
+        ],
+        hasAbsenceProlonge: "oui",
+      },
+      {},
+      {
+        publicodesInformations: [],
+        isStepHidden: false,
+        isStepSalaryHidden: false,
+        hasNoMissingQuestions: true,
+        informationError: false,
+      }
+    );
+    expect(result.isValid).toBe(false);
+    expect(result.errorState.errorAbsencePeriods?.absences).toStrictEqual(undefined);
+  });
 });

--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/Anciennete/store/validator/absencePeriods.ts
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/Anciennete/store/validator/absencePeriods.ts
@@ -1,4 +1,4 @@
-import { isWithinInterval } from "date-fns";
+import { isAfter, isWithinInterval } from "date-fns";
 import { parse } from "../../../../../common/utils";
 import {
   AncienneteAbsenceStoreError,
@@ -48,8 +48,9 @@ export const getAbsencePeriodsErrors = (
           item.motif.startAt &&
           item.motif.startAt(informationData) &&
           item.startedAt &&
-          state.dateEntree &&
-          state.dateSortie &&
+          dEntree &&
+          dSortie &&
+          isAfter(dSortie, dEntree) &&
           !isWithinInterval(parse(item.startedAt), {
             start: dEntree,
             end: dSortie,


### PR DESCRIPTION


Closes [#5744](https://github.com/SocialGouv/code-du-travail-numerique/issues/5744)