### PR TITLE
chore: docker build cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,16 @@ FROM node:$NODE_VERSION AS dist
 
 WORKDIR /dep
 
+# Copy lockfile
+COPY ./yarn.lock ./.yarnrc.yml ./
+COPY .yarn .yarn
+
+# Install packages
+RUN yarn fetch --immutable
+
+COPY . ./
+
+ENV NEXT_PUBLIC_APP_ENV=production
 # Add build-arg from github actions
 ARG NEXT_PUBLIC_IS_PRODUCTION_DEPLOYMENT
 ENV NEXT_PUBLIC_IS_PRODUCTION_DEPLOYMENT=$NEXT_PUBLIC_IS_PRODUCTION_DEPLOYMENT
@@ -37,17 +47,6 @@ ARG NEXT_PUBLIC_SENTRY_URL
 ENV NEXT_PUBLIC_SENTRY_URL=$NEXT_PUBLIC_SENTRY_URL
 ARG NEXT_PUBLIC_ES_INDEX_PREFIX
 ENV NEXT_PUBLIC_ES_INDEX_PREFIX=$NEXT_PUBLIC_ES_INDEX_PREFIX
-
-# Copy lockfile
-COPY ./yarn.lock ./.yarnrc.yml ./
-COPY .yarn .yarn
-
-# Install packages
-RUN yarn fetch --immutable
-
-COPY . ./
-
-ENV NEXT_PUBLIC_APP_ENV=production
 
 # hadolint ignore=SC2046
 RUN --mount=type=secret,id=sentry_auth_token \


### PR DESCRIPTION
Retarder l'inclusion des variables d'environnement vouées à changer fréquemment (comme le hash du dernier commit) permet de préserver le cache docker pour certaines étapes, en l'occurrence le téléchargement des dépendances.