### PR TITLE
chore: test readonly FS

### DIFF
--- a/.kontinuous/values.yaml
+++ b/.kontinuous/values.yaml
@@ -12,6 +12,8 @@ app:
   imagePackage: app
   imageProject: cdtn
   probesPath: /api/health
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
   envFrom:
     - configMapRef:
         name: www-configmap
@@ -24,3 +26,24 @@ app:
     requests:
       cpu: 400m
       memory: 512Mi
+  volumes:
+    - name: tmp
+      emptyDir: {}
+    - name: next
+      emptyDir: {}
+  volumeMounts:
+    - mountPath: /tmp
+      name: tmp
+    - mountPath: /app/packages/code-du-travail-frontend/.next
+      name: next
+  initContainers:
+    - name: copy-next
+      image:
+        "{{ .Values.global.registry }}/{{ .Values.global.projectName }}/{{
+        .Values.global.imageRepository }}/app:{{ .Values.global.imageTag }}"
+      command: ["/bin/sh", "-c"]
+      args:
+        - cp -r /app/packages/code-du-travail-frontend/.next/* /mnt/next;
+      volumeMounts:
+        - name: next
+          mountPath: /mnt/next

--- a/packages/code-du-travail-frontend/src/config.ts
+++ b/packages/code-du-travail-frontend/src/config.ts
@@ -19,4 +19,4 @@ export const IS_PROD =
   process.env.NEXT_PUBLIC_IS_PRODUCTION_DEPLOYMENT ?? false;
 export const ENTERPRISE_API_URL =
   "https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1";
-export const REVALIDATE_TIME = 1800; // 30 minutes
+export const REVALIDATE_TIME = 5; // 30 minutes

--- a/packages/code-du-travail-frontend/src/config.ts
+++ b/packages/code-du-travail-frontend/src/config.ts
@@ -19,4 +19,4 @@ export const IS_PROD =
   process.env.NEXT_PUBLIC_IS_PRODUCTION_DEPLOYMENT ?? false;
 export const ENTERPRISE_API_URL =
   "https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1";
-export const REVALIDATE_TIME = 5; // 30 minutes
+export const REVALIDATE_TIME = 1800; // 30 minutes


### PR DESCRIPTION
L'objectif est de passer tout le répertoire `/app/packages/code-du-travail-frontend/.next` à un volume Kubernetes plutôt que d'utiliser le filesystem de l'hôte. Après le build de l'image, ce répertoire contient les résultats du build NextJS, on ne peut donc pas simplement monter un volume vide.

On a donc besoin d'un **initContainer** pour monter le volume, copier le build préexistant dessus et ensuite laisser la main à l'application.