### PR TITLE
fix(rupture-co): changement du nom de l'event a l'étape `result`

### DIFF
--- a/packages/code-du-travail-frontend/src/lib/matomo/types.ts
+++ b/packages/code-du-travail-frontend/src/lib/matomo/types.ts
@@ -1,3 +1,5 @@
+import { IndemniteDepartType } from "../../outils/types";
+
 export enum MatomoBaseEvent {
   TRACK_EVENT = "trackEvent",
   OUTIL = "outil",
@@ -87,8 +89,8 @@ export enum MatomoActionEvent {
   HEURE_RECHERCHE_EMPLOI = "view_step_Heures d'absence pour rechercher un emploi",
   PREAVIS_DEMISSION = "view_step_Préavis de démission",
   PREAVIS_LICENCIEMENT = "view_step_Préavis de licenciement",
-  INDEMNITE_LICENCIEMENT = "view_step_Indemnité de licenciement",
-  RUPTURE_CONVENTIONNELLE = "view_step_Rupture conventionnelle",
+  INDEMNITE_LICENCIEMENT = `view_step_${IndemniteDepartType.LICENCIEMENT}`,
+  RUPTURE_CONVENTIONNELLE = `view_step_${IndemniteDepartType.RUPTURE_CONVENTIONNELLE}`,
   VIEW_STEP = "view_step",
   CLICK_PREVIOUS = "click_previous",
 }


### PR DESCRIPTION
fix #6102