### PR TITLE
fix(outils): bouton Suivant grisé au retour sur l'étape Informations

### DIFF
--- a/packages/code-du-travail-frontend/src/modules/outils/indemnite-depart/steps/Informations/store/store.ts
+++ b/packages/code-du-travail-frontend/src/modules/outils/indemnite-depart/steps/Informations/store/store.ts
@@ -91,6 +91,7 @@ const createCommonInformationsStore: StoreSlice<
                     info: undefined,
                   },
                 ];
+                state.informationsData.input.hasNoMissingQuestions = false;
                 if (type === IndemniteDepartType.RUPTURE_CONVENTIONNELLE) {
                   state.informationsData.input.isStepHidden = false;
                 }
@@ -104,6 +105,8 @@ const createCommonInformationsStore: StoreSlice<
             state.informationsData.input = {
               ...initialState(type).input,
               licenciementInaptitude: licenciementInaptitude,
+              // aucune question publicodes à poser : il ne manque plus rien
+              hasNoMissingQuestions: true,
             };
             state.informationsData.error = initialState(type).error;
           })
@@ -276,11 +279,15 @@ const createCommonInformationsStore: StoreSlice<
             : state.blockingNotification;
       }
 
+      const canProceed =
+        isValid && get().informationsData.input.hasNoMissingQuestions;
+
       set(
         produce((state: CommonInformationsStoreSlice) => {
-          state.informationsData.hasBeenSubmit = isValid ? false : true;
-          state.informationsData.isStepValid =
-            isValid && get().informationsData.input.hasNoMissingQuestions;
+          // hasBeenSubmit reste à true tant que l'étape bloque, sinon plus rien
+          // ne recalculerait isStepValid et le bouton resterait grisé
+          state.informationsData.hasBeenSubmit = !canProceed;
+          state.informationsData.isStepValid = canProceed;
           state.informationsData.error = errorState;
           state.informationsData.error.errorEligibility = errorEligibility;
         })
@@ -290,7 +297,7 @@ const createCommonInformationsStore: StoreSlice<
       }
       return errorEligibility
         ? ValidationResponse.NotEligible
-        : isValid
+        : canProceed
           ? ValidationResponse.Valid
           : ValidationResponse.NotValid;
     },

