### PR TITLE
fix(redirects): pointe la redirection canicule vers la page /information

### DIFF
--- a/packages/code-du-travail-frontend/redirects.json
+++ b/packages/code-du-travail-frontend/redirects.json
@@ -642,6 +642,6 @@
   {
     "source": "/fiche-ministere-travail/chaleur-et-canicule-au-travail-les-precautions-a-prendre",
     "permanent": true,
-    "destination": "/actualite/canicule-au-travail-quelles-sont-les-obligations-de-lemployeur"
+    "destination": "/information/fortes-chaleurs-canicule-quelles-mesures-lemployeur-doit-il-mettre-en-place"
   }
 ]


### PR DESCRIPTION
Links to #7320 

Suite à #7318 (déjà mergée), la redirection de l'ancienne fiche canicule pointait vers `/actualite/canicule-au-travail-quelles-sont-les-obligations-de-lemployeur`. La page cible souhaitée est plutôt la page info dédiée.