### PR TITLE
fix(error logs): retrait du log dans sentry des erreurs d'accès au localStorage

### DIFF
--- a/packages/code-du-travail-frontend/src/lib/useLocalStorage.ts
+++ b/packages/code-du-travail-frontend/src/lib/useLocalStorage.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import { Agreement, STORAGE_KEY_AGREEMENT } from "../outils/types";
-import { captureException } from "@sentry/nextjs";
 
 export function useLocalStorageForAgreementOnPageLoad(): [
   Agreement | any,
@@ -54,7 +53,6 @@ export const saveAgreementToLocalStorage = (agreement?: Agreement | null) => {
     }
   } catch (e) {
     console.error(e);
-    captureException(e);
   }
 };
 
@@ -66,7 +64,6 @@ export const getAgreementFromLocalStorage = (): Agreement | undefined => {
     }
   } catch (e) {
     console.error(e);
-    captureException(e);
   }
 };
 
@@ -77,6 +74,5 @@ export const removeAgreementFromLocalStorage = () => {
     }
   } catch (e) {
     console.error(e);
-    captureException(e);
   }
 };


### PR DESCRIPTION
Le but étant de ne plus être floodé.
Le log a été ajouté il y a [2 semaines](https://github.com/SocialGouv/code-du-travail-numerique/commit/837559becfdb02bd975c405f5caed0d787610ce5#diff-e5b576400a42f850bf83993be8d921a386f663458f3120b01e0a40db2bb1a28bR3), pour moi il n'est pas nécessaire