--- a/packages/code-du-travail-frontend/src/modules/outils/indemnite-licenciement/__tests__/navigation-etapes.test.tsx
+++ b/packages/code-du-travail-frontend/src/modules/outils/indemnite-licenciement/__tests__/navigation-etapes.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen } from "@testing-library/react";
+import { UserAction } from "../../common/utils/UserAction";
+import { CalculateurIndemniteLicenciement } from "../IndemniteLicenciementSimulator";
+import { ui } from "../../indemnite-depart/__tests__/ui";
+
+const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
+jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => undefined);
+
+const agreement16 = JSON.stringify({
+  num: 16,
+  shortTitle: "Transports routiers et activités auxiliaires du transport",
+  id: "KALICONT000005635624",
+  title: "Transports routiers et activités auxiliaires du transport",
+  url: "https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635624",
+  slug: "16-transports-routiers-et-activites-auxiliaires-du-transport",
+});
+
+describe("Indemnité licenciement - Navigation entre les étapes", () => {
+  let userAction: UserAction;
+
+  beforeEach(() => {
+    getItemSpy.mockReturnValue(null);
+    userAction = new UserAction();
+  });
+
+  describe("sans convention collective renseignée", () => {
+    test(`Le bouton Suivant reste actif quand on revient sur l'étape Informations avec Précédent`, () => {
+      render(<CalculateurIndemniteLicenciement title={""} />);
+
+      userAction
+        .click(ui.introduction.startButton.get())
+        .click(ui.agreement.noAgreement.get())
+        .click(ui.next.get());
+      expect(ui.activeStep.query()).toHaveTextContent("Informations");
+
+      userAction
+        .click(ui.information.inaptitude.non.get())
+        .click(ui.next.get());
+      expect(ui.activeStep.query()).toHaveTextContent("Ancienneté");
+
+      // On revient sur l'étape Informations : le bouton Suivant doit rester cliquable
+      userAction.click(ui.previous.get());
+      expect(ui.activeStep.query()).toHaveTextContent("Informations");
+      expect(ui.next.get()).toBeEnabled();
+
+      // et on doit pouvoir repartir en avant
+      userAction.click(ui.next.get());
+      expect(ui.activeStep.query()).toHaveTextContent("Ancienneté");
+    });
+
+    test(`Le bouton Suivant reste actif sur toutes les étapes quand on les remonte avec Précédent`, () => {
+      render(<CalculateurIndemniteLicenciement title={""} />);
+
+      userAction
+        .click(ui.introduction.startButton.get())
+        .click(ui.agreement.noAgreement.get())
+        .click(ui.next.get())
+        .click(ui.information.inaptitude.non.get())
+        .click(ui.next.get())
+        .setInput(ui.seniority.startDate.get(), "01/01/2018")
+        .setInput(ui.seniority.notificationDate.get(), "01/01/2024")
+        .setInput(ui.seniority.endDate.get(), "01/01/2024")
+        .click(ui.next.get())
+        .click(ui.absences.arretTravail.non.get())
+        .click(ui.absences.hasAbsence.non.get())
+        .click(ui.next.get())
+        .click(ui.salary.hasSameSalary.oui.get())
+        .setInput(ui.salary.sameSalaryValue.get(), "2500")
+        .click(ui.next.get());
+      expect(ui.activeStep.query()).toHaveTextContent("Indemnité");
+
+      // Remontée étape par étape : Suivant doit être actif partout
+      const etapesRemontees = [
+        "Salaires",
+        "Absences",
+        "Ancienneté",
+        "Informations",
+        "Convention collective",
+      ];
+      etapesRemontees.forEach((etape) => {
+        userAction.click(ui.previous.get());
+        expect(ui.activeStep.query()).toHaveTextContent(etape);
+        expect(ui.next.get()).toBeEnabled();
+      });
+
+      // Redescente : on doit pouvoir aller jusqu'au résultat sans ressaisir
+      const etapesRedescendues = [
+        "Informations",
+        "Ancienneté",
+        "Absences",
+        "Salaires",
+        "Indemnité",
+      ];
+      etapesRedescendues.forEach((etape) => {
+        userAction.click(ui.next.get());
+        expect(ui.activeStep.query()).toHaveTextContent(etape);
+      });
+    });
+  });
+
+  describe("avec une convention collective couverte (IDCC 16)", () => {
+    beforeEach(() => {
+      getItemSpy.mockReturnValue(agreement16);
+    });
+
+    test(`Le bouton Suivant reste bloqué tant qu'une question publicodes est sans réponse, puis reste actif au retour`, async () => {
+      render(<CalculateurIndemniteLicenciement title={""} />);
+
+      userAction.click(ui.introduction.startButton.get()).click(ui.next.get());
+      expect(ui.activeStep.query()).toHaveTextContent("Informations");
+
+      // Le garde-fou reste en place : on ne passe pas sans avoir tout répondu
+      userAction.click(ui.next.get());
+      expect(ui.activeStep.query()).toHaveTextContent("Informations");
+      expect(ui.next.get()).toBeDisabled();
+      expect(
+        screen.queryAllByText("Vous devez répondre à cette question").length
+      ).toBeGreaterThan(0);
+
+      userAction.click(ui.information.inaptitude.non.get());
+      await userAction.changeInputList(
+        ui.information.agreement16.proCategory.get(),
+        "Ingénieurs et cadres"
+      );
+      userAction
+        .click(ui.information.agreement16.proCategoryHasChanged.oui.get())
+        .setInput(
+          ui.information.agreement16.dateProCategoryChanged.get(),
+          "01/01/2010"
+        )
+        .setInput(ui.information.agreement16.engineerAge.get(), "38")
+        .click(ui.next.get());
+      expect(ui.activeStep.query()).toHaveTextContent("Ancienneté");
+
+      // Retour sur l'étape : le bouton Suivant doit rester cliquable
+      userAction.click(ui.previous.get());
+      expect(ui.activeStep.query()).toHaveTextContent("Informations");
+      expect(ui.next.get()).toBeEnabled();
+
+      userAction.click(ui.next.get());
+      expect(ui.activeStep.query()).toHaveTextContent("Ancienneté");
+    });
+  });
+});

