### PR TITLE
fix(recherche): utilisation du `displayTitle` pour les simulateurs

### DIFF
--- a/packages/code-du-travail-frontend/src/api/modules/search/queries.ts
+++ b/packages/code-du-travail-frontend/src/api/modules/search/queries.ts
@@ -171,6 +171,7 @@ export function getSearchBody(query, size, sources) {
       "highlight",
       "sectionDisplayMode",
       "shortTitle",
+      "displayTitle",
     ],
     query: {
       bool: {

--- a/packages/code-du-travail-frontend/src/api/modules/search/service/search.ts
+++ b/packages/code-du-travail-frontend/src/api/modules/search/service/search.ts
@@ -102,6 +102,19 @@ export const searchWithQuery = async (
   const fulltextHits: SearchResult[] = extractHits(results[DOCUMENTS_ES]).map(
     esDocToSearchResult(SEARCH_ALGO.FULL_TEXT)
   );
+
+  // Enrich tool results from presearch/prequalified with displayTitle from fulltext
+  const fulltextToolTitles = new Map(
+    fulltextHits
+      .filter((h) => h.source === SOURCES.TOOLS)
+      .map((h) => [h.cdtnId, h.title])
+  );
+  for (const doc of documents) {
+    if (doc.source === SOURCES.TOOLS && fulltextToolTitles.has(doc.cdtnId)) {
+      doc.title = fulltextToolTitles.get(doc.cdtnId)!;
+    }
+  }
+
   documents.push(...fulltextHits);
 
   if (shouldRequestCdt) {

--- a/packages/code-du-travail-frontend/src/api/modules/search/utils.ts
+++ b/packages/code-du-travail-frontend/src/api/modules/search/utils.ts
@@ -29,6 +29,6 @@ export const esDocToSearchResult =
   ({ _score, _source }): SearchResult => ({
     _score: _score ?? null,
     ..._source,
-    title: _source.shortTitle ?? _source.title,
+    title: _source.displayTitle ?? _source.shortTitle ?? _source.title,
     algo,
   });


### PR DESCRIPTION
fix #7004 

- Add displayTitle to fetched fields in Elasticsearch query
- Update title resolution to prioritize displayTitle over shortTitle
- Enrich tool results with displayTitle from fulltext search results