### PR TITLE
fix(rupture-co): retrait de l'autofocus sur l'étape ancienneté

### DIFF
--- a/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/Ancienneté/index.tsx
+++ b/packages/code-du-travail-frontend/src/outils/IndemniteLicenciement/steps/Ancienneté/index.tsx
@@ -84,7 +84,6 @@ const StepAnciennete = () => {
         id="dateEntree"
         showRequired
         dataTestId={"date-entree"}
-        autoFocus
       />
       <TextQuestion
         label="Quelle est la date de notification du licenciement&nbsp;?"

--- a/packages/code-du-travail-frontend/src/outils/RuptureCoventionnelle/steps/Anciennete/index.tsx
+++ b/packages/code-du-travail-frontend/src/outils/RuptureCoventionnelle/steps/Anciennete/index.tsx
@@ -80,7 +80,6 @@ const StepAnciennete = () => {
         id="dateEntree"
         showRequired
         dataTestId={"date-entree"}
-        autoFocus
       />
       <TextQuestion
         label="Quelle est la date de fin du contrat de travail&nbsp;?"


### PR DESCRIPTION
closes #6041 

D'après la doc W3C, ce n'est pas une bonne pratique d'accessibilité de mettre un autofocus : 

![CleanShot 2024-07-22 at 16 04 18@2x](https://github.com/user-attachments/assets/42423464-e824-4d43-8060-5884d0cb4324)

cf: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus#accessibility_concerns

Du coup, je retire l'autofocus.
