### PR TITLE
TEST : afficher-info-original scenario_a DO NOT MERGE

### DIFF
--- a/packages/code-du-travail-frontend/src/modules/contributions/ContributionAgreement.tsx
+++ b/packages/code-du-travail-frontend/src/modules/contributions/ContributionAgreement.tsx
@@ -29,7 +29,9 @@ export function ContributionAgreement({ contribution }: Props) {
     if (window.location.hash !== AGREEMENT_FOCUS_HASH) return;
     const timer = setTimeout(() => {
       agreementTitleRef.current?.scrollIntoView({ behavior: "smooth" });
-      agreementTitleRef.current?.focus();
+      // preventScroll : laisse le défilement fluide ci-dessus se dérouler sans
+      // que la mise au focus ne le court-circuite par un saut instantané.
+      agreementTitleRef.current?.focus({ preventScroll: true });
     }, 100);
     return () => clearTimeout(timer);
   }, []);

--- a/packages/code-du-travail-frontend/src/modules/contributions/ContributionGeneric.tsx
+++ b/packages/code-du-travail-frontend/src/modules/contributions/ContributionGeneric.tsx
@@ -106,9 +106,10 @@ export function ContributionGeneric({ contribution }: Props) {
         contribution={contribution}
         onAgreementSelect={(agreement) => {
           setSelectedAgreement(agreement);
-          if (!isRegularButtonVariant) {
-            setDisplayGeneric(false);
-          }
+          // Sélectionner une CC masque le Code du travail dans toutes les
+          // variantes (regular_button compris) ; il est réaffiché au besoin via
+          // « Afficher les informations ».
+          setDisplayGeneric(false);
           if (!agreement) return;
 
           if (isAgreementSupported(contribution, agreement)) {

--- a/packages/code-du-travail-frontend/src/modules/contributions/ContributionGeneric.tsx
+++ b/packages/code-du-travail-frontend/src/modules/contributions/ContributionGeneric.tsx
@@ -2,7 +2,6 @@
 import React, { useRef, useState, useEffect } from "react";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import { fr } from "@codegouvfr/react-dsfr";
-import { useABTestVariant } from "@socialgouv/matomo-next";
 import { useContributionTracking } from "./tracking";
 import {
   buildContributionAgreementPath,
@@ -18,7 +17,6 @@ import {
 import { useRouter, useSearchParams } from "next/navigation";
 import { ContributionGenericAgreementSearch } from "./ContributionGenericAgreementSearch";
 import {
-  CONTRIBUTION_AFFICHER_INFO_TEST,
   ContributionAfficherInfoVariations,
   getAfficherInfoVariantFlags,
 } from "../config/abTests";
@@ -38,7 +36,8 @@ export function ContributionGeneric({ contribution }: Props) {
   const personalizeTitleRef = useRef<HTMLParagraphElement>(null);
   const getTitle = () => `/contribution/${slug}`;
   const { slug, isNoCDT, relatedItems } = contribution;
-  const matomoVariant = useABTestVariant(CONTRIBUTION_AFFICHER_INFO_TEST);
+  // TEST scenario_a (DO NOT MERGE): variante figee en dur (au lieu de useABTestVariant)
+  const matomoVariant = ContributionAfficherInfoVariations.ORIGINAL;
   const variantOverride = searchParams?.get("ab") ?? null;
   const variant =
     variantOverride && ALLOWED_VARIANTS.has(variantOverride)

--- a/packages/code-du-travail-frontend/src/modules/contributions/ContributionGenericAgreementSearch.tsx
+++ b/packages/code-du-travail-frontend/src/modules/contributions/ContributionGenericAgreementSearch.tsx
@@ -179,10 +179,14 @@ export function ContributionGenericAgreementSearch({
 
   // Navigue vers la page CC en ajoutant le hash de focus : la cible n'est mise
   // en focus que lorsqu'on y arrive par cette action (cf. AGREEMENT_FOCUS_HASH).
+  // `scroll: false` : sans ça, Next réinitialise le scroll en haut de page à la
+  // navigation et écrase le défilement vers le titre « Votre convention
+  // collective » géré par la page CC — l'usager restait alors tout en haut.
   const navigateToAgreementPage = () => {
     if (!selectedAgreement) return;
     router.push(
-      `${buildContributionAgreementPath(slug, selectedAgreement)}${AGREEMENT_FOCUS_HASH}`
+      `${buildContributionAgreementPath(slug, selectedAgreement)}${AGREEMENT_FOCUS_HASH}`,
+      { scroll: false }
     );
   };
 

--- a/packages/code-du-travail-frontend/src/modules/contributions/__tests__/contribution-generic.tracking.test.tsx
+++ b/packages/code-du-travail-frontend/src/modules/contributions/__tests__/contribution-generic.tracking.test.tsx
@@ -504,7 +504,8 @@ describe("<ContributionGeneric />", () => {
       fireEvent.click(ui.generic.buttonDisplayInfo.get());
 
       expect(pushMock).toHaveBeenCalledWith(
-        "/contribution/1388-my-contrib#votre-convention-collective"
+        "/contribution/1388-my-contrib#votre-convention-collective",
+        { scroll: false }
       );
     });
 

--- a/packages/code-du-travail-frontend/src/modules/contributions/__tests__/contributions.test.tsx
+++ b/packages/code-du-travail-frontend/src/modules/contributions/__tests__/contributions.test.tsx
@@ -109,7 +109,8 @@ describe("<ContributionLayout />", () => {
       fireEvent.click(ccUi.buttonDisplayInfo.get());
       expect(pushMock).toHaveBeenCalledTimes(1);
       expect(pushMock).toHaveBeenCalledWith(
-        "/contribution/3239-slug#votre-convention-collective"
+        "/contribution/3239-slug#votre-convention-collective",
+        { scroll: false }
       );
       expect(sendEvent).toHaveBeenCalledWith({
         action: "cc_select_traitée",
@@ -172,7 +173,8 @@ describe("<ContributionLayout />", () => {
       fireEvent.click(ccUi.buttonDisplayInfo.get());
       expect(pushMock).toHaveBeenCalledTimes(1);
       expect(pushMock).toHaveBeenCalledWith(
-        "/contribution/16-slug#votre-convention-collective"
+        "/contribution/16-slug#votre-convention-collective",
+        { scroll: false }
       );
 
       expect(ccUi.warning.nonTreatedAgreement.query()).not.toBeInTheDocument();
@@ -260,7 +262,8 @@ describe("<ContributionLayout />", () => {
       fireEvent.click(ccUi.buttonDisplayInfo.get());
       expect(pushMock).toHaveBeenCalledTimes(1);
       expect(pushMock).toHaveBeenCalledWith(
-        "/contribution/16-slug#votre-convention-collective"
+        "/contribution/16-slug#votre-convention-collective",
+        { scroll: false }
       );
 
       expect(ccUi.warning.nonTreatedAgreement.query()).not.toBeInTheDocument();


### PR DESCRIPTION
## ⚠️ TEST — DO NOT MERGE

PR de test **uniquement** pour déployer une review-app dédiée.

**Scénario :** `scenario_a` — variante **`original`** du test A/B `contribution_afficher_info`.

### Ce que fait cette PR
Fige en dur la source de la variante dans `ContributionGeneric.tsx` (`matomoVariant` = `original` au lieu de `useABTestVariant`), pour que la review-app affiche toujours cette variante. La logique d'override par URL (`?ab=`) reste intacte.

- Base : `maxgfr/afficher-les-informations`
- Diff : 1 fichier (figeage de la variante + suppression des imports devenus inutiles)

**Ne pas merger.** 🚫

🤖 Generated with [Claude Code](https://claude.com/claude-code)