### PR TITLE
fix(enterprise): découple l'affichage des accords de la recherche d'entreprise

### DIFF
--- a/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/accords/__tests__/AccordsEntreprise.test.tsx
+++ b/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/accords/__tests__/AccordsEntreprise.test.tsx
@@ -13,6 +13,7 @@ jest.mock("@socialgouv/matomo-next", () => ({
 
 const mockFetch = (data: EntrepriseAccordsResponse) => {
   window.fetch = jest.fn().mockResolvedValue({
+    ok: true,
     json: jest.fn().mockResolvedValue(data),
   }) as unknown as typeof fetch;
 };
@@ -21,6 +22,14 @@ const mockFetchError = () => {
   window.fetch = jest
     .fn()
     .mockRejectedValue(new Error("Network error")) as unknown as typeof fetch;
+};
+
+const mockFetchHttpError = (status = 500) => {
+  window.fetch = jest.fn().mockResolvedValue({
+    ok: false,
+    status,
+    json: jest.fn().mockResolvedValue({ message: "Internal Server Error" }),
+  }) as unknown as typeof fetch;
 };
 
 const accordsData: EntrepriseAccordsResponse = {
@@ -58,6 +67,20 @@ describe("AccordsEntreprise", () => {
     expect(
       screen.getByText("Erreur lors du chargement des accords d'entreprise")
     ).toBeInTheDocument();
+  });
+
+  it("affiche une erreur (sans planter) si l'API renvoie une erreur HTTP, ex 500 PISTE", async () => {
+    mockFetchHttpError(500);
+    const onLoaded = jest.fn();
+    await act(async () => {
+      render(<AccordsEntreprise siret="12345678901234" onLoaded={onLoaded} />);
+    });
+    expect(
+      screen.getByText("Erreur lors du chargement des accords d'entreprise")
+    ).toBeInTheDocument();
+    // le compteur reste à 0 (et non `undefined`) pour ne pas corrompre
+    // le titre "X conventions ... et Y accords trouvés" du composant parent
+    expect(onLoaded).toHaveBeenCalledWith(0);
   });
 
   it("affiche un message si aucun accord n'est trouvé", async () => {

--- a/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/accords/index.tsx
+++ b/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/accords/index.tsx
@@ -38,7 +38,19 @@ export const AccordsEntreprise = ({ siret, onLoaded }: Props) => {
     let ignore = false;
 
     fetch(`/api/enterprises/accords/${siret}`)
-      .then((res) => res.json() as Promise<EntrepriseAccordsResponse>)
+      .then((res) => {
+        // `fetch` ne rejette pas sur un statut HTTP d'erreur : sans ce contrôle,
+        // une réponse 500 (ex. API DILA/PISTE indisponible) serait parsée comme
+        // un succès et planterait le rendu. On bascule explicitement vers l'état
+        // d'erreur pour que la recherche d'entreprise (conventions collectives)
+        // reste affichée même si les accords sont indisponibles.
+        if (!res.ok) {
+          throw new Error(
+            `Échec du chargement des accords (HTTP ${res.status})`
+          );
+        }
+        return res.json() as Promise<EntrepriseAccordsResponse>;
+      })
       .then((data) => {
         if (!ignore) {
           emitShowAccords(data.total);


### PR DESCRIPTION
## Contexte

Quand l'API « accords d'entreprise » (`/api/enterprises/accords/[siret]`, qui interroge l'API DILA/Légifrance via PISTE) tombe en panne (actuellement : `500 — Premature close` côté PISTE), la recherche d'entreprise était cassée. Objectif : **découpler les deux** pour que les conventions collectives s'affichent même quand les accords sont indisponibles.

## Cause

`fetch()` **ne rejette pas** sur un statut HTTP d'erreur. Sur un `500`, la réponse d'erreur `{message}` était parsée comme un succès :
- `onLoaded(undefined)` → le titre parent affichait « … et **undefined** accord d'entreprise trouvé » ;
- le rendu plantait ensuite sur `accordsState.accords.accords.map(...)` (`.map` sur `undefined`) → crash du sous-arbre accords.

## Correctif

`accords/index.tsx` : on vérifie `res.ok`. Un statut d'erreur bascule explicitement vers l'état d'erreur **déjà prévu** (alerte « Les accords d'entreprise ne sont pas disponibles pour le moment ») avec `onLoaded(0)`.

Résultat : si l'API accords/PISTE échoue, la **recherche d'entreprise et ses conventions collectives restent affichées**, et la section accords montre une alerte propre (plus de `undefined`, plus de crash).

## Tests

- Nouveau test : une erreur HTTP 500 affiche l'alerte d'erreur (sans planter) et appelle `onLoaded(0)`.
- Correction des mocks existants (`ok: true`) pour refléter le contrôle de `res.ok`.
- `EnterpriseAgreementSearch` : 36 tests verts. Prettier ✓.

> Note : ceci améliore la résilience UX. Le test e2e `trouver-sa-cc:86` restera rouge **tant que PISTE est down** (il attend des accords réels) — c'est l'incident externe, hors périmètre de cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)