### PR TITLE
fix(recherche-entreprise): suppression du paramètre `employer=true` qui bug 

### DIFF
--- a/packages/code-du-travail-frontend/cypress.config.js
+++ b/packages/code-du-travail-frontend/cypress.config.js
@@ -5,7 +5,7 @@ import htmlvalidate from "cypress-html-validate/plugin";
 dotenv.config();
 
 module.exports = defineConfig({
-  defaultCommandTimeout: 10000, // 10s
+  defaultCommandTimeout: 20000, // 20s
   e2e: {
     baseUrl: process.env.TEST_BASEURL ?? "http://localhost:3000",
     specPattern: process.env.ALL_TEST

--- a/packages/code-du-travail-frontend/src/api/__tests__/enterprise.test.ts
+++ b/packages/code-du-travail-frontend/src/api/__tests__/enterprise.test.ts
@@ -16,7 +16,7 @@ describe("Test enterprise endpoint", () => {
     expect(response.status).toEqual(404);
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith(
-      `https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=NOT-FOUND&convention=false&employer=true&open=true&matchingLimit=0`,
+      `https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=NOT-FOUND&convention=false&open=true&matchingLimit=0`,
       { headers: { referer: "cdtn-api" } }
     );
 
@@ -38,7 +38,7 @@ describe("Test enterprise endpoint", () => {
     expect(response.status).toEqual(200);
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith(
-      "https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=La%20p%C3%AAche%20%C3%A0%20la%20ligne&convention=false&employer=true&open=true&matchingLimit=0",
+      "https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=La%20p%C3%AAche%20%C3%A0%20la%20ligne&convention=false&open=true&matchingLimit=0",
       { headers: { referer: "cdtn-api" } }
     );
   });
@@ -99,7 +99,7 @@ describe("Test enterprise endpoint", () => {
     expect(response.status).toEqual(200);
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith(
-      `https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=AUTOEXPRESS&convention=false&employer=true&open=true&matchingLimit=0`,
+      `https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=AUTOEXPRESS&convention=false&open=true&matchingLimit=0`,
       { headers: { referer: "cdtn-api" } }
     );
 
@@ -121,7 +121,7 @@ describe("Test enterprise endpoint", () => {
     expect(response.status).toEqual(200);
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith(
-      "https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=hello&convention=false&employer=true&open=true&matchingLimit=0&address=my%20address",
+      "https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=hello&convention=false&open=true&matchingLimit=0&address=my%20address",
       { headers: { referer: "cdtn-api" } }
     );
   });
@@ -151,7 +151,7 @@ describe("Test enterprise endpoint", () => {
     expect(response.status).toEqual(200);
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith(
-      `https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=AUTOEXPRESS&convention=false&employer=true&open=true&matchingLimit=0`,
+      `https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=AUTOEXPRESS&convention=false&open=true&matchingLimit=0`,
       { headers: { referer: "cdtn-api" } }
     );
 
@@ -190,7 +190,7 @@ describe("Test enterprise endpoint", () => {
     expect(response.status).toEqual(200);
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith(
-      `https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=AUTOEXPRESS&convention=false&employer=true&open=true&matchingLimit=0`,
+      `https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=AUTOEXPRESS&convention=false&open=true&matchingLimit=0`,
       { headers: { referer: "cdtn-api" } }
     );
 
@@ -254,7 +254,7 @@ describe("Test enterprise endpoint", () => {
     expect(response.status).toEqual(200);
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith(
-      `https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=AUTOEXPRESS&convention=false&employer=true&open=true&matchingLimit=0`,
+      `https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=AUTOEXPRESS&convention=false&open=true&matchingLimit=0`,
       { headers: { referer: "cdtn-api" } }
     );
 
@@ -284,7 +284,7 @@ describe("Test enterprise endpoint", () => {
     expect(response.status).toEqual(200);
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith(
-      `https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=AUTOEXPRESS&convention=false&employer=true&open=true&matchingLimit=0`,
+      `https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=AUTOEXPRESS&convention=false&open=true&matchingLimit=0`,
       { headers: { referer: "cdtn-api" } }
     );
 
@@ -323,7 +323,7 @@ describe("Test enterprise endpoint", () => {
     expect(response.status).toEqual(200);
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith(
-      `https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=AUTOEXPRESS&convention=false&employer=true&open=true&matchingLimit=0`,
+      `https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=AUTOEXPRESS&convention=false&open=true&matchingLimit=0`,
       { headers: { referer: "cdtn-api" } }
     );
 
@@ -373,7 +373,7 @@ describe("Test enterprise endpoint", () => {
     expect(response.status).toEqual(200);
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith(
-      `https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=AUTOEXPRESS&convention=false&employer=true&open=true&matchingLimit=0`,
+      `https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=AUTOEXPRESS&convention=false&open=true&matchingLimit=0`,
       { headers: { referer: "cdtn-api" } }
     );
 
@@ -421,7 +421,7 @@ describe("Test enterprise endpoint", () => {
     expect(response.status).toEqual(200);
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith(
-      `https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=AUTOEXPRESS&convention=false&employer=true&open=true&matchingLimit=0`,
+      `https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=AUTOEXPRESS&convention=false&open=true&matchingLimit=0`,
       { headers: { referer: "cdtn-api" } }
     );
 
@@ -469,7 +469,7 @@ describe("Test enterprise endpoint", () => {
     expect(response.status).toEqual(200);
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith(
-      `https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=AUTOEXPRESS&convention=false&employer=true&open=true&matchingLimit=0`,
+      `https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=AUTOEXPRESS&convention=false&open=true&matchingLimit=0`,
       { headers: { referer: "cdtn-api" } }
     );
 
@@ -524,7 +524,7 @@ describe("Test enterprise endpoint", () => {
     expect(response.status).toEqual(200);
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith(
-      `https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=AUTOEXPRESS&convention=false&employer=true&open=true&matchingLimit=0`,
+      `https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/search?ranked=true&query=AUTOEXPRESS&convention=false&open=true&matchingLimit=0`,
       { headers: { referer: "cdtn-api" } }
     );
 

--- a/packages/code-du-travail-frontend/src/api/modules/enterprises/service/fetchEnterprises.ts
+++ b/packages/code-du-travail-frontend/src/api/modules/enterprises/service/fetchEnterprises.ts
@@ -23,7 +23,6 @@ export const fetchEnterprises = async (
     { k: "ranked", v: "true" },
     { k: "query", v: encodeURIComponent(query) },
     { k: "convention", v: "false" },
-    { k: "employer", v: "true" },
     { k: "open", v: "true" },
     { k: "matchingLimit", v: "0" },
   ];


### PR DESCRIPTION
fix [#5769](https://github.com/SocialGouv/code-du-travail-numerique/issues/5769)