### PR TITLE
feat(actualites): ajout de la page listant les actualités

### DIFF
--- a/packages/code-du-travail-frontend/app/actualite/[slug]/page.tsx
+++ b/packages/code-du-travail-frontend/app/actualite/[slug]/page.tsx
@@ -1,0 +1,57 @@
+import { notFound } from "next/navigation";
+import { DsfrLayout } from "src/modules/layout";
+
+import { generateDefaultMetadata } from "src/modules/common/metas";
+import { getRouteBySource, SOURCES } from "@socialgouv/cdtn-utils";
+import { fetchNews, format, News, NewsContainer } from "src/modules/actualite";
+import { Metadata } from "next";
+
+export async function generateMetadata(
+  props: PageProps<"/actualite/[slug]">
+): Promise<Metadata> {
+  const params = await props.params;
+  const news = await fetchNews(params.slug, ["title", "metaDescription"]);
+
+  if (!news) {
+    return notFound();
+  }
+
+  return generateDefaultMetadata({
+    title: news?.title,
+    description: news?.metaDescription,
+    path: `/${getRouteBySource(SOURCES.NEWS)}/${params.slug}`,
+  });
+}
+
+async function NewsPage(props: PageProps<"/actualite/[slug]">) {
+  const params = await props.params;
+  const news = await getNews(params.slug);
+
+  if (!news) {
+    return notFound();
+  }
+
+  return (
+    <DsfrLayout>
+      <NewsContainer news={news} />
+    </DsfrLayout>
+  );
+}
+
+const getNews = async (slug: string): Promise<News> => {
+  const news = await fetchNews(slug, [
+    "title",
+    "meta_title",
+    "meta_description",
+    "date",
+    "content",
+    "linkedContent",
+  ]);
+
+  if (!news) {
+    return notFound();
+  }
+  return format(news);
+};
+
+export default NewsPage;

--- a/packages/code-du-travail-frontend/app/actualite/page.tsx
+++ b/packages/code-du-travail-frontend/app/actualite/page.tsx
@@ -1,0 +1,32 @@
+import { DsfrLayout } from "src/modules/layout";
+import { generateDefaultMetadata } from "src/modules/common/metas";
+import { fetchNewsList, NewsList } from "src/modules/actualite";
+import { Metadata } from "next";
+
+export const metadata: Metadata = generateDefaultMetadata({
+  title: "Actualités",
+  description: "Découvrez toutes les actualités liés au code du travail.",
+  path: "/actualite",
+});
+
+async function Index({
+  searchParams,
+}: {
+  searchParams: Promise<{ page?: string }>;
+}) {
+  const { page } = await searchParams;
+  const pageNumber = Math.max(1, parseInt(page ?? "1", 10) || 1);
+
+  const { items, totalPages } = await fetchNewsList(
+    ["title", "content", "date", "slug"],
+    { page: pageNumber }
+  );
+
+  return (
+    <DsfrLayout>
+      <NewsList news={items} currentPage={pageNumber} totalPages={totalPages} />
+    </DsfrLayout>
+  );
+}
+
+export default Index;

