### PR TITLE
fix(link): ne pas afficher l'icon lien externe sur `code.travail.gouv.fr`

### DIFF
--- a/packages/react-ui/src/GlobalStyles/components/Links.js
+++ b/packages/react-ui/src/GlobalStyles/components/Links.js
@@ -27,8 +27,8 @@ export default createGlobalStyle`
     text-decoration-color: ${({ theme }) => theme.secondary};
   }
   a[target="_blank"]:not(.no-after):after,
-  a[href^="http://"]:not(.no-after):not([href*="social.gouv.fr"]):after,
-  a[href^="https://"]:not(.no-after):not([href*="social.gouv.fr"]):after{
+  a[href^="http://"]:not(.no-after):not([href*="code.travail.gouv.fr"]):after,
+  a[href^="https://"]:not(.no-after):not([href*="code.travail.gouv.fr"]):after{
     position: relative;
     top: 2px;
     width: 16px;


### PR DESCRIPTION
fix #6130