### PR TITLE
fix(idcc): ne pas afficher le lien vers la CC si pas de slug

### DIFF
--- a/packages/code-du-travail-frontend/src/conventions/Search/ConventionLink.tsx
+++ b/packages/code-du-travail-frontend/src/conventions/Search/ConventionLink.tsx
@@ -106,7 +106,7 @@ export const ConventionLink = ({
 
   return (
     <>
-      {num === 9999 ? (
+      {!convention.slug ? (
         <DisabledConvention convention={convention} commonProps={commonProps} />
       ) : (
         <EnabledConvention

--- a/packages/code-du-travail-frontend/src/conventions/Search/ConventionLink.tsx
+++ b/packages/code-du-travail-frontend/src/conventions/Search/ConventionLink.tsx
@@ -90,7 +90,6 @@ export const ConventionLink = ({
   onClick,
   small = false,
 }: Props): JSX.Element => {
-  const { num } = convention;
   const router = useRouter();
 
   const clickHandler = () => {

--- a/packages/code-du-travail-frontend/src/conventions/Search/index.tsx
+++ b/packages/code-du-travail-frontend/src/conventions/Search/index.tsx
@@ -80,15 +80,12 @@ const Search = ({ onSelectConvention }: Props): JSX.Element => {
                   title="CONVENTIONS COLLECTIVES"
                   query={query}
                   items={conventions.map((convention, index) => (
-                    <>
-                    AAAAAA  {convention}
                     <ConventionLink
                       convention={convention}
                       isFirst={index === 0}
                       key={convention.slug}
                       onClick={onSelectConvention}
                     />
-                    </>
                   ))}
                 />
               )}

--- a/packages/code-du-travail-frontend/src/conventions/Search/index.tsx
+++ b/packages/code-du-travail-frontend/src/conventions/Search/index.tsx
@@ -80,12 +80,15 @@ const Search = ({ onSelectConvention }: Props): JSX.Element => {
                   title="CONVENTIONS COLLECTIVES"
                   query={query}
                   items={conventions.map((convention, index) => (
+                    <>
+                    AAAAAA  {convention}
                     <ConventionLink
                       convention={convention}
                       isFirst={index === 0}
                       key={convention.slug}
                       onClick={onSelectConvention}
                     />
+                    </>
                   ))}
                 />
               )}


### PR DESCRIPTION
Fix [#6163](https://github.com/SocialGouv/code-du-travail-numerique/issues/6163)