### PR TITLE
fix(enterprise): ne pas déplacer le focus sur les résultats lors de la recherche automatique

### DIFF
--- a/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/EnterpriseAgreementSearchInput.tsx
+++ b/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/EnterpriseAgreementSearchInput.tsx
@@ -86,6 +86,9 @@ export const EnterpriseAgreementSearchInput = ({
   const [error, setError] = useState("");
   const [selectionRequired, setSelectionRequired] = useState(false);
   const resultRef = useRef<HTMLHeadingElement>(null);
+  // Le focus n'est déplacé sur les résultats que pour une recherche
+  // initiée par l'utilisateur (jamais pour la recherche automatique)
+  const shouldFocusResultsRef = useRef(false);
   const selectedConventionTitleRef = useRef<HTMLParagraphElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const TitleTag = `h${level}` as "h2" | "h3";
@@ -140,7 +143,7 @@ export const EnterpriseAgreementSearchInput = ({
       (base64String ? "&cp=" + base64String : "")
     );
   };
-  const onSubmit = async () => {
+  const onSubmit = async (focusResults = true) => {
     if (!search) {
       setSearchState("required");
       return;
@@ -150,6 +153,7 @@ export const EnterpriseAgreementSearchInput = ({
       search,
       location
     );
+    shouldFocusResultsRef.current = focusResults;
     setLoading(true);
     try {
       const result = await searchEnterprises({
@@ -182,7 +186,9 @@ export const EnterpriseAgreementSearchInput = ({
 
   useEffect(() => {
     if (defaultSearch) {
-      onSubmit();
+      // Recherche automatique (retour via « Précédent » ou lien direct) :
+      // ne pas déplacer le focus pour ne pas interrompre une saisie en cours
+      onSubmit(false);
     }
   }, [defaultSearch]);
   useEffect(() => {
@@ -194,7 +200,10 @@ export const EnterpriseAgreementSearchInput = ({
     }
   }, [selectedEnterprise]);
   useEffect(() => {
-    resultRef.current?.focus();
+    if (shouldFocusResultsRef.current) {
+      shouldFocusResultsRef.current = false;
+      resultRef.current?.focus();
+    }
   }, [enterprises]);
 
   useEffect(() => {

--- a/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/__tests__/EnterpriseAgreementSearchInput.test.tsx
+++ b/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/__tests__/EnterpriseAgreementSearchInput.test.tsx
@@ -1,0 +1,50 @@
+import { act, render } from "@testing-library/react";
+
+import { EnterpriseAgreementSearchInput } from "../EnterpriseAgreementSearchInput";
+import { ui } from "./ui";
+import { UserAction } from "src/modules/outils/common/utils/UserAction";
+
+jest.mock("@socialgouv/matomo-next", () => ({
+  sendEvent: jest.fn(),
+}));
+
+jest.mock("uuid", () => ({
+  v4: jest.fn(() => ""),
+}));
+
+jest.mock("../../queries");
+
+describe("<EnterpriseAgreementSearchInput /> - focus sur le titre des résultats", () => {
+  it("ne déplace pas le focus sur les résultats lors d'une recherche automatique via defaultSearch", async () => {
+    await act(async () => {
+      render(
+        <EnterpriseAgreementSearchInput
+          defaultSearch="carrefour"
+          trackingActionName="Trouver sa convention collective"
+          level={2}
+        />
+      );
+    });
+
+    expect(ui.enterpriseAgreementSearch.resultTitle.get()).toBeInTheDocument();
+    expect(ui.enterpriseAgreementSearch.resultTitle.get()).not.toHaveFocus();
+  });
+
+  it("déplace le focus sur les résultats lors d'une recherche déclenchée par l'utilisateur", async () => {
+    render(
+      <EnterpriseAgreementSearchInput
+        trackingActionName="Trouver sa convention collective"
+        level={2}
+      />
+    );
+
+    const userAction = new UserAction();
+    userAction.setInput(ui.enterpriseAgreementSearch.input.get(), "carrefour");
+    await act(async () => {
+      userAction.click(ui.enterpriseAgreementSearch.submitButton.get());
+    });
+
+    expect(ui.enterpriseAgreementSearch.resultTitle.get()).toBeInTheDocument();
+    expect(ui.enterpriseAgreementSearch.resultTitle.get()).toHaveFocus();
+  });
+});


### PR DESCRIPTION
## Problème

Le test e2e « Outil - Trouver sa convention collective › Recherche de convention collective par entreprise » (`trouver-sa-cc.e2e.ts:50`) échoue systématiquement depuis le 14/07 (sur `dev` comme sur les PRs), timeout en attendant les suggestions du champ « Code postal ou Ville ».

## Cause racine

Au retour via « Précédent », la page `/outils/convention-collective/entreprise?q=…` relance automatiquement la recherche d'entreprises (`useEffect [defaultSearch]`). Quand elle aboutit (~650 ms), `useEffect [enterprises]` fait `resultRef.current?.focus()` sur le titre « X entreprises trouvées », **volant le focus du champ localisation en cours de saisie**. Le blur ferme le menu Downshift : les suggestions (l'API geo répond pourtant 200 avec les bonnes données) ne s'affichent jamais.

Ce n'est pas qu'un problème de test : un utilisateur réel qui tape dans la seconde suivant le retour subit la même interruption de saisie. Le test passait avant par chance de timing — la recherche auto se terminait avant la saisie ; un glissement de latence de l'API entreprises a inversé la course (aucun commit applicatif entre le dernier run vert et le premier rouge).

## Correctif

Le focus n'est déplacé sur le titre des résultats que pour une recherche **initiée par l'utilisateur** (submit du formulaire), plus jamais pour la recherche automatique déclenchée par le paramètre d'URL — ce qui préserve l'intention a11y de #6425.

## Vérifications

- Nouveau test unitaire (rouge avant fix → vert après) : la recherche auto ne déplace pas le focus + garde-fou : le submit utilisateur focus toujours les résultats
- Suites unitaires `enterprise` et `convention-collective` vertes
- Scénario e2e complet rejoué contre la review app avec le correctif simulé au runtime (neutralisation du focus H2) : passe intégralement, y compris les assertions finales BOUILLON PIGALLE