--- a/packages/code-du-travail-frontend/app/page.tsx
+++ b/packages/code-du-travail-frontend/app/page.tsx
@@ -16,6 +16,7 @@ async function Index() {
   return (
     <DsfrLayout container="fr-container--fluid">
       <Home
+        news={data.news}
         agreements={data.agreements}
         contributions={data.contributions}
         highlights={data.highlights}

--- a/packages/code-du-travail-frontend/package.json
+++ b/packages/code-du-travail-frontend/package.json
@@ -42,7 +42,7 @@
     "@opentelemetry/instrumentation-net": "^0.55.0",
     "@sentry/nextjs": "~10.38.0",
     "@socialgouv/cdtn-elasticsearch": "^2.66.6",
-    "@socialgouv/cdtn-types": "^2.66.6",
+    "@socialgouv/cdtn-types": "^2.71.0",
     "@socialgouv/cdtn-utils": "link:../code-du-travail-utils",
     "@socialgouv/matomo-next": "^1.11.0",
     "@socialgouv/modeles-social": "link:../code-du-travail-modeles",

--- a/packages/code-du-travail-frontend/src/modules/actualite/NewsContainer.tsx
+++ b/packages/code-du-travail-frontend/src/modules/actualite/NewsContainer.tsx
@@ -1,0 +1,31 @@
+import { News } from "./type";
+import { fr } from "@codegouvfr/react-dsfr";
+import React from "react";
+import { ContainerRichWithBreadcrumbs } from "../layout/ContainerRichWithBreadcrumbs";
+import DisplayContent from "../common/DisplayContent";
+import { formatDateAsFrenchText } from "../utils";
+
+type Props = {
+  news: News;
+};
+
+export const NewsContainer = ({ news }: Props) => (
+  <ContainerRichWithBreadcrumbs
+    currentPage={news.title}
+    breadcrumbs={[
+      {
+        label: "Actualités",
+        position: 1,
+        slug: "/actualite",
+      },
+    ]}
+    relatedItems={news.relatedItems}
+    title={news.title}
+    description={news.meta_description}
+    showFeedback={false}
+  >
+    <h1 className={fr.cx("fr-mb-6w")}>{news.title}</h1>
+    <p className={fr.cx("fr-text--lg")}>{formatDateAsFrenchText(news.date)}</p>
+    <DisplayContent content={news.content} titleLevel={2} />
+  </ContainerRichWithBreadcrumbs>
+);

--- a/packages/code-du-travail-frontend/src/modules/actualite/NewsList.tsx
+++ b/packages/code-du-travail-frontend/src/modules/actualite/NewsList.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { fr } from "@codegouvfr/react-dsfr";
+import { NewsSummary } from "./type";
+import { NewsItem } from "./component/NewsItem";
+import Pagination from "@codegouvfr/react-dsfr/Pagination";
+import { css } from "@styled-system/css";
+import { ContainerWithBreadcrumbs } from "../layout/ContainerWithBreadcrumbs";
+
+type Props = {
+  news: NewsSummary[];
+  currentPage: number;
+  totalPages: number;
+};
+
+export function NewsList({ news, totalPages, currentPage }: Props) {
+  return (
+    <ContainerWithBreadcrumbs currentPage={"Actualités"} breadcrumbs={[]}>
+      <h1 id="actualites" className={fr.cx("fr-mt-0", "fr-mb-6w")}>
+        Actualités
+      </h1>
+      {news.length > 0 ? (
+        <>
+          {news.map((item) => {
+            return <NewsItem key={item.slug} {...item} />;
+          })}
+          <div className={`${fr.cx("fr-mb-12w")} ${layoutCenter}`}>
+            <Pagination
+              count={totalPages}
+              defaultPage={currentPage}
+              getPageLinkProps={(pageNumber) => ({
+                href: `/actualite?page=${pageNumber}`,
+              })}
+            />
+          </div>
+        </>
+      ) : (
+        <div>Aucune actualité publiée pour le moment.</div>
+      )}
+    </ContainerWithBreadcrumbs>
+  );
+}
+
+const layoutCenter = css({
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  flexWrap: "wrap",
+  width: "100%",
+});

--- a/packages/code-du-travail-frontend/src/modules/actualite/component/NewsItem.tsx
+++ b/packages/code-du-travail-frontend/src/modules/actualite/component/NewsItem.tsx
@@ -1,0 +1,46 @@
+import { NewsSummary } from "../type";
+import { fr } from "@codegouvfr/react-dsfr";
+import Button from "@codegouvfr/react-dsfr/Button";
+import DisplayContent from "../../common/DisplayContent";
+import { formatDateAsFrenchText } from "../../utils";
+
+type Props = NewsSummary;
+
+export const NewsItem = ({ date, title, content, slug }: Props) => {
+  return (
+    <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters", "fr-mb-3w")}>
+      <div
+        className={fr.cx(
+          "fr-col-md-2",
+          "fr-col-12",
+          "fr-mt-auto",
+          "fr-grid-row",
+          "fr-grid-row--right",
+          "fr-grid-row--bottom"
+        )}
+      >
+        <p className={fr.cx("fr-text--lg", "fr-mb-1v")}>
+          {formatDateAsFrenchText(date)}
+        </p>
+      </div>
+      <div className={fr.cx("fr-col-md-10", "fr-col-12")}>
+        <h2 className={fr.cx("fr-mb-0")}>{title}</h2>
+      </div>
+      <div className={fr.cx("fr-col-md-10", "fr-col-offset-md-2", "fr-col-12")}>
+        <DisplayContent content={content} titleLevel={2} />
+
+        <Button
+          title={`Lire l'actualité ${title}`}
+          priority="secondary"
+          iconId={"fr-icon-arrow-right-line"}
+          iconPosition="right"
+          linkProps={{
+            href: `/actualite/${slug}`,
+          }}
+        >
+          Lire l&apos;actualité
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/packages/code-du-travail-frontend/src/modules/actualite/index.ts
+++ b/packages/code-du-travail-frontend/src/modules/actualite/index.ts
@@ -1,0 +1,4 @@
+export * from "./queries";
+export * from "./type";
+export * from "./NewsList";
+export * from "./NewsContainer";

--- a/packages/code-du-travail-frontend/src/modules/actualite/queries.ts
+++ b/packages/code-du-travail-frontend/src/modules/actualite/queries.ts
@@ -1,0 +1,155 @@
+import { elasticDocumentsIndex, elasticsearchClient } from "../../api/utils";
+import { getRouteBySource, SOURCES } from "@socialgouv/cdtn-utils";
+import {
+  DocumentElasticResult,
+  fetchDocument,
+  RelatedItem,
+  Source,
+} from "../documents";
+import { NewsElasticDocument } from "@socialgouv/cdtn-types";
+import { LinkedContent } from "@socialgouv/cdtn-types/build/elastic/related-items";
+import { News } from "./type";
+
+export const fetchNewsList = async <K extends keyof NewsElasticDocument>(
+  fields: K[],
+  filters?: {
+    cdtnIds?: string[];
+    page?: number;
+    pageSize?: number;
+  }
+): Promise<{
+  items: Pick<NewsElasticDocument, K>[];
+  total: number;
+  totalPages: number;
+  page: number;
+  pageSize: number;
+}> => {
+  const page = filters?.page ?? 1;
+  const pageSize = filters?.pageSize ?? 4;
+  const from = (page - 1) * pageSize;
+
+  const baseFilters: Record<string, unknown>[] = [
+    { term: { source: SOURCES.NEWS } },
+    { term: { isPublished: true } },
+  ];
+
+  if (filters?.cdtnIds) {
+    baseFilters.push({ terms: { cdtnId: filters.cdtnIds } });
+  }
+
+  const response = await elasticsearchClient.search<
+    Pick<NewsElasticDocument, K>
+  >({
+    query: {
+      bool: {
+        filter: baseFilters,
+      },
+    },
+    from,
+    size: pageSize,
+    sort: [{ date: { order: "desc" } }],
+    _source: fields,
+    index: elasticDocumentsIndex,
+  });
+
+  const items = response.hits.hits
+    .map(({ _source }) => _source)
+    .filter((model) => model !== undefined);
+
+  const total =
+    typeof response.hits.total === "number"
+      ? response.hits.total
+      : (response.hits.total?.value ?? 0);
+  const totalPages = Math.ceil(total / pageSize);
+
+  return {
+    items,
+    total,
+    totalPages,
+    page,
+    pageSize,
+  };
+};
+
+export const fetchNews = async <K extends keyof NewsElasticDocument>(
+  slug: string,
+  fields: K[]
+): Promise<DocumentElasticResult<Pick<NewsElasticDocument, K>> | undefined> => {
+  return await fetchDocument<
+    NewsElasticDocument,
+    keyof DocumentElasticResult<NewsElasticDocument>
+  >(fields, {
+    query: {
+      bool: {
+        filter: [
+          { term: { source: SOURCES.NEWS } },
+          { term: { isPublished: true } },
+          { term: { slug } },
+        ],
+      },
+    },
+    size: 1,
+    _source: fields,
+    index: elasticDocumentsIndex,
+  });
+};
+
+export const format = ({
+  title,
+  meta_title,
+  date,
+  content,
+  meta_description,
+  linkedContent,
+}: Pick<
+  NewsElasticDocument,
+  | "title"
+  | "meta_title"
+  | "date"
+  | "content"
+  | "meta_description"
+  | "linkedContent"
+>): News => {
+  const buildItems = (arr: LinkedContent[]): RelatedItem[] =>
+    arr.map((item) => ({
+      title: item.title,
+      source: item.source as Source,
+      url: `/${getRouteBySource(item.source)}/${item.slug}`,
+    }));
+
+  const categories: Array<{
+    title: string;
+    filter: (i: LinkedContent) => boolean;
+  }> = [
+    {
+      title: "Simulateurs",
+      filter: (i) => i.source === SOURCES.TOOLS,
+    },
+    {
+      title: "Modèles de courriers",
+      filter: (i) => i.source === SOURCES.LETTERS,
+    },
+    {
+      title: "Contenus liés",
+      filter: (i) => i.source !== SOURCES.LETTERS && i.source !== SOURCES.TOOLS,
+    },
+  ];
+
+  const relatedItems = categories
+    .map(({ title, filter }) => {
+      const filtered = linkedContent.filter(filter);
+      return filtered.length
+        ? { title, items: buildItems(filtered) }
+        : undefined;
+    })
+    .filter((x): x is { title: string; items: RelatedItem[] } => Boolean(x));
+
+  return {
+    title,
+    meta_title,
+    date,
+    content,
+    meta_description,
+    relatedItems,
+  };
+};

--- a/packages/code-du-travail-frontend/src/modules/actualite/type.ts
+++ b/packages/code-du-travail-frontend/src/modules/actualite/type.ts
@@ -1,0 +1,14 @@
+import { NewsElasticDocument } from "@socialgouv/cdtn-types";
+import { RelatedItem } from "../documents";
+
+export type News = Pick<
+  NewsElasticDocument,
+  "title" | "meta_title" | "content" | "meta_description" | "date"
+> & {
+  relatedItems: { items: RelatedItem[]; title: string }[];
+};
+
+export type NewsSummary = Pick<
+  NewsElasticDocument,
+  "title" | "content" | "date" | "slug"
+>;

--- a/packages/code-du-travail-frontend/src/modules/home/Components/HomeNewsCard.tsx
+++ b/packages/code-du-travail-frontend/src/modules/home/Components/HomeNewsCard.tsx
@@ -1,0 +1,51 @@
+import { fr } from "@codegouvfr/react-dsfr";
+import { Card } from "@codegouvfr/react-dsfr/Card";
+import DisplayContent from "../../common/DisplayContent";
+import { HomeNewsCardItem } from "../queries";
+import { formatDateAsFrenchText } from "../../utils";
+import { css } from "@styled-system/css";
+
+export type HomeCardProps = HomeNewsCardItem;
+
+export const HomeNewsCard = ({
+  title,
+  description,
+  link,
+  date,
+}: HomeCardProps) => (
+  <Card
+    border
+    desc={
+      <span className={contentLimited}>
+        <DisplayContent content={description} titleLevel={4} />
+      </span>
+    }
+    horizontal
+    linkProps={{
+      href: link,
+    }}
+    size="medium"
+    title={title}
+    titleAs="h3"
+    enlargeLink
+    end={
+      <p className={fr.cx("fr-m-0", "fr-card__detail")}>
+        {formatDateAsFrenchText(date)}
+      </p>
+    }
+    classes={{
+      start: fr.cx("fr-mb-2w"),
+    }}
+  />
+);
+
+const contentLimited = css({
+  display: "-webkit-box !important",
+  // @ts-expect-error - vendor prefixed properties
+  WebkitBoxOrient: "vertical",
+  WebkitLineClamp: 5,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  overflowWrap: "break-word",
+  whiteSpace: "normal", // Important : force le retour à la ligne
+});

--- a/packages/code-du-travail-frontend/src/modules/home/News.tsx
+++ b/packages/code-du-travail-frontend/src/modules/home/News.tsx
@@ -1,0 +1,41 @@
+import { MatomoHomeEvent, useHomeTracking } from "./tracking";
+import { HomeNewsCardItem } from "./queries";
+import { HomeButton, SectionContainer } from "./Components";
+import { fr } from "@codegouvfr/react-dsfr";
+import { HomeNewsCard } from "./Components/HomeNewsCard";
+
+type Props = {
+  items: HomeNewsCardItem[];
+};
+
+export const News = ({ items }: Props) => {
+  const { emitHomeClickButtonEvent } = useHomeTracking();
+
+  return (
+    <SectionContainer
+      sectionId="home-actualite"
+      title="Actualités"
+      subtitle=""
+      footerNode={
+        <HomeButton
+          buttonLink="/actualite"
+          buttonText="Lire toutes les actualités"
+          onButtonClick={() => {
+            emitHomeClickButtonEvent(
+              MatomoHomeEvent.CLICK_VOIR_TOUTES_LES_ACTUALITES
+            );
+          }}
+        />
+      }
+    >
+      {items.map((item) => (
+        <div
+          key={`${item.link}`}
+          className={fr.cx("fr-col-12", "fr-col-md-6", "fr-col-lg-6")}
+        >
+          <HomeNewsCard {...item} />
+        </div>
+      ))}
+    </SectionContainer>
+  );
+};

--- a/packages/code-du-travail-frontend/src/modules/home/__tests__/index.test.tsx
+++ b/packages/code-du-travail-frontend/src/modules/home/__tests__/index.test.tsx
@@ -50,6 +50,14 @@ const mockData: HomePageProps = {
       description: "Theme description",
     },
   ],
+  news: [
+    {
+      title: "Actualité 1",
+      link: "/actualite/actaulite-1",
+      date: "29/03/2026",
+      description: "<p>Description de l'actualité 1</p>",
+    },
+  ],
 };
 
 describe("<Home />", () => {

--- a/packages/code-du-travail-frontend/src/modules/home/index.tsx
+++ b/packages/code-du-travail-frontend/src/modules/home/index.tsx
@@ -10,12 +10,14 @@ import { Agreements } from "./Agreements";
 import { Themes } from "./Themes";
 import { ComprendreLeDroitDuTravail } from "./ComprendreLeDroitDuTravail";
 import { LaQuestionAction } from "./LaQuestionAction";
+import { News } from "./News";
 
 export const Home = (props: HomePageProps) => {
   return (
     <div className={fr.cx("fr-grid-row")}>
       <div className={fr.cx("fr-col-12")}>
         <Search />
+        {props.news.length > 1 && <News items={props.news} />}
         <ComprendreLeDroitDuTravail />
         <LaQuestionAction />
         <Tools items={props.tools} />

--- a/packages/code-du-travail-frontend/src/modules/home/queries.ts
+++ b/packages/code-du-travail-frontend/src/modules/home/queries.ts
@@ -5,12 +5,17 @@ import { fetchTools } from "../outils";
 import { fetchModels } from "../modeles-de-courriers";
 import { fetchContributions } from "../contributions";
 import { fetchAgreementsByCdtnIds } from "../convention-collective";
+import { fetchNewsList } from "../actualite";
 
 export type HomeCardItem = {
   description: string;
   link: string;
   theme: string;
   title: string;
+};
+
+export type HomeNewsCardItem = Omit<HomeCardItem, "theme"> & {
+  date: string;
 };
 
 export type HomeTileItem = {
@@ -25,6 +30,7 @@ export type HomePageProps = {
   tools: HomeTileItem[];
   modeles: Omit<HomeCardItem, "description" | "theme">[];
   contributions: HomeCardItem[];
+  news: HomeNewsCardItem[];
   agreements: HomeCardItem[];
   themes: HomeTileItem[];
 };
@@ -69,6 +75,19 @@ export const fetchHomeData = async (): Promise<HomePageProps> => {
     title: modele.title,
   }));
 
+  const news = await fetchNewsList(
+    ["source", "date", "slug", "title", "content"],
+    {
+      pageSize: 2,
+      page: 1,
+    }
+  );
+  const parsedNews = news.items.map((item) => ({
+    description: item.content,
+    link: `/${getRouteBySource(item.source)}/${item.slug}`,
+    date: item.date,
+    title: item.title,
+  }));
   const contributions = await fetchContributions(
     ["source", "slug", "title", "description"],
     {
@@ -114,6 +133,7 @@ export const fetchHomeData = async (): Promise<HomePageProps> => {
     themes: parsedThemes,
     highlights: parsedHighlights,
     tools: parsedTools,
+    news: parsedNews,
     modeles: parsedModeles,
     contributions: parsedContributions,
     agreements: parsedAgreements,

--- a/packages/code-du-travail-frontend/src/modules/home/tracking.ts
+++ b/packages/code-du-travail-frontend/src/modules/home/tracking.ts
@@ -10,6 +10,7 @@ export enum MatomoHomeEvent {
   CLICK_VOIR_TOUTES_LES_FICHES = "click_voir_toutes_les_fiches_pratiques",
   CLICK_VOIR_TOUTES_LES_CONVENTIONS_COLLECTIVES = "click_voir_toutes_les_conventions_collectives",
   CLICK_VOIR_TOUTES_LES_THEMES = "click_voir_tous_les_themes",
+  CLICK_VOIR_TOUTES_LES_ACTUALITES = "click_voir_toutes_les_actualites",
   CLICK_COMPRENDRE_DROIT_DU_TRAVAIL = "click_comprendre_le_droit_du_travail",
   CLICK_PARCOURIR_LES_QUESTIONS = "click_parcourir_les_questions",
   CLICK_DE_LA_QUESTION_A_LACTION = "click_question_action",

--- a/packages/code-du-travail-frontend/src/modules/layout/ContainerRich.tsx
+++ b/packages/code-du-travail-frontend/src/modules/layout/ContainerRich.tsx
@@ -8,6 +8,7 @@ export type ContainerRichProps = {
   relatedItems: { items: RelatedItem[]; title: string }[];
   title: string;
   description: string;
+  showFeedback?: boolean;
   children: React.ReactNode;
 };
 
@@ -15,6 +16,7 @@ export const ContainerRich = ({
   children,
   relatedItems,
   title,
+  showFeedback = true,
   description,
 }: ContainerRichProps) => {
   return (
@@ -30,7 +32,7 @@ export const ContainerRich = ({
         className={fr.cx("fr-col-12", "fr-col-md-7", "fr-mb-6w", "fr-mb-md-0")}
       >
         {children}
-        <Feedback />
+        {showFeedback && <Feedback />}
       </div>
 
       <div className={fr.cx("fr-col-12", "fr-col-offset-md-1", "fr-col-md-4")}>

--- a/packages/code-du-travail-frontend/src/modules/layout/ContainerRichWithBreadcrumbs.tsx
+++ b/packages/code-du-travail-frontend/src/modules/layout/ContainerRichWithBreadcrumbs.tsx
@@ -20,6 +20,7 @@ export const ContainerRichWithBreadcrumbs = ({
   description,
   breadcrumbs,
   currentPage,
+  showFeedback = true,
 }: Props) => {
   return (
     <div>
@@ -58,7 +59,7 @@ export const ContainerRichWithBreadcrumbs = ({
           )}
         >
           {children}
-          <Feedback />
+          {showFeedback && <Feedback />}
         </div>
 
         <div

--- a/packages/code-du-travail-frontend/src/modules/layout/header/index.tsx
+++ b/packages/code-du-travail-frontend/src/modules/layout/header/index.tsx
@@ -30,6 +30,12 @@ export const Header = () => {
               },
             },
             {
+              text: "Actualités",
+              linkProps: {
+                href: "/actualite",
+              },
+            },
+            {
               text: "Nos infographies",
               linkProps: {
                 href: "/infographie",

--- a/packages/code-du-travail-frontend/src/modules/utils/date.ts
+++ b/packages/code-du-travail-frontend/src/modules/utils/date.ts
@@ -1,3 +1,6 @@
+import { format, parse } from "date-fns";
+import { fr } from "date-fns/locale/fr";
+
 export enum Month {
   janvier = 1,
   février = 2,
@@ -76,4 +79,9 @@ export const dateToString = (date: Date, withDay = false): string => {
   const num = date.getDate();
   const month = date.getMonth() + 1;
   return `${withDay ? `${days[day]} ` : ""}${num} ${Month[month].toString()}`;
+};
+
+export const formatDateAsFrenchText = (date: string): string => {
+  const parsedDate = parse(date, "dd/MM/yyyy", new Date());
+  return format(parsedDate, "d MMMM yyyy", { locale: fr });
 };

--- a/packages/code-du-travail-frontend/src/modules/utils/index.ts
+++ b/packages/code-du-travail-frontend/src/modules/utils/index.ts
@@ -4,3 +4,4 @@ export * from "./hash";
 export * from "./size";
 export * from "./url";
 export * from "./groupByThemes";
+export * from "./date";

--- a/packages/code-du-travail-utils/src/sources.ts
+++ b/packages/code-du-travail-utils/src/sources.ts
@@ -39,7 +39,7 @@ export const routeBySource = {
   [SOURCES.PREQUALIFIED]: "prequalified",
   [SOURCES.INFOGRAPHICS]: "infographie",
   [SOURCES.WHAT_IS_NEW]: "quoi-de-neuf",
-  [SOURCES.NEWS]: "actualites",
+  [SOURCES.NEWS]: "actualite",
 } as const;
 
 export const labelBySource = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: ^2.66.6
         version: 2.66.6
       '@socialgouv/cdtn-types':
-        specifier: ^2.66.6
-        version: 2.66.6
+        specifier: ^2.71.0
+        version: 2.71.0
       '@socialgouv/cdtn-utils':
         specifier: link:../code-du-travail-utils
         version: link:../code-du-travail-utils
@@ -2512,8 +2512,8 @@ packages:
   '@socialgouv/cdtn-elasticsearch@2.66.6':
     resolution: {integrity: sha512-zNq5UwVXrd0T/ofF5PclI85lPj4ZP7cldI7fY6XbCpTivw9lzN0w6MUnlyvwzMptmve60V3aqo/hghHNDOeGqA==}
 
-  '@socialgouv/cdtn-types@2.66.6':
-    resolution: {integrity: sha512-jC11HQ0O/2zBLLE6SmH+b1xCEkkpZBuFWj3NnzAEOuSWs99zIRZu9Dw/Pihyfej7AcBaDIklUMBSScE8GEMErA==}
+  '@socialgouv/cdtn-types@2.71.0':
+    resolution: {integrity: sha512-iI5AfIbk1uoogIcE0TKN5D0cT+NCNv+KNST6dlYLA9ytU55G7AFWXsf/nBPMtPoVZPHicO1fe9gm/VKLM8YkFg==}
 
   '@socialgouv/matomo-next@1.11.0':
     resolution: {integrity: sha512-48XLGnq4LzwOHf2wgm76UXFnGGKOKeOal4+QHeewQH+VY/gxJiIZ1k0o8LuUvKOHThW5Mqco8yAGNe25f7s28g==}
@@ -10515,7 +10515,7 @@ snapshots:
 
   '@socialgouv/cdtn-elasticsearch@2.66.6': {}
 
-  '@socialgouv/cdtn-types@2.66.6': {}
+  '@socialgouv/cdtn-types@2.71.0': {}
 
   '@socialgouv/matomo-next@1.11.0(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))':
     dependencies:


### PR DESCRIPTION
Pour info,

Il n'y a actuellement pas de test e2e sur la page car il n'y a pas de contenu en preprod. Il faut attendre d'avoir 2 actualités pour commencer à mettre en place des tests e2e. D'ailleurs un test e2e est en échec car sur ma branche j'ai des actualités mais sur la preprod ce sera vide et donc ça ne plantera pas.

Le json-ld et le plan du site sera vu dans une prochaine PR (elle est déjà assez grosse :) )