### PR TITLE
fix(références): ne pas afficher le `Convention collective :` pour les références `external`

### DIFF
--- a/packages/code-du-travail-frontend/src/modules/common/ReferencesList.tsx
+++ b/packages/code-du-travail-frontend/src/modules/common/ReferencesList.tsx
@@ -33,7 +33,9 @@ export const ReferenceList = ({
               href={ref.url}
               target="_blank"
               rel="noopener noreferrer"
-            >{`Convention collective: ${ref.title}`}</Link>
+            >
+              {ref.title}
+            </Link>
           );
       }
     })

--- a/packages/code-du-travail-frontend/src/modules/common/__tests__/ReferenceList.test.tsx
+++ b/packages/code-du-travail-frontend/src/modules/common/__tests__/ReferenceList.test.tsx
@@ -44,31 +44,24 @@ describe("<ReferenceList />", () => {
       "/code-du-travail/l2323-4"
     );
 
-    expect(
-      getByText("Convention collective: Article yyy du JO").tagName
-    ).toEqual("A");
-    expect(
-      getByText("Convention collective: Article yyy du JO")
-    ).toHaveAttribute("href", "https://article.jo/yyy");
-    expect(
-      getByText("Convention collective: Article yyy du JO")
-    ).toHaveAttribute("target", "_blank");
-    expect(
-      getByText("Convention collective: Article yyy du JO")
-    ).toHaveAttribute("rel", "noopener noreferrer");
-
-    expect(getByText("Convention collective: CCN metallurgie").tagName).toEqual(
-      "A"
+    expect(getByText("Article yyy du JO").tagName).toEqual("A");
+    expect(getByText("Article yyy du JO")).toHaveAttribute(
+      "href",
+      "https://article.jo/yyy"
     );
-    expect(getByText("Convention collective: CCN metallurgie")).toHaveAttribute(
+    expect(getByText("Article yyy du JO")).toHaveAttribute("target", "_blank");
+    expect(getByText("Article yyy du JO")).toHaveAttribute(
+      "rel",
+      "noopener noreferrer"
+    );
+
+    expect(getByText("CCN metallurgie").tagName).toEqual("A");
+    expect(getByText("CCN metallurgie")).toHaveAttribute(
       "href",
       "https://legifrance/ccn-metallurgie"
     );
-    expect(getByText("Convention collective: CCN metallurgie")).toHaveAttribute(
-      "target",
-      "_blank"
-    );
-    expect(getByText("Convention collective: CCN metallurgie")).toHaveAttribute(
+    expect(getByText("CCN metallurgie")).toHaveAttribute("target", "_blank");
+    expect(getByText("CCN metallurgie")).toHaveAttribute(
       "rel",
       "noopener noreferrer"
     );

--- a/packages/code-du-travail-frontend/src/modules/common/__tests__/__snapshots__/ReferenceList.test.tsx.snap
+++ b/packages/code-du-travail-frontend/src/modules/common/__tests__/__snapshots__/ReferenceList.test.tsx.snap
@@ -22,9 +22,9 @@ exports[`<ReferenceList /> should render 1`] = `
           href="https://article.jo/yyy"
           rel="noopener noreferrer"
           target="_blank"
-          title="Convention collective: Article yyy du JO - nouvelle fenêtre"
+          title="Article yyy du JO - nouvelle fenêtre"
         >
-          Convention collective: Article yyy du JO
+          Article yyy du JO
         </a>
       </p>
     </li>
@@ -36,9 +36,9 @@ exports[`<ReferenceList /> should render 1`] = `
           href="https://legifrance/ccn-metallurgie"
           rel="noopener noreferrer"
           target="_blank"
-          title="Convention collective: CCN metallurgie - nouvelle fenêtre"
+          title="CCN metallurgie - nouvelle fenêtre"
         >
-          Convention collective: CCN metallurgie
+          CCN metallurgie
         </a>
       </p>
     </li>


### PR DESCRIPTION
fix #6903 