### PR TITLE
fix(rupture-co): inéligibilité activée même si l'utilisateur clique CDI en premier

### DIFF
--- a/packages/code-du-travail-frontend/src/outils/CommonIndemniteDepart/steps/ContratTravail/store/validator.ts
+++ b/packages/code-du-travail-frontend/src/outils/CommonIndemniteDepart/steps/ContratTravail/store/validator.ts
@@ -1,25 +1,30 @@
 import { deepEqualObject, isValidDate } from "../../../../../lib";
 import { ContratTravailStoreError, ContratTravailStoreInput } from "./types";
 
+const isCDI = (state) => state.typeContratTravail === "cdi";
 export const validateStep = (state: ContratTravailStoreInput) => {
   const errorState: ContratTravailStoreError = {
     errorTypeContratTravail: !state.typeContratTravail
       ? "Vous devez répondre à cette question"
       : undefined,
     errorLicenciementFauteGrave:
-      !state.licenciementFauteGrave && state.typeContratTravail === "cdi"
+      !state.licenciementFauteGrave && isCDI(state)
         ? "Vous devez répondre à cette question"
         : undefined,
     errorLicenciementInaptitude:
-      !state.licenciementInaptitude && state.licenciementFauteGrave === "non"
+      !state.licenciementInaptitude &&
+      isCDI(state) &&
+      state.licenciementFauteGrave === "non"
         ? "Vous devez répondre à cette question"
         : undefined,
     errorArretTravail:
-      state.licenciementInaptitude === "non" && !state.arretTravail
+      !state.arretTravail &&
+      isCDI(state) &&
+      state.licenciementInaptitude === "non"
         ? "Vous devez répondre à cette question"
         : undefined,
     errorDateArretTravail:
-      state.arretTravail === "oui" && !state.dateArretTravail
+      state.arretTravail === "oui" && isCDI(state) && !state.dateArretTravail
         ? "Vous devez répondre à cette question"
         : state.arretTravail === "oui" &&
           state.dateArretTravail &&

--- a/packages/code-du-travail-frontend/src/outils/RuptureCoventionnelle/__tests__/eligibility-error-result.test.tsx
+++ b/packages/code-du-travail-frontend/src/outils/RuptureCoventionnelle/__tests__/eligibility-error-result.test.tsx
@@ -26,7 +26,7 @@ describe(`Tests d'éligibilité`, () => {
       ui.result.infoWarning.ineligibleInfoWarningblock.query()
     ).not.toBeInTheDocument();
   });
-  test("Vérifier l'affichage de l'erreur sur le type de contrat CDD même si CDI click avant", () => {
+  test("Vérifier l'affichage de l'erreur sur le type de contrat CDD même si on clique sur CDI avant", () => {
     fireEvent.click(ui.contract.type.cdi.get());
     fireEvent.click(ui.contract.type.cdd.get());
     fireEvent.click(ui.next.get());

--- a/packages/code-du-travail-frontend/src/outils/RuptureCoventionnelle/__tests__/eligibility-error-result.test.tsx
+++ b/packages/code-du-travail-frontend/src/outils/RuptureCoventionnelle/__tests__/eligibility-error-result.test.tsx
@@ -1,8 +1,7 @@
 import { CalculateurRuptureConventionnelle } from "../..";
 import { ui } from "../../CommonIndemniteDepart/__tests__/ui";
 
-import { fireEvent, render, screen } from "@testing-library/react";
-import { byText } from "testing-library-selector";
+import { fireEvent, render } from "@testing-library/react";
 
 describe(`Tests d'éligibilité`, () => {
   beforeEach(() => {
@@ -17,6 +16,18 @@ describe(`Tests d'éligibilité`, () => {
   });
 
   test("Vérifier l'affichage de l'erreur sur le type de contrat CDD", () => {
+    fireEvent.click(ui.contract.type.cdd.get());
+    fireEvent.click(ui.next.get());
+    expect(ui.result.legalError.cddRupture.query()).toBeInTheDocument();
+    expect(
+      ui.result.infoWarning.eligibleInfoWarningblock.query()
+    ).not.toBeInTheDocument();
+    expect(
+      ui.result.infoWarning.ineligibleInfoWarningblock.query()
+    ).not.toBeInTheDocument();
+  });
+  test("Vérifier l'affichage de l'erreur sur le type de contrat CDD même si CDI click avant", () => {
+    fireEvent.click(ui.contract.type.cdi.get());
     fireEvent.click(ui.contract.type.cdd.get());
     fireEvent.click(ui.next.get());
     expect(ui.result.legalError.cddRupture.query()).toBeInTheDocument();


### PR DESCRIPTION
Fix [#5843](https://github.com/SocialGouv/code-du-travail-numerique/issues/5843)