### PR TITLE
fix(html): correction de l'invalidité html sur la partie recherche

### DIFF
--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/a-propos.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/a-propos.test.tsx.snap
@@ -70,6 +70,7 @@ exports[`<About /> should render 1`] = `
             >
               <label
                 for="floating-search"
+                id="downshift-:r0:-label"
               >
                 Rechercher
               </label>
@@ -85,7 +86,14 @@ exports[`<About /> should render 1`] = `
               id="floating-search"
               placeholder="Rechercher"
               role="combobox"
+              type="search"
               value=""
+            />
+            <ul
+              aria-labelledby="downshift-:r0:-label"
+              class="sc-lbJcrp kokiBX"
+              id="downshift-:r0:-menu"
+              role="listbox"
             />
             <button
               aria-label="Lancer ma recherche"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/droit-du-travail.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/droit-du-travail.test.js.snap
@@ -70,6 +70,7 @@ exports[`<DroitDuTravail /> should render 1`] = `
             >
               <label
                 for="floating-search"
+                id="downshift-:r0:-label"
               >
                 Rechercher
               </label>
@@ -85,7 +86,14 @@ exports[`<DroitDuTravail /> should render 1`] = `
               id="floating-search"
               placeholder="Rechercher"
               role="combobox"
+              type="search"
               value=""
+            />
+            <ul
+              aria-labelledby="downshift-:r0:-label"
+              class="sc-hYmls gwHjRF"
+              id="downshift-:r0:-menu"
+              role="listbox"
             />
             <button
               aria-label="Lancer ma recherche"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/fiche-ministere-travail.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/fiche-ministere-travail.test.tsx.snap
@@ -70,6 +70,7 @@ exports[`<FicheMT /> should render 1`] = `
             >
               <label
                 for="floating-search"
+                id="downshift-:r0:-label"
               >
                 Rechercher
               </label>
@@ -85,7 +86,14 @@ exports[`<FicheMT /> should render 1`] = `
               id="floating-search"
               placeholder="Rechercher"
               role="combobox"
+              type="search"
               value=""
+            />
+            <ul
+              aria-labelledby="downshift-:r0:-label"
+              class="sc-gplwa-d hvAaYK"
+              id="downshift-:r0:-menu"
+              role="listbox"
             />
             <button
               aria-label="Lancer ma recherche"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire-[slug].test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire-[slug].test.tsx.snap
@@ -70,6 +70,7 @@ exports[`<Term /> should render 1`] = `
             >
               <label
                 for="floating-search"
+                id="downshift-:r0:-label"
               >
                 Rechercher
               </label>
@@ -85,7 +86,14 @@ exports[`<Term /> should render 1`] = `
               id="floating-search"
               placeholder="Rechercher"
               role="combobox"
+              type="search"
               value=""
+            />
+            <ul
+              aria-labelledby="downshift-:r0:-label"
+              class="sc-lbJcrp kokiBX"
+              id="downshift-:r0:-menu"
+              role="listbox"
             />
             <button
               aria-label="Lancer ma recherche"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/glossaire.test.tsx.snap
@@ -70,6 +70,7 @@ exports[`<Glossaire /> should render 1`] = `
             >
               <label
                 for="floating-search"
+                id="downshift-:r0:-label"
               >
                 Rechercher
               </label>
@@ -85,7 +86,14 @@ exports[`<Glossaire /> should render 1`] = `
               id="floating-search"
               placeholder="Rechercher"
               role="combobox"
+              type="search"
               value=""
+            />
+            <ul
+              aria-labelledby="downshift-:r0:-label"
+              class="sc-lbJcrp kokiBX"
+              id="downshift-:r0:-menu"
+              role="listbox"
             />
             <button
               aria-label="Lancer ma recherche"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/mentions-legales.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/mentions-legales.test.tsx.snap
@@ -70,6 +70,7 @@ exports[`<MentionLegales /> should render 1`] = `
             >
               <label
                 for="floating-search"
+                id="downshift-:r0:-label"
               >
                 Rechercher
               </label>
@@ -85,7 +86,14 @@ exports[`<MentionLegales /> should render 1`] = `
               id="floating-search"
               placeholder="Rechercher"
               role="combobox"
+              type="search"
               value=""
+            />
+            <ul
+              aria-labelledby="downshift-:r0:-label"
+              class="sc-lbJcrp kokiBX"
+              id="downshift-:r0:-menu"
+              role="listbox"
             />
             <button
               aria-label="Lancer ma recherche"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers-[slug].test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers-[slug].test.tsx.snap
