### PR TITLE
fix(search-cc): erreur 404 à la sélection d'une entreprise

### DIFF
--- a/packages/code-du-travail-frontend/src/outils/ConventionCollective/index.tsx
+++ b/packages/code-du-travail-frontend/src/outils/ConventionCollective/index.tsx
@@ -101,8 +101,8 @@ function AgreementSearchTool({
       setScreen(ScreenType.agreementSelection);
     } else {
       router.push(
-        `/${SOURCES.TOOLS}/convention-collective/${ScreenType.agreementSelection}`,
         {
+          pathname: `/${SOURCES.TOOLS}/convention-collective/${ScreenType.agreementSelection}`,
           query: {
             noRedirect,
           },


### PR DESCRIPTION
fix https://github.com/SocialGouv/code-du-travail-numerique/issues/5876

Source du fix: https://github.com/vercel/next.js/issues/9574#issuecomment-663688720