--- a/packages/code-du-travail-frontend/src/modules/outils/preavis-retraite/__tests__/navigation-etapes.spec.tsx
+++ b/packages/code-du-travail-frontend/src/modules/outils/preavis-retraite/__tests__/navigation-etapes.spec.tsx
@@ -1,0 +1,31 @@
+import { render } from "@testing-library/react";
+import { UserAction } from "../../common/utils/UserAction";
+import { CalculateurPreavisRetraite } from "../PreavisRetraiteSimulator";
+import { ui } from "./ui";
+
+test(`Le bouton Suivant reste actif quand on revient sur l'étape Informations avec Précédent`, () => {
+  render(<CalculateurPreavisRetraite title="Préavis de retraite" />);
+  const userAction = new UserAction();
+
+  userAction
+    .click(ui.introduction.startButton.get())
+    .click(ui.contract.originDepart.depart.get())
+    .click(ui.next.get())
+    .click(ui.agreement.noAgreement.get())
+    .click(ui.next.get());
+  expect(ui.activeStep.query()).toHaveTextContent("Informations");
+
+  userAction
+    .click(ui.information.handicap.answerNon.get())
+    .click(ui.next.get());
+  expect(ui.activeStep.query()).toHaveTextContent("Ancienneté");
+
+  // On revient sur l'étape Informations : le bouton Suivant doit rester cliquable
+  userAction.click(ui.previous.get());
+  expect(ui.activeStep.query()).toHaveTextContent("Informations");
+  expect(ui.next.get()).toBeEnabled();
+
+  // et on doit pouvoir repartir en avant
+  userAction.click(ui.next.get());
+  expect(ui.activeStep.query()).toHaveTextContent("Ancienneté");
+});

--- a/packages/code-du-travail-frontend/src/modules/outils/preavis-retraite/__tests__/ui.ts
+++ b/packages/code-du-travail-frontend/src/modules/outils/preavis-retraite/__tests__/ui.ts
@@ -110,4 +110,6 @@ export const ui = {
     echelon: byTestId("situation-Échelon"),
   },
   next: byText("Suivant"),
+  previous: byText("Précédent"),
+  activeStep: byTestId("stepper"),
 };

--- a/packages/code-du-travail-frontend/src/modules/outils/preavis-retraite/steps/Informations/store/store.ts
+++ b/packages/code-du-travail-frontend/src/modules/outils/preavis-retraite/steps/Informations/store/store.ts
@@ -67,13 +67,18 @@ const createCommonInformationsStore: StoreSliceWrapperPreavisRetraite<
                   info: undefined,
                 },
               ];
+              state.informationsData.input.hasNoMissingQuestions = false;
             })
           );
           return true;
         }
         set(
           produce((state: InformationsStoreSlice) => {
-            state.informationsData.input = initialState.input;
+            state.informationsData.input = {
+              ...initialState.input,
+              // aucune question publicodes à poser : il ne manque plus rien
+              hasNoMissingQuestions: true,
+            };
             state.informationsData.error = initialState.error;
           })
         );
@@ -180,15 +185,20 @@ const createCommonInformationsStore: StoreSliceWrapperPreavisRetraite<
       const state = get().informationsData.input;
       const originDepartState = get().originDepartData.input;
       const { isValid, errorState } = validateStep(state, originDepartState);
+      const canProceed =
+        isValid && get().informationsData.input.hasNoMissingQuestions;
       set(
         produce((state: InformationsStoreSlice) => {
-          state.informationsData.hasBeenSubmit = isValid ? false : true;
-          state.informationsData.isStepValid =
-            isValid && get().informationsData.input.hasNoMissingQuestions;
+          // hasBeenSubmit reste à true tant que l'étape bloque, sinon plus rien
+          // ne recalculerait isStepValid et le bouton resterait grisé
+          state.informationsData.hasBeenSubmit = !canProceed;
+          state.informationsData.isStepValid = canProceed;
           state.informationsData.error = errorState;
         })
       );
-      return isValid ? ValidationResponse.Valid : ValidationResponse.NotValid;
+      return canProceed
+        ? ValidationResponse.Valid
+        : ValidationResponse.NotValid;
     },
   },
 });


### PR DESCRIPTION
Closes #7444

## Le bug

Sur l'**indemnité de licenciement**, à l'étape « Informations » : on répond à la question sur l'inaptitude, on clique sur **Suivant** (on avance bien), puis sur **Précédent** — et le bouton **Suivant** est grisé. Définitivement : même en changeant la réponse. La simulation est bloquée, il faut recharger la page et tout ressaisir.

Sont concernés tous les parcours où l'étape n'a aucune question publicodes, c'est-à-dire **sans convention collective renseignée ou avec une CC non couverte** pour l'indemnité de licenciement.

## Cause

Dans `indemnite-depart/steps/Informations/store/store.ts`, `onNextStep` posait

```ts
state.informationsData.hasBeenSubmit = isValid ? false : true;
state.informationsData.isStepValid =
  isValid && get().informationsData.input.hasNoMissingQuestions;
...
return errorEligibility ? NotEligible : isValid ? Valid : NotValid;
```