@@ -70,6 +70,7 @@ exports[`<ModelesDeCourrier /> should render 1`] = `
             >
               <label
                 for="floating-search"
+                id="downshift-:r0:-label"
               >
                 Rechercher
               </label>
@@ -85,7 +86,14 @@ exports[`<ModelesDeCourrier /> should render 1`] = `
               id="floating-search"
               placeholder="Rechercher"
               role="combobox"
+              type="search"
               value=""
+            />
+            <ul
+              aria-labelledby="downshift-:r0:-label"
+              class="sc-lbJcrp kokiBX"
+              id="downshift-:r0:-menu"
+              role="listbox"
             />
             <button
               aria-label="Lancer ma recherche"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/modeles-de-courriers.test.tsx.snap
@@ -70,6 +70,7 @@ exports[`<ModelesDeCourriers /> should render 1`] = `
             >
               <label
                 for="floating-search"
+                id="downshift-:r0:-label"
               >
                 Rechercher
               </label>
@@ -85,7 +86,14 @@ exports[`<ModelesDeCourriers /> should render 1`] = `
               id="floating-search"
               placeholder="Rechercher"
               role="combobox"
+              type="search"
               value=""
+            />
+            <ul
+              aria-labelledby="downshift-:r0:-label"
+              class="sc-lbJcrp kokiBX"
+              id="downshift-:r0:-menu"
+              role="listbox"
             />
             <button
               aria-label="Lancer ma recherche"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/recherche.test.js.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/recherche.test.js.snap
@@ -120,6 +120,7 @@ exports[`<Recherche /> should render 1`] = `
             >
               <label
                 for="search-input"
+                id="downshift-:r0:-label"
               >
                 Rechercher
               </label>
@@ -135,7 +136,14 @@ exports[`<Recherche /> should render 1`] = `
               id="search-input"
               placeholder="congés payés, durée de préavis"
               role="combobox"
+              type="search"
               value=""
+            />
+            <ul
+              aria-labelledby="downshift-:r0:-label"
+              class="sc-hoLEA dbnMIx"
+              id="downshift-:r0:-menu"
+              role="listbox"
             />
             <button
               aria-label="Lancer ma recherche"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/stats.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/stats.test.tsx.snap
@@ -70,6 +70,7 @@ exports[`<Stats /> should render 1`] = `
             >
               <label
                 for="floating-search"
+                id="downshift-:r0:-label"
               >
                 Rechercher
               </label>
@@ -85,7 +86,14 @@ exports[`<Stats /> should render 1`] = `
               id="floating-search"
               placeholder="Rechercher"
               role="combobox"
+              type="search"
               value=""
+            />
+            <ul
+              aria-labelledby="downshift-:r0:-label"
+              class="sc-lbJcrp kokiBX"
+              id="downshift-:r0:-menu"
+              role="listbox"
             />
             <button
               aria-label="Lancer ma recherche"

--- a/packages/code-du-travail-frontend/__tests__/__snapshots__/themes.test.tsx.snap
+++ b/packages/code-du-travail-frontend/__tests__/__snapshots__/themes.test.tsx.snap
@@ -70,6 +70,7 @@ exports[`<Theme /> should render 1`] = `
             >
               <label
                 for="floating-search"
+                id="downshift-:r0:-label"
               >
                 Rechercher
               </label>
@@ -85,7 +86,14 @@ exports[`<Theme /> should render 1`] = `
               id="floating-search"
               placeholder="Rechercher"
               role="combobox"
+              type="search"
               value=""
+            />
+            <ul
+              aria-labelledby="downshift-:r0:-label"
+              class="sc-fUBkdm eFBISl"
+              id="downshift-:r0:-menu"
+              role="listbox"
             />
             <button
               aria-label="Lancer ma recherche"

