### PR TITLE
fix: correction du role sur la combobox

### DIFF
--- a/packages/code-du-travail-frontend/src/modules/common/Autocomplete/Autocomplete.tsx
+++ b/packages/code-du-travail-frontend/src/modules/common/Autocomplete/Autocomplete.tsx
@@ -91,10 +91,7 @@ export const Autocomplete = <K,>({
         getRootProps,
         clearSelection,
       }) => (
-        <div
-          className={`${searchContainer}`}
-          {...getRootProps({}, { suppressRefError: true })}
-        >
+        <div className={`${searchContainer}`}>
           <Input
             nativeLabelProps={getLabelProps()}
             hideLabel={isSearch}
@@ -137,6 +134,8 @@ export const Autocomplete = <K,>({
               "data-testid": dataTestId,
               placeholder,
               ref: setInputRef,
+              role: getRootProps().role,
+              "aria-expanded": getRootProps()["aria-expanded"],
               ...getInputProps(),
             }}
             className={`${fr.cx("fr-mb-0")}`}

--- a/packages/code-du-travail-frontend/src/modules/home/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/code-du-travail-frontend/src/modules/home/__tests__/__snapshots__/index.test.tsx.snap
@@ -44,11 +44,7 @@ exports[`<Home /> should match snapshot 1`] = `
                   class="fr-col-12 fr-col-md-8"
                 >
                   <div
-                    aria-expanded="false"
-                    aria-haspopup="listbox"
-                    aria-labelledby="downshift-0-label"
                     class="d_flex flex-d_row ai_center w_100% pos_relative"
-                    role="combobox"
                   >
                     <div
                       class="fr-input-group w_100% fr-mb-0"
@@ -70,11 +66,13 @@ exports[`<Home /> should match snapshot 1`] = `
                       >
                         <input
                           aria-autocomplete="list"
+                          aria-expanded="false"
                           aria-labelledby="downshift-0-label"
                           autocomplete="off"
                           class="fr-input"
                           data-testid="search-input"
                           id="downshift-0-input"
+                          role="combobox"
                           type="search"
                           value=""
                         />

--- a/packages/code-du-travail-frontend/src/modules/layout/header/HeaderSearch.tsx
+++ b/packages/code-du-travail-frontend/src/modules/layout/header/HeaderSearch.tsx
@@ -48,7 +48,6 @@ export const HeaderSearch = ({ onSearchSubmit }: HeaderSearchProps) => {
                   );
                   return results;
                 } catch (error) {
-                  console.log("Failed");
                   return [];
                 }
               }}

--- a/packages/code-du-travail-frontend/src/modules/layout/header/__tests__/__snapshots__/HeaderDsfr.test.tsx.snap
+++ b/packages/code-du-travail-frontend/src/modules/layout/header/__tests__/__snapshots__/HeaderDsfr.test.tsx.snap
@@ -105,11 +105,7 @@ exports[`<Header /> should match snapshot 1`] = `
                   role="search"
                 >
                   <div
-                    aria-expanded="false"
-                    aria-haspopup="listbox"
-                    aria-labelledby="downshift-0-label"
                     class="d_flex flex-d_row ai_center w_100% pos_relative"
-                    role="combobox"
                   >
                     <div
                       class="fr-input-group w_100% fr-mb-0"
@@ -126,11 +122,13 @@ exports[`<Header /> should match snapshot 1`] = `
                       >
                         <input
                           aria-autocomplete="list"
+                          aria-expanded="false"
                           aria-labelledby="downshift-0-label"
                           autocomplete="off"
                           class="fr-input"
                           id="downshift-0-input"
                           placeholder="Rechercher sur le site"
+                          role="combobox"
                           type="search"
                           value=""
                         />


### PR DESCRIPTION
Correction suite à la review de Marie : 

> le role="combobox" doit être sur la balise <input>
> l'attribut aria-expanded="[true/false]" doit être sur la balise <input>
> l'attribut aria-haspopup="listbox" et aria-labelledby doivent être retirer de la balise <div> englobant l'élément

C'est étrange car sur la doc de downshift et l'exemple : https://www.downshift-js.com/downshift#usage-with-getrootprops, on a bien le role sur la div et c'est ce qu'il recommande.

Par contre sur la doc w3c, en regardant l'exemple : https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/ on voit qu'ils indiquent comme ce que dit Marie.

Du coup, j'ai modifié pour être iso à ce que dit Marie :)