Deux défauts qui se combinent :

1. **`hasNoMissingQuestions` restait à `false` alors qu'il n'y a aucune question à poser.** Quand publicodes n'en génère aucune, `generatePublicodesQuestions` réinitialisait `input` avec `initialState(type).input`, où le drapeau vaut `false`. Or il signifie « il ne reste plus de question à poser » : il devrait valoir `true`.
2. **`isStepValid` et la valeur de retour n'étaient pas d'accord.** On renvoyait `Valid` (donc on avançait) tout en marquant l'étape invalide. Et comme `hasBeenSubmit` repassait à `false`, plus rien ne recalculait `isStepValid` : `SimulatorLayout` gardait le bouton grisé.

## Correctif

- `generatePublicodesQuestions` pose désormais explicitement `hasNoMissingQuestions` dans ses **deux** branches : `false` s'il reste une question (évite un `true` périmé quand on change de CC ou qu'on bascule la réponse inaptitude), `true` quand il n'y en a aucune.
- `onNextStep` calcule `canProceed = isValid && hasNoMissingQuestions` et l'utilise pour `isStepValid`, pour `hasBeenSubmit` (`!canProceed`, comme le fait déjà l'étape Salaires — l'état ne peut plus se figer) et pour la valeur de retour. Le garde-fou est conservé, il bloque maintenant réellement au lieu de corrompre l'état.

C'est le pattern déjà en place dans `preavis-demission/steps/Informations/store/store.ts`.

## Audit des autres étapes

Balayage de tous les `onNextStep` des stores d'étapes des 7 simulateurs :

| Store | `isStepValid` | Valeur de retour | Verdict |
|---|---|---|---|
| indemnite-depart · **Informations** | `isValid && hasNoMissingQuestions` | `isValid` | **incohérent → le bug** |
| preavis-retraite · **Informations** | `isValid && hasNoMissingQuestions` | `isValid` | **même code** |
| indemnite-depart · Convention collective / Ancienneté / Absences | `isValid` | `isValid` | OK |
| indemnite-depart · Salaires | `isValid && isAgreementValid` | idem | OK |
| preavis-demission / preavis-licenciement / heures-recherche-emploi · Informations | `canProceed` | `canProceed` | OK (référence) |
| indemnite-precarite, preavis-retraite (Origine/CC/Ancienneté), preavis-licenciement (Statut) | `isValid` | `isValid` | OK |

Seuls ces 2 fichiers portaient l'incohérence, les deux sont corrigés ici.

À noter : sur **préavis retraite** le bug n'est pas atteignable aujourd'hui (l'étape pose toujours au moins la question « travailleur handicapé », même sans CC). Le code est aligné pour supprimer le piège, pas pour corriger un symptôme visible. `rupture-conventionnelle` partage le store `indemnite-depart` mais masque l'étape quand il n'y a pas de question — non touchée, et protégée par le correctif.

## Tests

`indemnite-licenciement/__tests__/navigation-etapes.test.tsx` (nouveau, testing-library) :

1. **Reproduction du bug** — sans CC, aller-retour Suivant/Précédent sur l'étape Informations. Rouge avant le correctif, vert après.
2. **Balayage de toutes les étapes** — parcours complet jusqu'au résultat, remontée avec Précédent en vérifiant que Suivant est actif à chaque étape, puis redescente jusqu'au résultat sans ressaisie. Rouge avant le correctif, vert après.
3. **Non-régression du garde-fou** — avec la CC 16 : le bouton reste bien bloqué tant qu'une question publicodes est sans réponse, et reste actif au retour une fois tout rempli.

`preavis-retraite/__tests__/navigation-etapes.spec.tsx` (nouveau) : aller-retour sur l'étape Informations. Ce test passe déjà avant le correctif — il garde le passage à `canProceed`, il ne reproduit pas de bug visible.

### Vérifications

- `jest src/modules/outils/{indemnite-licenciement,indemnite-depart,preavis-retraite,rupture-conventionnelle}` → **64 suites / 190 tests, tous verts**
- suite frontend complète → 372 suites vertes ; les 49 suites rouges (48 `indemnite-precarite` + 1 `IntegrationDetailContent`) **sont déjà rouges sur `dev`**, vérifié en rejouant la même commande sans le correctif : chiffres identiques
- `tsc --noEmit` → 0 erreur · `eslint` → 0 erreur · prettier → OK · catalogue d'events Matomo inchangé
