### PR TITLE
fix(texte cc 3239): modification du texte lors la séléction de CC pour corriger le fait que la 3239 est sur-représenté aujourd'hui

### DIFF
--- a/packages/code-du-travail-frontend/src/outils/CommonSteps/Agreement/components/NoEnterprise.tsx
+++ b/packages/code-du-travail-frontend/src/outils/CommonSteps/Agreement/components/NoEnterprise.tsx
@@ -31,9 +31,8 @@ export function NoEnterprise({
         <InputCheckbox
           label={
             <span>
-              <StrongItem>Je n&apos;ai pas d&apos;entreprise</StrongItem> (ma
-              recherche concerne les assistants maternels, employés
-              de&nbsp;maison)
+              Votre recherche concerne{" "}
+              <strong>les assistants maternels, employés de maison</strong>
             </span>
           }
           name="salarieParticulierEmployeur"
@@ -82,12 +81,6 @@ export function NoEnterprise({
 }
 
 const { spacings } = theme;
-
-const StrongItem = styled.strong`
-  font-weight: 600;
-  font-size: ${theme.fonts.sizes.default};
-  color: ${theme.colors.paragraph};
-`;
 
 const RowWrapper = styled.div`
   display: flex;

--- a/packages/code-du-travail-frontend/src/outils/ConventionCollective/common/NoEnterprise.tsx
+++ b/packages/code-du-travail-frontend/src/outils/ConventionCollective/common/NoEnterprise.tsx
@@ -46,7 +46,8 @@ export function NoEnterprise(props: Props): JSX.Element {
           stripe="left"
           shift={theme.spacings.xmedium}
         >
-          Votre recherche concerne <strong>les assistants maternels, employés de maison</strong> ?
+          Votre recherche concerne{" "}
+          <strong>les assistants maternels, employés de maison</strong>&nbsp;?
         </Heading>
         <StyledButton variant="link" onClick={onClick}>
           Consultez votre convention collective

--- a/packages/code-du-travail-frontend/src/outils/ConventionCollective/common/NoEnterprise.tsx
+++ b/packages/code-du-travail-frontend/src/outils/ConventionCollective/common/NoEnterprise.tsx
@@ -46,8 +46,7 @@ export function NoEnterprise(props: Props): JSX.Element {
           stripe="left"
           shift={theme.spacings.xmedium}
         >
-          <strong>Vous n&apos;avez pas d&apos;entreprise</strong> (votre
-          recherche concerne les assistants maternels, employés de maison) ?
+          Votre recherche concerne <strong>les assistants maternels, employés de maison</strong> ?
         </Heading>
         <StyledButton variant="link" onClick={onClick}>
           Consultez votre convention collective


### PR DESCRIPTION
Fix [#5963](https://github.com/SocialGouv/code-du-travail-numerique/issues/5963)