### PR TITLE
fix(preavis-licenciement): catégorie professionnel rajouté en plus sur 2420

### DIFF
--- a/packages/code-du-travail-modeles/src/simulators/preavis-licenciement/preavis-licenciement.data.json
+++ b/packages/code-du-travail-modeles/src/simulators/preavis-licenciement/preavis-licenciement.data.json
@@ -5504,8 +5504,7 @@
     },
     {
       "criteria": {
-        "ancienneté": "38| Moins de 2 ans",
-        "catégorie professionnelle": "101| Assistants maternels du particulier employeur"
+        "ancienneté": "38| Moins de 2 ans"
       },
       "type": "préavis de Licenciement",
       "idcc": 2420,


### PR DESCRIPTION
fix #5992

A l'époque dans cette PR : https://github.com/SocialGouv/code-du-travail-numerique/pull/4122/files#diff-0815d38d331fd5efa6a21a57b747ca4cee47576697c69f272d118466d2305a8dL7043

J'avais rajouté par mégarde une catégorie pro à une CC qui n'en avait pas

<img width="1304" alt="Screenshot 2024-06-25 at 16 02 09" src="https://github.com/SocialGouv/code-du-travail-numerique/assets/25312957/1a7622e7-b5a1-4330-98dd-8c28efd377c7">
