### PR TITLE
fix(accessibilité): mauvais `hn` sur le titre des infographies

### DIFF
--- a/packages/code-du-travail-frontend/src/modules/informations/__tests__/information.test.tsx
+++ b/packages/code-du-travail-frontend/src/modules/informations/__tests__/information.test.tsx
@@ -101,10 +101,11 @@ describe("<Information />", () => {
     );
     expect(getByText("Quelle est votre situation ?")).toBeInTheDocument();
     const heading2 = getAllByRole("heading", { level: 2 });
-    expect(heading2).toHaveLength(7);
+    const heading3 = getByRole("heading", { level: 3, name: /Télécharger/ });
+    expect(heading2).toHaveLength(6);
     expect(heading2[0]).toHaveTextContent("Quelle est votre situation ?");
     expect(heading2[1]).toHaveTextContent("La procédure");
-    expect(heading2[2]).toHaveTextContent("Télécharger l'infographie");
+    expect(heading3).toHaveTextContent("Télécharger l'infographie");
     const lists = getAllByRole("list");
     expect(lists).toHaveLength(5);
     // On vérifie la bonne génération des modèles et outils liés

--- a/packages/code-du-travail-frontend/src/modules/informations/content/components/Infographic.tsx
+++ b/packages/code-du-travail-frontend/src/modules/informations/content/components/Infographic.tsx
@@ -48,7 +48,11 @@ export const Infographic = ({
           },
         ]}
       />
-      <DownloadTile filename={pdfUrl} filesize={pdfSize} />
+      <DownloadTile
+        filename={pdfUrl}
+        filesize={pdfSize}
+        titleAs={`h${titleLevel}`}
+      />
     </div>
   );
 };

--- a/packages/code-du-travail-frontend/src/modules/layout/ContainerInformation.tsx
+++ b/packages/code-du-travail-frontend/src/modules/layout/ContainerInformation.tsx
@@ -73,7 +73,7 @@ export const ContainerInformation = ({
                 <DownloadTile
                   filename={infography.fileUrl}
                   filesize={infography.size}
-                  titleAs={"h2"}
+                  titleAs={"h3"}
                 />
               </div>
             </div>

--- a/packages/code-du-travail-frontend/src/modules/layout/ContainerInformation.tsx
+++ b/packages/code-du-travail-frontend/src/modules/layout/ContainerInformation.tsx
@@ -73,7 +73,7 @@ export const ContainerInformation = ({
                 <DownloadTile
                   filename={infography.fileUrl}
                   filesize={infography.size}
-                  titleAs={"h3"}
+                  titleAs={"h2"}
                 />
               </div>
             </div>


### PR DESCRIPTION
fix #6829

Pour la page : https://code.travail.gouv.fr/information/licenciement-pour-motif-disciplinaire ; j'ai passé les deux `Tile` en h3, à la base les deux en h2. Pour moi ça, mais est-ce que vous ça vous convient ?