### PR TITLE
feat(matomo): event sur le nombre de conventions collectives trouvées (#7428)

### DIFF
--- a/packages/code-du-travail-frontend/src/modules/analytics/types.ts
+++ b/packages/code-du-travail-frontend/src/modules/analytics/types.ts
@@ -18,6 +18,7 @@ export enum MatomoSearchAgreementCategory {
   ENTERPRISE_SEARCH = "enterprise_search",
   AGREEMENT_SEARCH_TYPE_OF_USERS = "cc_search_type_of_users",
   ACCORD_ENTERPRISE_SEARCH = "accord_enterprise_search",
+  CC_ENTERPRISE_SEARCH = "cc_enterprise_search",
 }
 
 export enum MatomoSimulatorEvent {

--- a/packages/code-du-travail-frontend/src/modules/contributions/__tests__/contribution-generic.tracking.test.tsx
+++ b/packages/code-du-travail-frontend/src/modules/contributions/__tests__/contribution-generic.tracking.test.tsx
@@ -210,7 +210,7 @@ describe("<ContributionGeneric />", () => {
       byText(/Vous avez sélectionné la convention collective/).query()
     ).toBeInTheDocument();
 
-    expect(sendEvent).toHaveBeenCalledTimes(5);
+    expect(sendEvent).toHaveBeenCalledTimes(6);
     // @ts-ignore
     expect(sendEvent.mock.calls).toEqual([
       [
@@ -246,6 +246,16 @@ describe("<ContributionGeneric />", () => {
           action: "cc_select_non_traitée",
           category: "outil",
           name: "2216",
+        },
+      ],
+      // Le nombre de CC trouvées pour l'entreprise part depuis un `useEffect`,
+      // donc après les events émis dans les gestionnaires de clic : il ferme la
+      // séquence. Carrefour Proximité n'a qu'une convention, d'où `name: "1"`.
+      [
+        {
+          action: "show_agreements",
+          category: "cc_enterprise_search",
+          name: "1",
         },
       ],
     ]);

--- a/packages/code-du-travail-frontend/src/modules/convention-collective/tracking.ts
+++ b/packages/code-du-travail-frontend/src/modules/convention-collective/tracking.ts
@@ -4,6 +4,7 @@ export enum TrackingAgreementSearchCategory {
   CC_SEARCH_TYPE_OF_USERS = "cc_search_type_of_users",
   ENTERPRISE_SEARCH = "enterprise_search",
   ACCORD_ENTERPRISE_SEARCH = "accord_enterprise_search",
+  CC_ENTERPRISE_SEARCH = "cc_enterprise_search",
   VIEW_STEP = "view_step_Trouver sa convention collective",
   CC_SELECT_P1 = "cc_select_p1",
   CC_SELECT_P2 = "cc_select_p2",

--- a/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/EnterpriseAgreementSearchInput.tsx
+++ b/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/EnterpriseAgreementSearchInput.tsx
@@ -72,6 +72,7 @@ export const EnterpriseAgreementSearchInput = ({
     emitNoEnterpriseClickEvent,
     emitSelectEnterpriseAgreementEvent,
     emitNoEnterpriseSelectEvent,
+    emitShowAgreements,
   } = useEnterpriseAgreementSearchTracking();
 
   const [search, setSearch] = useState<string>(defaultSearch ?? "");
@@ -91,6 +92,11 @@ export const EnterpriseAgreementSearchInput = ({
   const shouldFocusResultsRef = useRef(false);
   const selectedConventionTitleRef = useRef<HTMLParagraphElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  // Dernier SIRET pour lequel `show_agreements` a été émis : le composant se
+  // re-rend à chaque changement de radio et `selectedEnterprise` est re-posé
+  // par l'effet miroir de la prop `enterprise`, sans quoi l'event partirait
+  // plusieurs fois pour une même entreprise.
+  const trackedAgreementsSiretRef = useRef<string | undefined>(undefined);
   const TitleTag = `h${level}` as "h2" | "h3";
 
   const getStateMessage = () => {
@@ -198,6 +204,17 @@ export const EnterpriseAgreementSearchInput = ({
       );
       setSelectedAgreement(enterpriseAgreement);
     }
+  }, [selectedEnterprise]);
+  // On se branche sur `selectedEnterprise` plutôt que sur le formulaire de
+  // sélection : celui-ci est court-circuité dès qu'une convention est
+  // sélectionnée (cf. l'effet d'auto-sélection ci-dessus pour les entreprises
+  // à une seule CC). Ici on capte uniformément les cas 0, 1 et N conventions.
+  useEffect(() => {
+    const siret = selectedEnterprise?.siret;
+    if (!siret || trackedAgreementsSiretRef.current === siret) return;
+    trackedAgreementsSiretRef.current = siret;
+    emitShowAgreements(selectedEnterprise.conventions?.length ?? 0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedEnterprise]);
   useEffect(() => {
     if (shouldFocusResultsRef.current) {

--- a/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/EnterpriseAgreementSelectionLink.tsx
+++ b/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/EnterpriseAgreementSelectionLink.tsx
@@ -32,17 +32,26 @@ export const EnterpriseAgreementSelectionLink = ({
   level,
 }: Props) => {
   const searchParams = useSearchParams();
-  const { emitSelectEnterpriseAgreementEvent } =
+  const { emitSelectEnterpriseAgreementEvent, emitShowAgreements } =
     useEnterpriseAgreementSearchTracking();
   const agreementPlurial = enterprise.conventions.length > 1 ? "s" : "";
   const [accordCount, setAccordCount] = useState(0);
   const titleRef = useRef<HTMLParagraphElement>(null);
+  // Cf. EnterpriseAgreementSearchInput : garde par SIRET pour n'émettre
+  // `show_agreements` qu'une fois par entreprise affichée.
+  const trackedAgreementsSiretRef = useRef<string | undefined>(undefined);
   useEffect(() => {
     setTimeout(() => {
       titleRef?.current?.focus();
       titleRef?.current?.scrollIntoView({ behavior: "smooth" });
     }, 100);
   }, []);
+  useEffect(() => {
+    if (trackedAgreementsSiretRef.current === enterprise.siret) return;
+    trackedAgreementsSiretRef.current = enterprise.siret;
+    emitShowAgreements(enterprise.conventions?.length ?? 0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enterprise.siret]);
 
   return (
     <>

--- a/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/__tests__/AgreementSelection.test.tsx
+++ b/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/__tests__/AgreementSelection.test.tsx
@@ -86,6 +86,9 @@ describe("Trouver sa CC - recherche par nom d'entreprise CC", () => {
     expect(
       ui.enterpriseAgreementSelection.agreement.IDCC2216.link.query()
     ).not.toHaveAttribute("target", "_blank");
+    // Le montage émet déjà `show_agreements` (nombre de CC trouvées) : on
+    // repart de zéro pour n'observer que ce que déclenche le clic.
+    (sendEvent as jest.Mock).mockClear();
     userAction.click(
       ui.enterpriseAgreementSelection.agreement.IDCC2216.link.get()
     );

--- a/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/__tests__/ShowAgreementsTracking.test.tsx
+++ b/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/__tests__/ShowAgreementsTracking.test.tsx
@@ -1,0 +1,234 @@
+import { act, render, screen } from "@testing-library/react";
+import React from "react";
+import { sendEvent } from "@socialgouv/matomo-next";
+
+import { EnterpriseAgreementSearchInput } from "../EnterpriseAgreementSearchInput";
+import { EnterpriseAgreementSelectionLink } from "../EnterpriseAgreementSelectionLink";
+import { TrackingEnterpriseAgreementSearchAction } from "../tracking";
+import { TrackingAgreementSearchCategory } from "../../../convention-collective/tracking";
+import { UserAction } from "src/modules/outils/common/utils/UserAction";
+
+jest.mock("@socialgouv/matomo-next", () => ({
+  sendEvent: jest.fn(),
+}));
+
+jest.mock("uuid", () => ({
+  v4: jest.fn(() => ""),
+}));
+
+jest.mock("next/navigation", () => ({
+  redirect: jest.fn(),
+  useSearchParams: jest.fn(),
+}));
+
+jest.mock("../accords", () => ({
+  AccordsEntreprise: () => null,
+}));
+
+jest.mock("../../queries");
+
+const agreement2216 = {
+  id: "2216",
+  contributions: true,
+  num: 2216,
+  shortTitle: "Commerce de détail et de gros à prédominance alimentaire",
+  title: "Commerce de détail et de gros à prédominance alimentaire",
+  url: "https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=1",
+  slug: "2216-commerce-de-detail-et-de-gros-a-predominance-alimentaire",
+};
+
+const agreement1486 = {
+  id: "1486",
+  contributions: true,
+  num: 1486,
+  shortTitle: "Bureaux d'études techniques",
+  title: "Bureaux d'études techniques",
+  url: "https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=2",
+  slug: "1486-bureaux-detudes-techniques",
+};
+
+const buildEnterprise = (siret: string, conventions: unknown[]) =>
+  ({
+    label: "CARREFOUR PROXIMITE FRANCE",
+    simpleLabel: "CARREFOUR PROXIMITE FRANCE",
+    highlightLabel: "CARREFOUR PROXIMITE FRANCE",
+    activitePrincipale: "47.11F - Hypermarchés",
+    address: "ZI ROUTE DE PARIS 14120 MONDEVILLE",
+    etablissements: 1,
+    matching: 1,
+    matchingEtablissementCount: 1,
+    siren: siret.slice(0, 9),
+    siret,
+    conventions,
+  }) as any;
+
+const enterpriseWithTwoAgreements = buildEnterprise("45132133500023", [
+  agreement2216,
+  agreement1486,
+]);
+const enterpriseWithOneAgreement = buildEnterprise("34513048800013", [
+  agreement2216,
+]);
+const enterpriseWithoutAgreement = buildEnterprise("11111111100011", []);
+
+// `sendEvent` porte aussi enterprise_select et cc_select_p2 : on isole les
+// seuls events de comptage pour que les assertions restent lisibles.
+const showAgreementsEvents = () =>
+  (sendEvent as jest.Mock).mock.calls
+    .map(([event]) => event)
+    .filter(
+      (event) =>
+        event.action === TrackingEnterpriseAgreementSearchAction.SHOW_AGREEMENTS
+    );
+
+describe("Event show_agreements", () => {
+  beforeEach(() => {
+    (sendEvent as jest.Mock).mockClear();
+  });
+
+  describe("<EnterpriseAgreementSearchInput /> (simulateurs et contributions)", () => {
+    const renderInput = async (enterprise: unknown) =>
+      act(async () =>
+        render(
+          <EnterpriseAgreementSearchInput
+            enterprise={enterprise as any}
+            onAgreementSelect={jest.fn()}
+            trackingActionName="Trouver sa convention collective"
+            level={2}
+          />
+        )
+      );
+
+    it("émet le nombre de conventions collectives affichées", async () => {
+      await renderInput(enterpriseWithTwoAgreements);
+
+      expect(showAgreementsEvents()).toEqual([
+        {
+          category: TrackingAgreementSearchCategory.CC_ENTERPRISE_SEARCH,
+          action: TrackingEnterpriseAgreementSearchAction.SHOW_AGREEMENTS,
+          name: "2",
+        },
+      ]);
+    });
+
+    it("émet 0 quand l'entreprise n'a déclaré aucune convention collective", async () => {
+      await renderInput(enterpriseWithoutAgreement);
+
+      expect(showAgreementsEvents()).toEqual([
+        {
+          category: TrackingAgreementSearchCategory.CC_ENTERPRISE_SEARCH,
+          action: TrackingEnterpriseAgreementSearchAction.SHOW_AGREEMENTS,
+          name: "0",
+        },
+      ]);
+    });
+
+    it("émet 1 pour une entreprise à convention unique, malgré l'auto-sélection", async () => {
+      await renderInput(enterpriseWithOneAgreement);
+
+      expect(showAgreementsEvents()).toHaveLength(1);
+      expect(showAgreementsEvents()[0].name).toBe("1");
+    });
+
+    it("n'émet pas de doublon quand l'usager change de convention collective", async () => {
+      await renderInput(enterpriseWithTwoAgreements);
+      const userAction = new UserAction();
+
+      await act(async () => {
+        userAction.click(
+          screen.getByLabelText(/Bureaux d'études techniques IDCC 1486/)
+        );
+      });
+      await act(async () => {
+        userAction.click(
+          screen.getByLabelText(
+            /Commerce de détail et de gros à prédominance alimentaire IDCC 2216/
+          )
+        );
+      });
+
+      // Les clics ont bien été pris en compte (cc_select_p2 part à chaque
+      // sélection) : sans cette assertion, le test passerait à vide si les
+      // libellés de radio changeaient.
+      expect(
+        (sendEvent as jest.Mock).mock.calls
+          .map(([event]) => event)
+          .filter(
+            (event) =>
+              event.category === TrackingAgreementSearchCategory.CC_SELECT_P2
+          )
+      ).toHaveLength(2);
+      expect(showAgreementsEvents()).toHaveLength(1);
+    });
+
+    it("émet un nouvel event quand l'usager change d'entreprise", async () => {
+      let rerender: (ui: React.ReactElement) => void;
+      await act(async () => {
+        ({ rerender } = render(
+          <EnterpriseAgreementSearchInput
+            enterprise={enterpriseWithTwoAgreements}
+            onAgreementSelect={jest.fn()}
+            trackingActionName="Trouver sa convention collective"
+            level={2}
+          />
+        ));
+      });
+
+      await act(async () => {
+        rerender(
+          <EnterpriseAgreementSearchInput
+            enterprise={enterpriseWithoutAgreement}
+            onAgreementSelect={jest.fn()}
+            trackingActionName="Trouver sa convention collective"
+            level={2}
+          />
+        );
+      });
+
+      expect(showAgreementsEvents().map(({ name }) => name)).toEqual([
+        "2",
+        "0",
+      ]);
+    });
+  });
+
+  describe("<EnterpriseAgreementSelectionLink /> (page dédiée et widget)", () => {
+    it("émet le nombre de conventions collectives au montage", async () => {
+      await act(async () => {
+        render(
+          <EnterpriseAgreementSelectionLink
+            enterprise={enterpriseWithTwoAgreements}
+            level={2}
+          />
+        );
+      });
+
+      expect(showAgreementsEvents()).toEqual([
+        {
+          category: TrackingAgreementSearchCategory.CC_ENTERPRISE_SEARCH,
+          action: TrackingEnterpriseAgreementSearchAction.SHOW_AGREEMENTS,
+          name: "2",
+        },
+      ]);
+    });
+
+    it("émet 0 quand l'entreprise n'a déclaré aucune convention collective", async () => {
+      await act(async () => {
+        render(
+          <EnterpriseAgreementSelectionLink
+            enterprise={enterpriseWithoutAgreement}
+            level={2}
+          />
+        );
+      });
+
+      expect(showAgreementsEvents()).toEqual([
+        {
+          category: TrackingAgreementSearchCategory.CC_ENTERPRISE_SEARCH,
+          action: TrackingEnterpriseAgreementSearchAction.SHOW_AGREEMENTS,
+          name: "0",
+        },
+      ]);
+    });
+  });
+});

--- a/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/tracking.ts
+++ b/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/tracking.ts
@@ -5,6 +5,10 @@ import {
 } from "../../convention-collective/tracking";
 import { ApiGeoResult } from "./searchCities";
 
+export enum TrackingEnterpriseAgreementSearchAction {
+  SHOW_AGREEMENTS = "show_agreements",
+}
+
 export const useEnterpriseAgreementSearchTracking = () => {
   const emitEnterpriseAgreementSearchInputEvent = (
     action: string,
@@ -29,6 +33,19 @@ export const useEnterpriseAgreementSearchTracking = () => {
       category: TrackingAgreementSearchCategory.CC_ENTERPRISE_SELECT,
       action: action,
       name: JSON.stringify(enterprise),
+    });
+  };
+
+  // Émis à l'affichage des conventions collectives d'une entreprise, quel que
+  // soit le parcours (simulateurs, contributions, page dédiée, widget) et y
+  // compris quand l'entreprise n'en déclare aucune (`name` vaut alors "0").
+  // Équivalent de `show_accords` côté accords d'entreprise : on n'envoie que le
+  // nombre, ni SIRET ni liste d'IDCC.
+  const emitShowAgreements = (count: number) => {
+    sendEvent({
+      category: TrackingAgreementSearchCategory.CC_ENTERPRISE_SEARCH,
+      action: TrackingEnterpriseAgreementSearchAction.SHOW_AGREEMENTS,
+      name: String(count),
     });
   };
 
@@ -66,6 +83,7 @@ export const useEnterpriseAgreementSearchTracking = () => {
   return {
     emitEnterpriseAgreementSearchInputEvent,
     emitSelectEnterpriseEvent,
+    emitShowAgreements,
     emitSelectEnterpriseAgreementEvent,
     emitPreviousEvent,
     emitNoEnterpriseClickEvent,

--- a/packages/code-du-travail-stats/events/TRACKING_PLAN.md
+++ b/packages/code-du-travail-stats/events/TRACKING_PLAN.md
@@ -11,7 +11,7 @@ Ce document décrit les évènements Matomo **écrits explicitement dans le code
 (`code.travail.gouv.fr`). Il est destiné au métier : pour **chaque** évènement, il explique
 **quand** il part et **pourquoi** on le mesure, puis en donne le contenu exact.
 
-**102** events uniques · **111** au total · **31** catégories Matomo. Couverture vérifiée
+**103** events uniques · **112** au total · **32** catégories Matomo. Couverture vérifiée
 exhaustivement face au catalogue extrait du code.
 
 #### tracking générique (automatique sur chaque page)
@@ -395,6 +395,7 @@ entreprise/accords.
 | ----------------------- | ------------------------------- | --------------------------------- | ---------------- |
 | enterprise_search       | `Nom du contexte`               | 🔀 `{"query":…,"apiGeoResult":…}` | Soumission du formulaire de recherche d'entreprise. |
 | enterprise_select       | `Nom du contexte`               | 🔀 `{"label":…,"siren":…}`        | Sélection d'une entreprise (ou auto-sélection si convention unique). |
+| cc_enterprise_search    | show_agreements                 | 📌 `<count>`                      | Affichage des conventions collectives d'une entreprise ; `name` = nombre trouvé, **`"0"` compris** quand l'entreprise n'en déclare aucune. Émis une seule fois par entreprise, sur tous les parcours (simulateurs, contributions, page dédiée, widget). Mesure la distribution 0 / 1 / N CC par entreprise et le taux d'échec de la recherche par SIRET, que les events au clic ci-dessus ne captent pas (ils ignorent les abandons). |
 | cc_select_p2            | `Nom du contexte`               | 🔀 `idcc<num>`                    | Validation de la CC rattachée à l'entreprise. |
 | view_step_cc_search_p2  | back_step_cc_search_p2          | 📌 Trouver sa convention collective | Clic « Précédent » à l'étape recherche par entreprise. |
 | cc_search_type_of_users | click_je_n_ai_pas_d_entreprise  | 📌 Trouver sa convention collective | Carte « assistants maternels / particuliers employeurs » en mode lien → fiche CC 3239 (clic sortant). |

--- a/packages/code-du-travail-stats/events/events.extracted.json
+++ b/packages/code-du-travail-stats/events/events.extracted.json
@@ -1,8 +1,8 @@
 {
   "scan_root": "packages/code-du-travail-frontend/src",
-  "callsites": 75,
-  "total_events": 112,
-  "unique_events": 103,
+  "callsites": 76,
+  "total_events": 113,
+  "unique_events": 104,
   "unresolved_callsites": 0,
   "events": [
     {
@@ -120,13 +120,27 @@
       "tracking_method": "sendEvent"
     },
     {
+      "category": "cc_enterprise_search",
+      "action": "show_agreements",
+      "name_pattern": "<String(count)>",
+      "resolution": "literal",
+      "emit_function": "emitShowAgreements",
+      "file": "packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/tracking.ts",
+      "line": 45,
+      "enum_refs": [
+        "TrackingAgreementSearchCategory.CC_ENTERPRISE_SEARCH",
+        "TrackingEnterpriseAgreementSearchAction.SHOW_AGREEMENTS"
+      ],
+      "tracking_method": "sendEvent"
+    },
+    {
       "category": "cc_search_type_of_users",
       "action": "click_je_n_ai_pas_d_entreprise",
       "name_pattern": "Trouver sa convention collective",
       "resolution": "literal",
       "emit_function": "emitNoEnterpriseClickEvent",
       "file": "packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/tracking.ts",
-      "line": 52,
+      "line": 69,
       "enum_refs": [
         "TrackingAgreementSearchAction.AGREEMENT_SEARCH",
         "TrackingAgreementSearchAction.CLICK_NO_COMPANY",
@@ -155,7 +169,7 @@
       "resolution": "literal",
       "emit_function": "emitNavigateAgreementSearchEvent",
       "file": "packages/code-du-travail-frontend/src/modules/convention-collective/tracking.ts",
-      "line": 35,
+      "line": 36,
       "enum_refs": [
         "TrackingAgreementSearchAction.AGREEMENT_SEARCH",
         "TrackingAgreementSearchAction.CLICK_P1",
@@ -198,7 +212,7 @@
       "resolution": "literal",
       "emit_function": "emitNavigateEnterpriseSearchEvent",
       "file": "packages/code-du-travail-frontend/src/modules/convention-collective/tracking.ts",
-      "line": 43,
+      "line": 44,
       "enum_refs": [
         "TrackingAgreementSearchAction.AGREEMENT_SEARCH",
         "TrackingAgreementSearchAction.CLICK_P2",
@@ -255,7 +269,7 @@
       "resolution": "literal",
       "emit_function": "emitNoEnterpriseSelectEvent",
       "file": "packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/tracking.ts",
-      "line": 59,
+      "line": 76,
       "enum_refs": [
         "TrackingAgreementSearchAction.AGREEMENT_SEARCH",
         "TrackingAgreementSearchAction.SELECT_NO_COMPANY",
@@ -284,7 +298,7 @@
       "resolution": "dynamic",
       "emit_function": "emitSelectEvent",
       "file": "packages/code-du-travail-frontend/src/modules/convention-collective/tracking.ts",
-      "line": 51,
+      "line": 52,
       "enum_refs": [
         "TrackingAgreementSearchCategory.CC_SELECT_P1"
       ],
@@ -375,7 +389,7 @@
       "resolution": "literal",
       "emit_function": "emitSelectEvent",
       "file": "packages/code-du-travail-frontend/src/modules/convention-collective/tracking.ts",
-      "line": 51,
+      "line": 52,
       "enum_refs": [
         "TrackingAgreementSearchCategory.CC_SELECT_P1"
       ],
@@ -388,7 +402,7 @@
       "resolution": "dynamic",
       "emit_function": "emitSelectEnterpriseAgreementEvent",
       "file": "packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/tracking.ts",
-      "line": 36,
+      "line": 53,
       "enum_refs": [
         "TrackingAgreementSearchCategory.CC_SELECT_P2"
       ],
@@ -479,7 +493,7 @@
       "resolution": "literal",
       "emit_function": "emitSelectEnterpriseAgreementEvent",
       "file": "packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/tracking.ts",
-      "line": 36,
+      "line": 53,
       "enum_refs": [
         "TrackingAgreementSearchCategory.CC_SELECT_P2"
       ],
@@ -633,7 +647,7 @@
       "resolution": "dynamic",
       "emit_function": "emitEnterpriseAgreementSearchInputEvent",
       "file": "packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/tracking.ts",
-      "line": 14,
+      "line": 18,
       "enum_refs": [
         "JSON.stringify",
         "TrackingAgreementSearchCategory.ENTERPRISE_SEARCH"
@@ -647,7 +661,7 @@
       "resolution": "dynamic",
       "emit_function": "emitSelectEnterpriseEvent",
       "file": "packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/tracking.ts",
-      "line": 28,
+      "line": 32,
       "enum_refs": [
         "JSON.stringify",
         "TrackingAgreementSearchCategory.CC_ENTERPRISE_SELECT"
@@ -1196,7 +1210,7 @@
       "resolution": "literal",
       "emit_function": "emitViewStepEvent",
       "file": "packages/code-du-travail-frontend/src/modules/convention-collective/tracking.ts",
-      "line": 27,
+      "line": 28,
       "enum_refs": [
         "TrackingAgreementSearchAction.AGREEMENT_SEARCH"
       ],
@@ -1464,7 +1478,7 @@
       "resolution": "literal",
       "emit_function": "emitPreviousEvent",
       "file": "packages/code-du-travail-frontend/src/modules/convention-collective/tracking.ts",
-      "line": 59,
+      "line": 60,
       "enum_refs": [
         "TrackingAgreementSearchAction.AGREEMENT_SEARCH",
         "TrackingAgreementSearchAction.BACK_STEP_P1",
@@ -1479,7 +1493,7 @@
       "resolution": "literal",
       "emit_function": "emitPreviousEvent",
       "file": "packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/tracking.ts",
-      "line": 44,
+      "line": 61,
       "enum_refs": [
         "TrackingAgreementSearchAction.AGREEMENT_SEARCH",
         "TrackingAgreementSearchAction.BACK_STEP_P2",


### PR DESCRIPTION
Closes #7428

## Le besoin

On sait combien d'**accords d'entreprise** on trouve pour un SIRET (`accord_enterprise_search / show_accords`), mais pas combien de **conventions collectives**. Impossible aujourd'hui de mesurer la distribution 0 / 1 / N CC par entreprise, ni le taux d'entreprises sans CC déclarée — alors que c'est le cas d'échec le plus structurant du parcours p2.

Les events existants ne répondent pas : `enterprise_select` et `cc_select_p2` partent **au clic**, donc ignorent les abandons.

## L'event

| | |
|---|---|
| category | `cc_enterprise_search` |
| action | `show_agreements` |
| name | le nombre de CC trouvées, `"0"` compris |

Calqué sur `show_accords` : **seul le nombre est envoyé**, ni SIRET ni liste d'IDCC.

## Où il est émis

À l'affichage des résultats, sur **tous** les parcours : les 7 simulateurs, les contributions, la page dédiée « Trouver sa convention collective » et le widget.

Deux points d'appel, sur des pages disjointes (donc aucun double comptage) :

- `EnterpriseAgreementSearchInput` — simulateurs et contributions
- `EnterpriseAgreementSelectionLink` — page dédiée et widget

Dans le premier, l'event part d'un `useEffect` branché sur **l'entreprise sélectionnée**, et non sur le formulaire de sélection : celui-ci est court-circuité dès qu'une convention est retenue (auto-sélection des entreprises à une seule CC). On capte ainsi uniformément les cas 0, 1 et N.

Une garde par SIRET évite les doublons : le composant se re-rend à chaque changement de radio, et l'entreprise est re-posée par l'effet miroir de la prop.

## Comportement

| Situation | Event |
|---|---|
| Entreprise à 2 CC | `"2"`, une seule fois |
| L'usager hésite et change de radio 3 fois | aucun event supplémentaire |
| Entreprise sans CC déclarée | `"0"` |
| Entreprise à 1 CC (auto-sélection) | `"1"` |
| Re-sélection de la même entreprise | aucun event |
| Sélection d'une autre entreprise | nouvel event |

Un remontage (retour sur l'étape CC d'un simulateur) ré-émet l'event — cohérent avec « à l'affichage » et avec le comportement de `show_accords`, à garder en tête à la lecture dans Matomo.

## Tests

Nouveau fichier `ShowAgreementsTracking.test.tsx` : 0 / 1 / N CC, absence de doublon au changement de convention, nouvel event au changement d'entreprise, et les deux surfaces.

Deux tests existants adaptés :
- `AgreementSelection.test.tsx` — le compteur est remis à zéro avant le clic pour continuer à mesurer ce que déclenche le clic seul
- `contribution-generic.tracking.test.tsx` — l'event ferme la séquence du parcours p2 (il part d'un effet, donc après les gestionnaires de clic)

## Vérifications

`type-check`, `lint --quiet`, `format:check`, `test:frontend` (418 suites, 1881 tests) et `events:check` passent. Le catalogue `events.extracted.json` et le `TRACKING_PLAN.md` sont à jour.