### PR TITLE
fix(sdr): correction des URLs qui sont en 404 et des redirections

### DIFF
--- a/packages/code-du-travail-frontend/src/e2e/besoin-plus-informations.e2e.ts
+++ b/packages/code-du-travail-frontend/src/e2e/besoin-plus-informations.e2e.ts
@@ -22,7 +22,7 @@ test.describe("Page Besoin de plus d'information", () => {
       .click();
 
     const link = page.locator(
-      'a[href="https://idf.drieets.gouv.fr/Adresse-et-horaires-d-ouverture-de-l-unite-departementale-75"]'
+      'a[href="https://idf.drieets.gouv.fr/Contacts-de-l-unite-departementale-75"]'
     );
 
     await expect(link).toHaveAttribute("target", "_blank");

--- a/packages/code-du-travail-frontend/src/modules/besoin-plus-informations/data/services-de-renseignement.json
+++ b/packages/code-du-travail-frontend/src/modules/besoin-plus-informations/data/services-de-renseignement.json
@@ -113,11 +113,11 @@
   },
   "2a": {
     "name": "CORSE-DU-SUD",
-    "url": "https://lannuaire.service-public.gouv.fr/corse/corse-du-sud/60320122-f3e5-4bb9-8ae4-a3ba1d83e371"
+    "url": "https://corse.dreets.gouv.fr/Contacter-la-DREETS"
   },
   "2b": {
     "name": "HAUTE-CORSE",
-    "url": "https://lannuaire.service-public.gouv.fr/corse/haute-corse/94cd2319-1ef7-4490-8bbd-3a0132fb23d9"
+    "url": "https://corse.dreets.gouv.fr/Contacter-la-DREETS"
   },
   "30": {
     "name": "GARD",

--- a/packages/code-du-travail-frontend/src/modules/besoin-plus-informations/data/services-de-renseignement.json
+++ b/packages/code-du-travail-frontend/src/modules/besoin-plus-informations/data/services-de-renseignement.json
@@ -17,7 +17,7 @@
   },
   "5": {
     "name": "HAUTES-ALPES",
-    "url": "https://paca.dreets.gouv.fr/Le-Service-Renseignement-en-droit-du-Travail"
+    "url": "https://paca.dreets.gouv.fr/Renseignement-en-droit-du-Travail-17923"
   },
   "6": {
     "name": "ALPES-MARITIMES",
@@ -29,11 +29,11 @@
   },
   "8": {
     "name": "ARDENNES",
-    "url": "https://grand-est.dreets.gouv.fr/La-DDETSPP-des-Ardennes"
+    "url": "https://lannuaire.service-public.gouv.fr/grand-est/ardennes/0397f22e-d223-4b83-8639-06c0412e0e8f"
   },
   "9": {
     "name": "ARIEGE",
-    "url": "https://occitanie.dreets.gouv.fr/Renseignements-en-droit-du-travail-a-la-DREETS-Occitanie"
+    "url": "https://occitanie.dreets.gouv.fr/travail-info"
   },
   "10": {
     "name": "aube",
@@ -41,11 +41,11 @@
   },
   "11": {
     "name": "AUDE",
-    "url": "https://occitanie.dreets.gouv.fr/Renseignements-en-droit-du-travail-a-la-DREETS-Occitanie"
+    "url": "https://occitanie.dreets.gouv.fr/travail-info"
   },
   "12": {
     "name": "AVEYRON",
-    "url": "https://occitanie.dreets.gouv.fr/Renseignements-en-droit-du-travail-a-la-DREETS-Occitanie"
+    "url": "https://occitanie.dreets.gouv.fr/travail-info"
   },
   "13": {
     "name": "BOUCHES-DU-RHONE",
@@ -81,7 +81,7 @@
   },
   "22": {
     "name": "COTE D'ARMOR",
-    "url": "https://bretagne.dreets.gouv.fr/Le-Service-Renseignement-du-Public-2949"
+    "url": "https://bretagne.dreets.gouv.fr/Service-Renseignements-en-droit-du-travail"
   },
   "23": {
     "name": "CREUSE",
@@ -113,23 +113,23 @@
   },
   "2a": {
     "name": "CORSE-DU-SUD",
-    "url": "https://corse.dreets.gouv.fr/Renseignements-en-droit-du-travail"
+    "url": "https://corse.dreets.gouv.fr/Renseignements-en-droit-du-travail-18561"
   },
   "2b": {
     "name": "HAUTE-CORSE",
-    "url": "https://corse.dreets.gouv.fr/Renseignements-en-droit-du-travail-17835"
+    "url": "https://corse.dreets.gouv.fr/Renseignements-en-droit-du-travail-18561"
   },
   "30": {
     "name": "GARD",
-    "url": "https://occitanie.dreets.gouv.fr/Renseignements-en-droit-du-travail-a-la-DREETS-Occitanie"
+    "url": "https://occitanie.dreets.gouv.fr/travail-info"
   },
   "31": {
     "name": "HAUTE-GARONNE",
-    "url": "https://occitanie.dreets.gouv.fr/Renseignements-en-droit-du-travail-a-la-DREETS-Occitanie"
+    "url": "https://occitanie.dreets.gouv.fr/travail-info"
   },
   "32": {
     "name": "GERS",
-    "url": "https://occitanie.dreets.gouv.fr/Renseignements-en-droit-du-travail-a-la-DREETS-Occitanie"
+    "url": "https://occitanie.dreets.gouv.fr/travail-info"
   },
   "33": {
     "name": "GIRONDE",
@@ -137,7 +137,7 @@
   },
   "34": {
     "name": "HERAULT",
-    "url": "https://occitanie.dreets.gouv.fr/Renseignements-en-droit-du-travail-a-la-DREETS-Occitanie"
+    "url": "https://occitanie.dreets.gouv.fr/travail-info"
   },
   "35": {
     "name": "ILLE-ET-VILAINE",
@@ -177,7 +177,7 @@
   },
   "44": {
     "name": "LOIRE-ATLANTIQUE",
-    "url": "https://pays-de-la-loire.dreets.gouv.fr/Acces-au-droit-du-travail-les-DDETS-et-DDETS-PP-vous-renseignent"
+    "url": "https://pays-de-la-loire.dreets.gouv.fr/Besoin-de-renseignements-en-droit-du-travail"
   },
   "45": {
     "name": "LOiRET",
@@ -185,7 +185,7 @@
   },
   "46": {
     "name": "LOT",
-    "url": "https://occitanie.dreets.gouv.fr/Renseignements-en-droit-du-travail-a-la-DREETS-Occitanie"
+    "url": "https://occitanie.dreets.gouv.fr/travail-info"
   },
   "47": {
     "name": "LOT-ET-GARONNE",
@@ -193,11 +193,11 @@
   },
   "48": {
     "name": "LOZERE",
-    "url": "https://occitanie.dreets.gouv.fr/Renseignements-en-droit-du-travail-a-la-DREETS-Occitanie"
+    "url": "https://occitanie.dreets.gouv.fr/travail-info"
   },
   "49": {
     "name": "MAINE-ET-LOIRE",
-    "url": "https://pays-de-la-loire.dreets.gouv.fr/Acces-au-droit-du-travail-les-DDETS-et-DDETS-PP-vous-renseignent"
+    "url": "https://pays-de-la-loire.dreets.gouv.fr/Besoin-de-renseignements-en-droit-du-travail"
   },
   "50": {
     "name": "MANCHE",
@@ -205,23 +205,23 @@
   },
   "51": {
     "name": "MARNE",
-    "url": "https://grand-est.dreets.gouv.fr/La-DDETSPP-de-la-Marne"
+    "url": "https://www.marne.gouv.fr/Services-de-l-Etat/Direction-departementale-de-l-emploi-du-travail-des-solidarites-et-de-la-protection-des-populations"
   },
   "52": {
     "name": "HAUTE-MARNE",
-    "url": "https://grand-est.dreets.gouv.fr/Direction-departementale-de-l-emploi-du-travail-des-solidarites-et-de-la"
+    "url": "https://www.haute-marne.gouv.fr/Services-de-l-Etat/Emploi-travail-solidarites-et-protection-des-populations/Direction-departementale-de-l-emploi-du-travail-des-solidarite-et-de-la-protection-des-populations"
   },
   "53": {
     "name": "MAYENNE",
-    "url": "https://pays-de-la-loire.dreets.gouv.fr/Acces-au-droit-du-travail-les-DDETS-et-DDETS-PP-vous-renseignent"
+    "url": "https://pays-de-la-loire.dreets.gouv.fr/Besoin-de-renseignements-en-droit-du-travail"
   },
   "54": {
     "name": "MEURTHE-ET-MOSELLE",
-    "url": "https://grand-est.dreets.gouv.fr/Presentation-de-la-DDETS-Nous-contacter"
+    "url": "https://www.meurthe-et-moselle.gouv.fr/Services-de-l-Etat/Travail-insertion-sociale-et-professionnelle"
   },
   "55": {
     "name": "MEUSE",
-    "url": "https://grand-est.dreets.gouv.fr/La-Direction-departementale-de-l-emploi-du-travail-des-solidarites-et-de-la"
+    "url": "https://www.meuse.gouv.fr/Services-de-l-Etat/Emploi-Travail-Solidarites-Sante-Protection-des-populations/La-DDETSPP"
   },
   "56": {
     "name": "MORBIHAN",
@@ -229,7 +229,7 @@
   },
   "57": {
     "name": "MOSELLE",
-    "url": "https://grand-est.dreets.gouv.fr/Presentation-de-la-DDETS-Moselle-Nous-contacter"
+    "url": "https://www.moselle.gouv.fr/Services-de-l-Etat/Les-Directions-departementales/La-Direction-departementale-de-l-emploi-du-travail-et-des-solidarites-DDETS"
   },
   "58": {
     "name": "NIEVRE",
@@ -261,11 +261,11 @@
   },
   "65": {
     "name": "HAUTES-PYRENEES",
-    "url": "https://occitanie.dreets.gouv.fr/Renseignements-en-droit-du-travail-a-la-DREETS-Occitanie"
+    "url": "https://occitanie.dreets.gouv.fr/travail-info"
   },
   "66": {
     "name": "PYRENEES-ORIENTALES",
-    "url": "https://occitanie.dreets.gouv.fr/Renseignements-en-droit-du-travail-a-la-DREETS-Occitanie"
+    "url": "https://occitanie.dreets.gouv.fr/travail-info"
   },
   "67": {
     "name": "BAS-RHIN",
@@ -273,7 +273,7 @@
   },
   "68": {
     "name": "HAUT-RHIN",
-    "url": "https://grand-est.dreets.gouv.fr/La-DDETS-du-Haut-Rhin"
+    "url": "https://www.haut-rhin.gouv.fr/Services-de-l-Etat/DDETSPP2/La-DDETSPP-du-Haut-Rhin/La-DDETSPP-du-Haut-Rhin"
   },
   "69": {
     "name": "RHONE",
@@ -289,7 +289,7 @@
   },
   "72": {
     "name": "SARTHE",
-    "url": "https://pays-de-la-loire.dreets.gouv.fr/Acces-au-droit-du-travail-les-DDETS-et-DDETS-PP-vous-renseignent"
+    "url": "https://pays-de-la-loire.dreets.gouv.fr/Besoin-de-renseignements-en-droit-du-travail"
   },
   "73": {
     "name": "SAVOIE",
@@ -301,7 +301,7 @@
   },
   "75": {
     "name": "PARIS",
-    "url": "https://idf.drieets.gouv.fr/Adresse-et-horaires-d-ouverture-de-l-unite-departementale-75"
+    "url": "https://idf.drieets.gouv.fr/Contacts-de-l-unite-departementale-75"
   },
   "76": {
     "name": "SEINE-MARITIME",
@@ -325,11 +325,11 @@
   },
   "81": {
     "name": "TARN",
-    "url": "https://occitanie.dreets.gouv.fr/Renseignements-en-droit-du-travail-a-la-DREETS-Occitanie"
+    "url": "https://occitanie.dreets.gouv.fr/travail-info"
   },
   "82": {
     "name": "TARN-ET-GARONNE",
-    "url": "https://occitanie.dreets.gouv.fr/Renseignements-en-droit-du-travail-a-la-DREETS-Occitanie"
+    "url": "https://occitanie.dreets.gouv.fr/travail-info"
   },
   "83": {
     "name": "VAR",
@@ -341,7 +341,7 @@
   },
   "85": {
     "name": "VENDEE",
-    "url": "https://pays-de-la-loire.dreets.gouv.fr/Acces-au-droit-du-travail-les-DDETS-et-DDETS-PP-vous-renseignent"
+    "url": "https://pays-de-la-loire.dreets.gouv.fr/Besoin-de-renseignements-en-droit-du-travail"
   },
   "86": {
     "name": "VIENNE",
@@ -353,7 +353,7 @@
   },
   "88": {
     "name": "VOSGES",
-    "url": "https://grand-est.dreets.gouv.fr/La-DDETSPP-des-Vosges"
+    "url": "https://www.vosges.gouv.fr/Services-de-l-Etat/Travail-emploi-solidarite-et-protection-des-populations/DDETSPP-des-Vosges"
   },
   "89": {
     "name": "YONNE",

--- a/packages/code-du-travail-frontend/src/modules/besoin-plus-informations/data/services-de-renseignement.json
+++ b/packages/code-du-travail-frontend/src/modules/besoin-plus-informations/data/services-de-renseignement.json
@@ -113,11 +113,11 @@
   },
   "2a": {
     "name": "CORSE-DU-SUD",
-    "url": "https://corse.dreets.gouv.fr/Renseignements-en-droit-du-travail-18561"
+    "url": "https://lannuaire.service-public.gouv.fr/corse/corse-du-sud/60320122-f3e5-4bb9-8ae4-a3ba1d83e371"
   },
   "2b": {
     "name": "HAUTE-CORSE",
-    "url": "https://corse.dreets.gouv.fr/Renseignements-en-droit-du-travail-18561"
+    "url": "https://lannuaire.service-public.gouv.fr/corse/haute-corse/94cd2319-1ef7-4490-8bbd-3a0132fb23d9"
   },
   "30": {
     "name": "GARD",


### PR DESCRIPTION
- Update DREETS Occitanie URLs to simplified /travail-info endpoint
- Replace Grand-Est regional URLs with direct departmental prefectural links
- Update Pays-de-la-Loire regional URLs to current government pages
- Fix Brittany, Corse, IDF and other regional service page redirects
- Ensure accurate access to current labor information services