### PR TITLE
fix(modeles): correction du bug HTML invalide dans les modèles de courrier

### DIFF
--- a/packages/code-du-travail-frontend/src/modules/modeles-de-courriers/components/LetterModelContent.tsx
+++ b/packages/code-du-travail-frontend/src/modules/modeles-de-courriers/components/LetterModelContent.tsx
@@ -30,9 +30,9 @@ export const LetterModelContent = ({
     <>
       <p className={fr.cx("fr-mb-6w")}>Mis à jour le&nbsp;: {date}</p>
       {intro && (
-        <p className={`${fr.cx("fr-highlight", "fr-mb-6w")}`}>
+        <div className={`${fr.cx("fr-highlight", "fr-mb-6w")}`}>
           <DisplayContent content={intro} titleLevel={2} />
-        </p>
+        </div>
       )}
       <div className={fr.cx("fr-hidden-md")}>
         <div className={fr.cx("fr-mb-6w")}>

--- a/packages/code-du-travail-frontend/tsconfig.json
+++ b/packages/code-du-travail-frontend/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -22,7 +26,9 @@
     ],
     "baseUrl": ".",
     "paths": {
-      "@styled-system/*": ["./src/styled-system/*"]
+      "@styled-system/*": [
+        "./src/styled-system/*"
+      ]
     },
     "target": "es2024"
   },
@@ -32,7 +38,11 @@
     "**/*.tsx",
     ".next/types/**/*.ts",
     "./global.d.ts",
-    ".next/dev/types/**/*.ts"
+    ".next/dev/types/**/*.ts",
+    ".next/dev/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules/**/*", "cypress"]
+  "exclude": [
+    "node_modules/**/*",
+    "cypress"
+  ]
 }


### PR DESCRIPTION
### Problème
Sur les pages de modèles de courrier (exemple : lettre de licenciement économique),
le validateur HTML détecte une erreur : un élément `<ul>` est imbriqué dans un `<p>`,
ce qui est invalide en HTML5.

### Cause
Dans `LetterModelContent.tsx`, la section `intro` avec la classe `fr-highlight`
était wrappée dans un `<p>`. Le composant `DisplayContent` peut générer des listes
`<ul>`, créant ainsi du HTML invalide.

### Solution
Remplacement de la balise `<p>` par `<div>` pour la section highlight.
Cela permet à `DisplayContent` de générer n'importe quel contenu bloc valide.

Fixes #7030