--- a/packages/code-du-travail-frontend/src/outils/common/Agreement/AgreementSearch/AgreementInput/SearchAgreementInput.tsx
+++ b/packages/code-du-travail-frontend/src/outils/common/Agreement/AgreementSearch/AgreementInput/SearchAgreementInput.tsx
@@ -139,7 +139,7 @@ export const SearchAgreementInput = ({
 
 const StyledSearch = styled(StyledInput)`
   margin-top: ${theme.spacings.small};
-  padding: 1rem 1.6rem;
+  padding-right: 1.6rem;
 `;
 
 const StyledUl = styled(StyledList)`

--- a/packages/code-du-travail-frontend/src/outils/common/Agreement/AgreementSearch/AgreementInput/SearchAgreementInput.tsx
+++ b/packages/code-du-travail-frontend/src/outils/common/Agreement/AgreementSearch/AgreementInput/SearchAgreementInput.tsx
@@ -36,6 +36,7 @@ export const SearchAgreementInput = ({
     isOpen,
     getMenuProps,
     getInputProps,
+    getLabelProps,
     highlightedIndex,
     getItemProps,
   } = useCombobox({
@@ -72,7 +73,11 @@ export const SearchAgreementInput = ({
 
   return (
     <>
-      <InlineLabel htmlFor="agreement-search" id="agreement-search-label">
+      <InlineLabel
+        {...getLabelProps()}
+        htmlFor="agreement-search"
+        id="agreement-search-label"
+      >
         Nom de la convention collective ou son numéro d’identification{" "}
         <abbr title="Identifiant de la Convention Collective">IDCC</abbr>{" "}
         <Text fontWeight="400" fontSize="small">
@@ -102,12 +107,12 @@ export const SearchAgreementInput = ({
         type="search"
       />
 
-      {isOpen && suggestions.length > 0 && (
-        <StyledUl
-          {...getMenuProps()}
-          hideBorder={suggestions.length === 0 || !isOpen}
-        >
-          {suggestions.map((item: Agreement, index) => (
+      <StyledUl
+        {...getMenuProps()}
+        hideBorder={suggestions.length === 0 || !isOpen}
+      >
+        {isOpen &&
+          suggestions.map((item: Agreement, index) => (
             <StyledSuggestion
               {...getItemProps({
                 item,
@@ -119,8 +124,7 @@ export const SearchAgreementInput = ({
               {item.shortTitle} (IDCC {formatIdcc(item.num)})
             </StyledSuggestion>
           ))}
-        </StyledUl>
-      )}
+      </StyledUl>
       {query !== null && query !== "" && (
         <AgreementNoResult
           data={suggestions}
@@ -135,6 +139,7 @@ export const SearchAgreementInput = ({
 
 const StyledSearch = styled(StyledInput)`
   margin-top: ${theme.spacings.small};
+  padding: 1rem 1.6rem;
 `;
 
 const StyledUl = styled(StyledList)`

--- a/packages/code-du-travail-frontend/src/outils/common/Agreement/AgreementSearch/AgreementInput/SearchAgreementInput.tsx
+++ b/packages/code-du-travail-frontend/src/outils/common/Agreement/AgreementSearch/AgreementInput/SearchAgreementInput.tsx
@@ -99,6 +99,7 @@ export const SearchAgreementInput = ({
         data-testid="agreement-search-input"
         id="agreement-search"
         placeholder={"Ex : Transports routiers ou 1486"}
+        type="search"
       />
 
       {isOpen && suggestions.length > 0 && (

--- a/packages/code-du-travail-frontend/src/search/SearchBar/index.tsx
+++ b/packages/code-du-travail-frontend/src/search/SearchBar/index.tsx
@@ -31,6 +31,7 @@ const SearchBar = ({
     isOpen,
     getMenuProps,
     getInputProps,
+    getLabelProps,
     highlightedIndex,
     getItemProps,
   } = useCombobox({
@@ -102,7 +103,9 @@ const SearchBar = ({
   return (
     <SearchForm role="search" action="/recherche" onSubmit={onFormSubmit}>
       <ScreenReaderOnly>
-        <label htmlFor={inputId}>Rechercher</label>
+        <label {...getLabelProps()} htmlFor={inputId}>
+          Rechercher
+        </label>
       </ScreenReaderOnly>
       {hasButton && !hasSearchIcon && <SearchIconLeft aria-hidden="true" />}
 
@@ -117,9 +120,9 @@ const SearchBar = ({
         type="search"
       />
 
-      {isOpen && suggestions.length > 0 && (
-        <StyledList {...getMenuProps()} hasButton={hasButton}>
-          {suggestions.map((item, index) => (
+      <StyledList {...getMenuProps()} hasButton={hasButton}>
+        {isOpen &&
+          suggestions.map((item, index) => (
             <StyledSuggestion
               {...getItemProps({
                 item,
@@ -131,8 +134,7 @@ const SearchBar = ({
               <Html>{renderBoldFromQuery(item, query)}</Html>
             </StyledSuggestion>
           ))}
-        </StyledList>
-      )}
+      </StyledList>
 
       {hasButton ? (
         <SubmitButton

--- a/packages/code-du-travail-frontend/src/search/SearchBar/index.tsx
+++ b/packages/code-du-travail-frontend/src/search/SearchBar/index.tsx
@@ -114,6 +114,7 @@ const SearchBar = ({
         }
         hasButton={hasButton}
         hasSearchIcon={hasSearchIcon}
+        type="search"
       />
 
       {isOpen && suggestions.length > 0 && (


### PR DESCRIPTION
Correction de ces 3 erreurs : <img width="1162" alt="Screenshot 2024-06-24 at 16 09 40" src="https://github.com/SocialGouv/code-du-travail-numerique/assets/25312957/13ab92cb-861a-4bc1-a07b-7fe9f2ecb3ee">
