### PR TITLE
fix(e2e): legifrance a ajouté une protection qui empêche l'accès à leur page depuis un robot

### DIFF
--- a/packages/code-du-travail-frontend/cypress/integration/light/conventions-collectives.spec.ts
+++ b/packages/code-du-travail-frontend/cypress/integration/light/conventions-collectives.spec.ts
@@ -159,28 +159,6 @@ describe("Conventions collectives", () => {
         "eq",
         "https://www.legifrance.gouv.fr/search/kali?rawQuery=cong%C3%A9s&idcc=2941&tab_selection=kali&searchField=ALL&query=cong%25C3%25A9s&searchType=ALL&typePagination=DEFAUT&sortValue=PERTINENCE&pageSize=10&page=1"
       );
-
-      cy.contains("Convention collective nationale", { timeout: 10000 }).should(
-        "be.visible"
-      );
-
-      cy.get(".result-item").then(($items) => {
-        const avenants = $items.filter((_, item) => {
-          return Cypress.$(item).text().includes("Avenant");
-        });
-
-        expect(avenants.length).to.be.at.least(
-          2,
-          "La page devrait contenir au moins 2 avenants"
-        );
-
-        cy.log(`Nombre d'avenants trouvés: ${avenants.length}`);
-
-        avenants.each((index, avenant) => {
-          const title = Cypress.$(avenant).find(".title").text().trim();
-          cy.log(`Avenant ${index + 1}: ${title}`);
-        });
-      });
     });
   });
 });


### PR DESCRIPTION
![Google Chrome 2025-07-09 13 27 15](https://github.com/user-attachments/assets/383d964d-f6d8-42d4-b940-45e42cc4f69f)
