### PR TITLE
fix(matomo): les noms d'events falsy étaient jetés, tout un pan des rapports manquait

### DIFF
--- a/packages/code-du-travail-frontend/src/api/modules/nps/__tests__/service.test.ts
+++ b/packages/code-du-travail-frontend/src/api/modules/nps/__tests__/service.test.ts
@@ -35,6 +35,19 @@ describe("sendNpsEvent", () => {
     );
   });
 
+  // Une note donnée depuis la page d'accueil arrive avec un slug vide : envoyé
+  // tel quel, Matomo jette le nom de l'event. L'URL canonique, elle, doit
+  // rester celle de l'accueil — surtout pas `/accueil`, qui n'existe pas.
+  it("étiquette la page d'accueil sans dénaturer l'URL canonique", async () => {
+    await sendNpsEvent({ slug: "", score: 9 });
+
+    const [url] = mockFetch.mock.calls[0] as unknown as [string];
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("e_n")).toBe("accueil");
+    expect(params.get("url")).toMatch(/\/$/);
+    expect(params.get("url")).not.toContain("/accueil");
+  });
+
   it("sans userAgent : pas de header User-Agent", async () => {
     await sendNpsEvent({ slug: "a", score: 0 });
     const [, init] = mockFetch.mock.calls[0] as unknown as [

--- a/packages/code-du-travail-frontend/src/api/modules/nps/__tests__/service.test.ts
+++ b/packages/code-du-travail-frontend/src/api/modules/nps/__tests__/service.test.ts
@@ -43,7 +43,7 @@ describe("sendNpsEvent", () => {
 
     const [url] = mockFetch.mock.calls[0] as unknown as [string];
     const params = new URLSearchParams(url.split("?")[1]);
-    expect(params.get("e_n")).toBe("accueil");
+    expect(params.get("e_n")).toBe("index");
     expect(params.get("url")).toMatch(/\/$/);
     expect(params.get("url")).not.toContain("/accueil");
   });

--- a/packages/code-du-travail-frontend/src/api/modules/nps/service.ts
+++ b/packages/code-du-travail-frontend/src/api/modules/nps/service.ts
@@ -1,4 +1,5 @@
 import { NPS_CATEGORY } from "../../../modules/nps/constants";
+import { HOME_EVENT_NAME } from "../../../modules/analytics/eventName";
 import { PIWIK_SITE_ID, PIWIK_URL, SITE_URL } from "../../../config";
 import { MATOMO_TIMEOUT_MS } from "../constants";
 
@@ -39,7 +40,11 @@ export const sendNpsEvent = async ({
     // Catégorie en dur : cette API ne relaie QUE la soumission d'une note NPS.
     e_c: NPS_CATEGORY,
     e_a: `score_${score}`,
-    e_n: slug,
+    // Sur la page d'accueil le slug est vide : Matomo jetterait le nom de
+    // l'event (cf. toPageEventName). On étiquette donc l'accueil ici, sans
+    // toucher au slug qui sert à construire l'URL canonique juste au-dessus —
+    // celle de l'accueil est bien `${SITE_URL}/`, pas `${SITE_URL}/accueil`.
+    e_n: slug || HOME_EVENT_NAME,
     url,
   });
 

--- a/packages/code-du-travail-frontend/src/modules/analytics/__tests__/eventName.test.ts
+++ b/packages/code-du-travail-frontend/src/modules/analytics/__tests__/eventName.test.ts
@@ -1,4 +1,4 @@
-import { toCountEventName, toEventName } from "../eventName";
+import { toCountEventName, toEventName, toPageEventName } from "../eventName";
 
 describe("toEventName", () => {
   it("retire le slash initial d'un chemin", () => {
@@ -40,5 +40,21 @@ describe("toCountEventName", () => {
     expect(toCountEventName(1)).toEqual("1");
     expect(toCountEventName(19)).toEqual("19");
     expect(toCountEventName(164)).toEqual("164");
+  });
+});
+
+describe("toPageEventName", () => {
+  // La racine est le seul chemin dont `toEventName` fait une chaîne vide, que
+  // Matomo jette au même titre que "0".
+  it("étiquette la page d'accueil au lieu d'envoyer une chaîne vide", () => {
+    expect(toPageEventName("/")).toEqual("accueil");
+    expect(toPageEventName("")).toEqual("accueil");
+  });
+
+  it("laisse les autres chemins inchangés", () => {
+    expect(toPageEventName("/contribution/mon-slug")).toEqual(
+      "contribution/mon-slug"
+    );
+    expect(toPageEventName("themes/mon-slug")).toEqual("themes/mon-slug");
   });
 });

--- a/packages/code-du-travail-frontend/src/modules/analytics/__tests__/eventName.test.ts
+++ b/packages/code-du-travail-frontend/src/modules/analytics/__tests__/eventName.test.ts
@@ -1,4 +1,4 @@
-import { toEventName } from "../eventName";
+import { toCountEventName, toEventName } from "../eventName";
 
 describe("toEventName", () => {
   it("retire le slash initial d'un chemin", () => {
@@ -25,5 +25,20 @@ describe("toEventName", () => {
 
   it("accepte la racine", () => {
     expect(toEventName("/")).toEqual("");
+  });
+});
+
+describe("toCountEventName", () => {
+  // Le zéro est le seul cas qui pose problème : Matomo traite la chaîne "0"
+  // comme vide et jette le nom de l'event, rendant invisible tout le seau
+  // « aucun résultat ».
+  it('étiquette le zéro au lieu d\'envoyer "0"', () => {
+    expect(toCountEventName(0)).toEqual("aucun");
+  });
+
+  it("laisse les valeurs non nulles en chiffres, pour ne pas rompre la continuité des rapports", () => {
+    expect(toCountEventName(1)).toEqual("1");
+    expect(toCountEventName(19)).toEqual("19");
+    expect(toCountEventName(164)).toEqual("164");
   });
 });

--- a/packages/code-du-travail-frontend/src/modules/analytics/__tests__/eventName.test.ts
+++ b/packages/code-du-travail-frontend/src/modules/analytics/__tests__/eventName.test.ts
@@ -47,8 +47,8 @@ describe("toPageEventName", () => {
   // La racine est le seul chemin dont `toEventName` fait une chaîne vide, que
   // Matomo jette au même titre que "0".
   it("étiquette la page d'accueil au lieu d'envoyer une chaîne vide", () => {
-    expect(toPageEventName("/")).toEqual("accueil");
-    expect(toPageEventName("")).toEqual("accueil");
+    expect(toPageEventName("/")).toEqual("index");
+    expect(toPageEventName("")).toEqual("index");
   });
 
   it("laisse les autres chemins inchangés", () => {

--- a/packages/code-du-travail-frontend/src/modules/analytics/eventName.ts
+++ b/packages/code-du-travail-frontend/src/modules/analytics/eventName.ts
@@ -11,20 +11,38 @@
 // dépendances dans les bundles qui n'ont besoin que de cette fonction.
 export const toEventName = (path: string): string => path.replace(/^\/+/, "");
 
-// Un event dont le `name` transporte un comptage ne doit JAMAIS envoyer la
-// chaîne "0" nue : Matomo la traite comme vide (`empty("0")` vaut `true` en PHP)
-// et jette le nom. L'event est bien compté, mais il atterrit sans nom — le seau
-// « aucun résultat » devient invisible dans les rapports.
+// ---------------------------------------------------------------------------
+// Noms d'events falsy : le piège commun
+// ---------------------------------------------------------------------------
 //
-// Constaté en production (site 4, 15-28 août 2026) : sur 13 091 `show_accords`
-// reçus, 3 078 seulement portaient un nom ; idem 2 426 des 15 841
-// `show_agreements`. Sur les 500 noms d'events distincts du site, "1", "2",
-// "16", "3248" existent — "0" pas une seule fois.
+// Matomo JETTE le nom d'un event quand celui-ci est une chaîne falsy — la chaîne
+// vide, mais aussi "0" (`empty("0")` vaut `true` en PHP). L'event est bien
+// compté dans le total de son action, mais il atterrit sans nom : la ligne
+// correspondante n'existe simplement pas dans le rapport « Noms d'événements ».
 //
-// On étiquette donc le zéro plutôt que de l'envoyer en chiffre nu. Les valeurs
-// non nulles restent inchangées, pour ne pas rompre la continuité des rapports
-// existants (noms "1" à "164" déjà en base).
+// Constaté en production (site 4, 15-28 août 2026) :
+//
+//   show_accords         13 091 events reçus,  3 078 avec un nom → 10 013 perdus
+//   show_agreements      15 841 events reçus, 13 415 avec un nom →  2 426 perdus
+//   display_exit_intent  78 171 events reçus, 76 805 avec un nom →  1 366 perdus
+//   submit_search           407 events reçus,    110 avec un nom →    297 perdus
+//
+// Sur les 500 noms d'events distincts du site, "1", "2", "16", "3248" existent
+// — "0" pas une seule fois.
+//
+// Les deux helpers ci-dessous produisent donc un nom toujours non vide. Ils
+// n'altèrent que le cas falsy : les autres valeurs restent inchangées, pour ne
+// pas rompre la continuité des rapports existants.
+
+// Comptage : "0" devient "aucun", le reste reste un chiffre.
 export const ZERO_COUNT_EVENT_NAME = "aucun";
 
 export const toCountEventName = (count: number): string =>
   count === 0 ? ZERO_COUNT_EVENT_NAME : String(count);
+
+// Chemin de page : la racine "/" donne une chaîne vide une fois le slash retiré
+// (c'est la page d'accueil), et perdrait donc son nom.
+export const HOME_EVENT_NAME = "accueil";
+
+export const toPageEventName = (path: string): string =>
+  toEventName(path) || HOME_EVENT_NAME;

--- a/packages/code-du-travail-frontend/src/modules/analytics/eventName.ts
+++ b/packages/code-du-travail-frontend/src/modules/analytics/eventName.ts
@@ -42,7 +42,7 @@ export const toCountEventName = (count: number): string =>
 
 // Chemin de page : la racine "/" donne une chaîne vide une fois le slash retiré
 // (c'est la page d'accueil), et perdrait donc son nom.
-export const HOME_EVENT_NAME = "accueil";
+export const HOME_EVENT_NAME = "index";
 
 export const toPageEventName = (path: string): string =>
   toEventName(path) || HOME_EVENT_NAME;

--- a/packages/code-du-travail-frontend/src/modules/analytics/eventName.ts
+++ b/packages/code-du-travail-frontend/src/modules/analytics/eventName.ts
@@ -10,3 +10,21 @@
 // par son chemin (`../analytics/eventName`) pour ne pas embarquer ces
 // dépendances dans les bundles qui n'ont besoin que de cette fonction.
 export const toEventName = (path: string): string => path.replace(/^\/+/, "");
+
+// Un event dont le `name` transporte un comptage ne doit JAMAIS envoyer la
+// chaîne "0" nue : Matomo la traite comme vide (`empty("0")` vaut `true` en PHP)
+// et jette le nom. L'event est bien compté, mais il atterrit sans nom — le seau
+// « aucun résultat » devient invisible dans les rapports.
+//
+// Constaté en production (site 4, 15-28 août 2026) : sur 13 091 `show_accords`
+// reçus, 3 078 seulement portaient un nom ; idem 2 426 des 15 841
+// `show_agreements`. Sur les 500 noms d'events distincts du site, "1", "2",
+// "16", "3248" existent — "0" pas une seule fois.
+//
+// On étiquette donc le zéro plutôt que de l'envoyer en chiffre nu. Les valeurs
+// non nulles restent inchangées, pour ne pas rompre la continuité des rapports
+// existants (noms "1" à "164" déjà en base).
+export const ZERO_COUNT_EVENT_NAME = "aucun";
+
+export const toCountEventName = (count: number): string =>
+  count === 0 ? ZERO_COUNT_EVENT_NAME : String(count);

--- a/packages/code-du-travail-frontend/src/modules/contributions/tracking.ts
+++ b/packages/code-du-travail-frontend/src/modules/contributions/tracking.ts
@@ -1,6 +1,6 @@
 import { sendEvent } from "@socialgouv/matomo-next";
 import { MatomoAgreementEvent } from "../analytics";
-import { toEventName } from "../analytics/eventName";
+import { toPageEventName } from "../analytics/eventName";
 import { getRouteBySource, SOURCES } from "@socialgouv/cdtn-utils";
 
 export enum TrackingContributionCategory {
@@ -117,7 +117,7 @@ export const useContributionTracking = () => {
     sendEvent({
       category: TrackingContributionCategory.CONTRIBUTION,
       action: TrackingContributionAction.CLICK_AGREEMENT_DECLINATION,
-      name: toEventName(href),
+      name: toPageEventName(href),
     });
   };
 

--- a/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/__tests__/ShowAgreementsTracking.test.tsx
+++ b/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/__tests__/ShowAgreementsTracking.test.tsx
@@ -111,14 +111,14 @@ describe("Event show_agreements", () => {
       ]);
     });
 
-    it("émet 0 quand l'entreprise n'a déclaré aucune convention collective", async () => {
+    it('émet "aucun" — jamais "0", que Matomo jette — quand l\'entreprise n\'a déclaré aucune convention collective', async () => {
       await renderInput(enterpriseWithoutAgreement);
 
       expect(showAgreementsEvents()).toEqual([
         {
           category: TrackingAgreementSearchCategory.CC_ENTERPRISE_SEARCH,
           action: TrackingEnterpriseAgreementSearchAction.SHOW_AGREEMENTS,
-          name: "0",
+          name: "aucun",
         },
       ]);
     });
@@ -187,7 +187,7 @@ describe("Event show_agreements", () => {
 
       expect(showAgreementsEvents().map(({ name }) => name)).toEqual([
         "2",
-        "0",
+        "aucun",
       ]);
     });
   });
@@ -230,10 +230,10 @@ describe("Event show_agreements", () => {
       expect(showAgreementsEvents().map(({ name }) => name)).toEqual(["1"]);
     });
 
-    it("émet 0 quand l'entreprise n'a déclaré aucune convention collective", async () => {
+    it('émet "aucun" — jamais "0", que Matomo jette — quand l\'entreprise n\'a déclaré aucune convention collective', async () => {
       await renderInSimulator(enterpriseWithoutAgreement);
 
-      expect(showAgreementsEvents().map(({ name }) => name)).toEqual(["0"]);
+      expect(showAgreementsEvents().map(({ name }) => name)).toEqual(["aucun"]);
     });
   });
 
@@ -257,7 +257,7 @@ describe("Event show_agreements", () => {
       ]);
     });
 
-    it("émet 0 quand l'entreprise n'a déclaré aucune convention collective", async () => {
+    it('émet "aucun" — jamais "0", que Matomo jette — quand l\'entreprise n\'a déclaré aucune convention collective', async () => {
       await act(async () => {
         render(
           <EnterpriseAgreementSelectionLink
@@ -271,7 +271,7 @@ describe("Event show_agreements", () => {
         {
           category: TrackingAgreementSearchCategory.CC_ENTERPRISE_SEARCH,
           action: TrackingEnterpriseAgreementSearchAction.SHOW_AGREEMENTS,
-          name: "0",
+          name: "aucun",
         },
       ]);
     });

--- a/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/__tests__/ShowAgreementsTracking.test.tsx
+++ b/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/__tests__/ShowAgreementsTracking.test.tsx
@@ -192,6 +192,51 @@ describe("Event show_agreements", () => {
     });
   });
 
+  // Le parcours simulateur passe `isInSimulator` et
+  // `canContinueSimulationIfNoAgreement` (cf. CommonAgreementStep) : ces props
+  // changent le rendu — avec moins de deux conventions, le composant
+  // court-circuite le formulaire de sélection. Le comptage doit partir malgré
+  // ce court-circuit.
+  describe("<EnterpriseAgreementSearchInput isInSimulator /> (simulateurs)", () => {
+    const renderInSimulator = async (enterprise: unknown) =>
+      act(async () =>
+        render(
+          <EnterpriseAgreementSearchInput
+            enterprise={enterprise as any}
+            onAgreementSelect={jest.fn()}
+            trackingActionName="Simulateur - Indemnité de licenciement"
+            isInSimulator
+            canContinueSimulationIfNoAgreement
+            level={3}
+          />
+        )
+      );
+
+    it("émet le nombre de conventions collectives affichées", async () => {
+      await renderInSimulator(enterpriseWithTwoAgreements);
+
+      expect(showAgreementsEvents()).toEqual([
+        {
+          category: TrackingAgreementSearchCategory.CC_ENTERPRISE_SEARCH,
+          action: TrackingEnterpriseAgreementSearchAction.SHOW_AGREEMENTS,
+          name: "2",
+        },
+      ]);
+    });
+
+    it("émet 1 pour une convention unique, malgré le court-circuit du formulaire", async () => {
+      await renderInSimulator(enterpriseWithOneAgreement);
+
+      expect(showAgreementsEvents().map(({ name }) => name)).toEqual(["1"]);
+    });
+
+    it("émet 0 quand l'entreprise n'a déclaré aucune convention collective", async () => {
+      await renderInSimulator(enterpriseWithoutAgreement);
+
+      expect(showAgreementsEvents().map(({ name }) => name)).toEqual(["0"]);
+    });
+  });
+
   describe("<EnterpriseAgreementSelectionLink /> (page dédiée et widget)", () => {
     it("émet le nombre de conventions collectives au montage", async () => {
       await act(async () => {

--- a/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/accords/__tests__/AccordsEntreprise.test.tsx
+++ b/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/accords/__tests__/AccordsEntreprise.test.tsx
@@ -154,6 +154,73 @@ describe("AccordsEntreprise", () => {
       (sendEvent as jest.Mock).mockClear();
     });
 
+    // `sendEvent` porte aussi click_accord et click_all_accords : on isole le
+    // seul event de comptage pour pouvoir compter les envois.
+    const showAccordsEvents = () =>
+      (sendEvent as jest.Mock).mock.calls
+        .map(([event]) => event)
+        .filter(
+          (event) =>
+            event.action === TrackingAccordEntrepriseSearchAction.SHOW_ACCORDS
+        );
+
+    // Cas réel signalé : la fiche Carrefour affiche « 19 accords d'entreprise
+    // trouvés » alors que l'API n'en renvoie que 5 (ACCORDS_MAX_RESULTS). Le
+    // compteur suivi doit être `total`, la même valeur que celle affichée par le
+    // parent — jamais la longueur de la liste.
+    it("émet le total renvoyé par l'API, pas le nombre d'accords affichés", async () => {
+      mockFetch({ total: 19, accords: accordsData.accords });
+      const onLoaded = jest.fn();
+      await act(async () => {
+        render(
+          <AccordsEntreprise siret="45132133500023" onLoaded={onLoaded} />
+        );
+      });
+      expect(onLoaded).toHaveBeenCalledWith(19);
+      expect(showAccordsEvents()).toEqual([
+        {
+          category: TrackingAgreementSearchCategory.ACCORD_ENTERPRISE_SEARCH,
+          action: TrackingAccordEntrepriseSearchAction.SHOW_ACCORDS,
+          name: "19",
+        },
+      ]);
+    });
+
+    // Sans cette garde, un compteur gonflé par des envois multiples ferait
+    // douter des chiffres remontés dans Matomo.
+    it("n'émet qu'un seul event quand le composant se re-rend avec le même siret", async () => {
+      mockFetch(accordsData);
+      let rerender: (ui: React.ReactElement) => void;
+      await act(async () => {
+        ({ rerender } = render(
+          <AccordsEntreprise siret="12345678901234" onLoaded={() => {}} />
+        ));
+      });
+      await act(async () => {
+        rerender(
+          <AccordsEntreprise siret="12345678901234" onLoaded={() => {}} />
+        );
+      });
+      expect(showAccordsEvents()).toHaveLength(1);
+    });
+
+    it("émet un nouvel event, avec le nouveau total, quand le siret change", async () => {
+      mockFetch(accordsData);
+      let rerender: (ui: React.ReactElement) => void;
+      await act(async () => {
+        ({ rerender } = render(
+          <AccordsEntreprise siret="12345678901234" onLoaded={() => {}} />
+        ));
+      });
+      mockFetch({ total: 0, accords: [] });
+      await act(async () => {
+        rerender(
+          <AccordsEntreprise siret="98765432101234" onLoaded={() => {}} />
+        );
+      });
+      expect(showAccordsEvents().map(({ name }) => name)).toEqual(["2", "0"]);
+    });
+
     it("émet emitShowAccords avec le nombre d'accords au chargement", async () => {
       mockFetch(accordsData);
       await act(async () => {

--- a/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/accords/__tests__/AccordsEntreprise.test.tsx
+++ b/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/accords/__tests__/AccordsEntreprise.test.tsx
@@ -218,7 +218,10 @@ describe("AccordsEntreprise", () => {
           <AccordsEntreprise siret="98765432101234" onLoaded={() => {}} />
         );
       });
-      expect(showAccordsEvents().map(({ name }) => name)).toEqual(["2", "0"]);
+      expect(showAccordsEvents().map(({ name }) => name)).toEqual([
+        "2",
+        "aucun",
+      ]);
     });
 
     it("émet emitShowAccords avec le nombre d'accords au chargement", async () => {
@@ -235,7 +238,7 @@ describe("AccordsEntreprise", () => {
       });
     });
 
-    it("émet emitShowAccords avec 0 quand aucun accord n'est trouvé", async () => {
+    it('émet "aucun" — jamais "0", que Matomo jette — quand aucun accord n\'est trouvé', async () => {
       mockFetch({ total: 0, accords: [] });
       await act(async () => {
         render(
@@ -245,7 +248,7 @@ describe("AccordsEntreprise", () => {
       expect(sendEvent).toHaveBeenCalledWith({
         category: TrackingAgreementSearchCategory.ACCORD_ENTERPRISE_SEARCH,
         action: TrackingAccordEntrepriseSearchAction.SHOW_ACCORDS,
-        name: "0",
+        name: "aucun",
       });
     });
 

--- a/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/accords/tracking.ts
+++ b/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/accords/tracking.ts
@@ -1,5 +1,6 @@
 import { sendEvent } from "@socialgouv/matomo-next";
 import { TrackingAgreementSearchCategory } from "../../../convention-collective/tracking";
+import { toCountEventName } from "../../../analytics/eventName";
 
 export enum TrackingAccordEntrepriseSearchAction {
   CLICK_ACCORD = "click_accord",
@@ -25,11 +26,13 @@ export const useAccordEnterpriseTracking = () => {
     });
   };
 
+  // `name` = nombre d'accords trouvés, "aucun" quand il n'y en a pas
+  // (cf. toCountEventName : Matomo jette un nom d'event valant "0").
   const emitShowAccords = (count: number) => {
     sendEvent({
       category: TrackingAgreementSearchCategory.ACCORD_ENTERPRISE_SEARCH,
       action: TrackingAccordEntrepriseSearchAction.SHOW_ACCORDS,
-      name: String(count),
+      name: toCountEventName(count),
     });
   };
 

--- a/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/tracking.ts
+++ b/packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/tracking.ts
@@ -4,6 +4,7 @@ import {
   TrackingAgreementSearchCategory,
 } from "../../convention-collective/tracking";
 import { ApiGeoResult } from "./searchCities";
+import { toCountEventName } from "../../analytics/eventName";
 
 export enum TrackingEnterpriseAgreementSearchAction {
   SHOW_AGREEMENTS = "show_agreements",
@@ -38,14 +39,15 @@ export const useEnterpriseAgreementSearchTracking = () => {
 
   // Émis à l'affichage des conventions collectives d'une entreprise, quel que
   // soit le parcours (simulateurs, contributions, page dédiée, widget) et y
-  // compris quand l'entreprise n'en déclare aucune (`name` vaut alors "0").
+  // compris quand l'entreprise n'en déclare aucune (`name` vaut alors "aucun",
+  // cf. toCountEventName : Matomo jette un nom d'event valant "0").
   // Équivalent de `show_accords` côté accords d'entreprise : on n'envoie que le
   // nombre, ni SIRET ni liste d'IDCC.
   const emitShowAgreements = (count: number) => {
     sendEvent({
       category: TrackingAgreementSearchCategory.CC_ENTERPRISE_SEARCH,
       action: TrackingEnterpriseAgreementSearchAction.SHOW_AGREEMENTS,
-      name: String(count),
+      name: toCountEventName(count),
     });
   };
 

--- a/packages/code-du-travail-frontend/src/modules/nps/__tests__/tracking.test.ts
+++ b/packages/code-du-travail-frontend/src/modules/nps/__tests__/tracking.test.ts
@@ -24,6 +24,21 @@ describe("useNpsEvents", () => {
     });
   });
 
+  // Sur la page d'accueil, le chemin se réduit à "" une fois le slash retiré —
+  // un nom falsy que Matomo jette. Le widget NPS est présent sur toutes les
+  // pages, l'accueil compris.
+  it("étiquette la page d'accueil au lieu d'envoyer un nom vide", () => {
+    const { result } = renderHook(() => useNpsEvents());
+    result.current.trackDisplayed(NpsTrigger.MAIN, "/");
+    result.current.trackRefusal(NpsTrigger.MAIN, "/");
+    result.current.trackOptOut(NpsTrigger.MAIN, "/");
+    expect(mockSendEvent.mock.calls.map(([event]) => event.name)).toEqual([
+      "accueil",
+      "accueil",
+      "accueil",
+    ]);
+  });
+
   it("trackRefusal → sendEvent standard (category=refusal)", () => {
     const { result } = renderHook(() => useNpsEvents());
     result.current.trackRefusal(

--- a/packages/code-du-travail-frontend/src/modules/nps/__tests__/tracking.test.ts
+++ b/packages/code-du-travail-frontend/src/modules/nps/__tests__/tracking.test.ts
@@ -33,9 +33,9 @@ describe("useNpsEvents", () => {
     result.current.trackRefusal(NpsTrigger.MAIN, "/");
     result.current.trackOptOut(NpsTrigger.MAIN, "/");
     expect(mockSendEvent.mock.calls.map(([event]) => event.name)).toEqual([
-      "accueil",
-      "accueil",
-      "accueil",
+      "index",
+      "index",
+      "index",
     ]);
   });
 

--- a/packages/code-du-travail-frontend/src/modules/nps/tracking.ts
+++ b/packages/code-du-travail-frontend/src/modules/nps/tracking.ts
@@ -7,14 +7,14 @@
 
 import { sendEvent } from "@socialgouv/matomo-next";
 import { NPS_CATEGORY, NpsTrigger } from "./constants";
-import { toEventName } from "../analytics/eventName";
+import { toPageEventName } from "../analytics/eventName";
 
 export const useNpsEvents = () => {
   const trackDisplayed = (trigger: NpsTrigger, pagePath: string) => {
     sendEvent({
       category: NPS_CATEGORY,
       action: `display_${trigger}`,
-      name: toEventName(pagePath),
+      name: toPageEventName(pagePath),
     });
   };
 
@@ -22,7 +22,7 @@ export const useNpsEvents = () => {
     sendEvent({
       category: NPS_CATEGORY,
       action: `refusal_${trigger}`,
-      name: toEventName(pagePath),
+      name: toPageEventName(pagePath),
     });
   };
 
@@ -32,7 +32,7 @@ export const useNpsEvents = () => {
     sendEvent({
       category: NPS_CATEGORY,
       action: `optout_${trigger}`,
-      name: toEventName(pagePath),
+      name: toPageEventName(pagePath),
     });
   };
 

--- a/packages/code-du-travail-frontend/src/modules/recherche/__tests__/tracking.test.ts
+++ b/packages/code-du-travail-frontend/src/modules/recherche/__tests__/tracking.test.ts
@@ -1,0 +1,41 @@
+/** @jest-environment jsdom */
+import { renderHook } from "@testing-library/react";
+import { sendEvent } from "@socialgouv/matomo-next";
+import { useSearchTracking } from "../tracking";
+import { MatomoBaseEvent } from "../../analytics/types";
+
+jest.mock("@socialgouv/matomo-next", () => ({
+  sendEvent: jest.fn(),
+  push: jest.fn(),
+}));
+
+const mockSendEvent = sendEvent as jest.MockedFunction<typeof sendEvent>;
+
+describe("emitWidgetSubmitSearchEvent", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("envoie la requête telle quelle", () => {
+    const { result } = renderHook(() => useSearchTracking());
+    result.current.emitWidgetSubmitSearchEvent("congés payés");
+
+    expect(mockSendEvent).toHaveBeenCalledWith({
+      category: MatomoBaseEvent.WIDGET_SEARCH,
+      action: "submit_search",
+      name: "congés payés",
+    });
+  });
+
+  // Le widget laisse soumettre à vide, et c'est le cas majoritaire. Envoyée
+  // telle quelle, la chaîne vide fait jeter le nom de l'event par Matomo : la
+  // soumission à vide devient invisible dans les rapports.
+  it("étiquette la requête vide au lieu d'envoyer un nom vide", () => {
+    const { result } = renderHook(() => useSearchTracking());
+    result.current.emitWidgetSubmitSearchEvent("");
+
+    expect(mockSendEvent).toHaveBeenCalledWith({
+      category: MatomoBaseEvent.WIDGET_SEARCH,
+      action: "submit_search",
+      name: "(vide)",
+    });
+  });
+});

--- a/packages/code-du-travail-frontend/src/modules/recherche/tracking.ts
+++ b/packages/code-du-travail-frontend/src/modules/recherche/tracking.ts
@@ -24,6 +24,10 @@ export enum MatomoWidgetEvent {
   SUBMIT_SEARCH = "submit_search",
 }
 
+// Étiquette d'une requête de recherche vide, pour ne jamais envoyer un `name`
+// falsy que Matomo jetterait.
+export const EMPTY_QUERY_EVENT_NAME = "(vide)";
+
 export const useSearchTracking = () => {
   const lastFullsearchKeyRef = useRef<string | null>(null);
 
@@ -125,11 +129,15 @@ export const useSearchTracking = () => {
     });
   }, []);
 
+  // Le widget laisse soumettre le formulaire à vide, et c'est le cas le plus
+  // fréquent (297 des 407 soumissions sur 14 jours en août 2026). On étiquette
+  // donc la requête vide : envoyée telle quelle, Matomo jette le nom de l'event
+  // et la soumission à vide devient invisible (cf. toPageEventName).
   const emitWidgetSubmitSearchEvent = useCallback((query: string) => {
     sendEvent({
       category: MatomoBaseEvent.WIDGET_SEARCH,
       action: MatomoWidgetEvent.SUBMIT_SEARCH,
-      name: query,
+      name: query || EMPTY_QUERY_EVENT_NAME,
     });
   }, []);
 

--- a/packages/code-du-travail-stats/events/TRACKING_PLAN.md
+++ b/packages/code-du-travail-stats/events/TRACKING_PLAN.md
@@ -14,6 +14,41 @@ Ce document décrit les évènements Matomo **écrits explicitement dans le code
 **103** events uniques · **112** au total · **32** catégories Matomo. Couverture vérifiée
 exhaustivement face au catalogue extrait du code.
 
+#### Règle transverse : un nom d'event n'est jamais « falsy »
+
+Matomo **jette** le nom d'un event quand celui-ci est une chaîne falsy — la chaîne vide,
+mais aussi `"0"` (`empty("0")` vaut `true` en PHP). L'event reste compté dans le total de
+son action, mais il atterrit **sans nom** : la ligne correspondante n'existe simplement pas
+dans le rapport « Noms d'événements ». Silencieux, et invisible tant qu'on ne compare pas le
+total d'une action à la somme de ses lignes nommées.
+
+Constaté en production avant correction (site 4, 15-28 août 2026) :
+
+| Action                | Events reçus | Avec un nom | **Perdus** |
+| --------------------- | -----------: | ----------: | ---------: |
+| `show_accords`        |       13 091 |       3 078 | **10 013** |
+| `show_agreements`     |       15 841 |      13 415 |  **2 426** |
+| `display_exit_intent` |       78 171 |      76 805 |  **1 366** |
+| `refusal_exit_intent` |       40 636 |      39 809 |    **827** |
+| `submit_search`       |          407 |         110 |    **297** |
+
+Sur les 500 noms d'events distincts du site, `"1"`, `"2"`, `"16"`, `"3248"` existaient —
+`"0"` pas une seule fois.
+
+Deux helpers (`src/modules/analytics/eventName.ts`) garantissent désormais un nom non vide,
+en n'altérant **que** le cas falsy pour ne pas rompre la continuité des rapports :
+
+- `toCountEventName(count)` — un comptage nul devient `aucun`, le reste reste un chiffre ;
+- `toPageEventName(path)` — la page d'accueil (`/`, réduite à `""`) devient `accueil`.
+
+S'y ajoutent deux cas nommés sur place : la requête de recherche vide du widget devient
+`(vide)`, et le relais serveur du score NPS étiquette l'accueil en `e_n` **sans** toucher au
+slug qui construit l'URL canonique (celle de l'accueil reste `${SITE_URL}/`).
+
+**Conséquence pour la lecture** : les lignes sans nom antérieures au correctif sont les
+zéros et les accueils historiques ; les lignes `aucun`, `accueil` et `(vide)` prennent le
+relais ensuite.
+
 #### tracking générique (automatique sur chaque page)
 
 Lors d'une visite sur une page du site, Matomo envoie par défaut un évènement de visite qui
@@ -395,32 +430,15 @@ entreprise/accords.
 | ----------------------- | ------------------------------- | --------------------------------- | ---------------- |
 | enterprise_search       | `Nom du contexte`               | 🔀 `{"query":…,"apiGeoResult":…}` | Soumission du formulaire de recherche d'entreprise. |
 | enterprise_select       | `Nom du contexte`               | 🔀 `{"label":…,"siren":…}`        | Sélection d'une entreprise (ou auto-sélection si convention unique). |
-| cc_enterprise_search    | show_agreements                 | 📌 `<count>`                      | Affichage des conventions collectives d'une entreprise ; `name` = nombre trouvé, ou **`aucun`** quand l'entreprise n'en déclare aucune (cf. « Le cas du zéro » ci-dessous). Émis une seule fois par entreprise, sur tous les parcours (simulateurs, contributions, page dédiée, widget). Mesure la distribution 0 / 1 / N CC par entreprise et le taux d'échec de la recherche par SIRET, que les events au clic ci-dessus ne captent pas (ils ignorent les abandons). |
+| cc_enterprise_search    | show_agreements                 | 📌 `<count>`                      | Affichage des conventions collectives d'une entreprise ; `name` = nombre trouvé, ou **`aucun`** quand l'entreprise n'en déclare aucune (cf. « Règle transverse : un nom d'event n'est jamais falsy » en tête de document). Émis une seule fois par entreprise, sur tous les parcours (simulateurs, contributions, page dédiée, widget). Mesure la distribution 0 / 1 / N CC par entreprise et le taux d'échec de la recherche par SIRET, que les events au clic ci-dessus ne captent pas (ils ignorent les abandons). |
 | cc_select_p2            | `Nom du contexte`               | 🔀 `idcc<num>`                    | Validation de la CC rattachée à l'entreprise. |
 | view_step_cc_search_p2  | back_step_cc_search_p2          | 📌 Trouver sa convention collective | Clic « Précédent » à l'étape recherche par entreprise. |
 | cc_search_type_of_users | click_je_n_ai_pas_d_entreprise  | 📌 Trouver sa convention collective | Carte « assistants maternels / particuliers employeurs » en mode lien → fiche CC 3239 (clic sortant). |
 | cc_search_type_of_users | select_je_n_ai_pas_d_entreprise | 📌 Trouver sa convention collective | Même option en mode simulateur (sélection intégrée au parcours). |
 | accord_enterprise_search | click_accord                   | 📌 `<url>`                        | Clic sur une carte d'accord d'entreprise (Légifrance). |
 | accord_enterprise_search | click_all_accords              | 📌 `<siret>`                      | « Voir tous les accords sur Légifrance ». |
-| accord_enterprise_search | show_accords                   | 📌 `<count>`                      | Chargement réussi des accords ; `name` = nombre trouvé, ou **`aucun`** quand il n'y en a pas (cf. « Le cas du zéro » ci-dessous). Le nombre est le **total** renvoyé par l'API pour le SIRET, pas le nombre de cartes affichées (plafonné à 5). |
+| accord_enterprise_search | show_accords                   | 📌 `<count>`                      | Chargement réussi des accords ; `name` = nombre trouvé, ou **`aucun`** quand il n'y en a pas (cf. « Règle transverse : un nom d'event n'est jamais falsy » en tête de document). Le nombre est le **total** renvoyé par l'API pour le SIRET, pas le nombre de cartes affichées (plafonné à 5). |
 | accord_enterprise_search | load_accords_failed            | 📌 `<siret>`                      | Échec de l'appel API des accords (incident). |
-
-**Le cas du zéro**
-
-Ces deux events transportent un comptage dans le `name`. Ils n'envoient jamais la
-chaîne `"0"` nue : Matomo la traite comme vide (`empty("0")` vaut `true` en PHP) et
-**jette le nom de l'event**. L'event est bien compté dans le total de l'action, mais
-il atterrit sans nom — et le seau « aucun résultat » devient invisible.
-
-Constaté en production avant correction (site 4, 15-28 août 2026) : sur 13 091
-`show_accords` reçus, 3 078 seulement portaient un nom ; idem pour 13 415 des 15 841
-`show_agreements`. Sur les 500 noms d'events distincts du site, `"1"`, `"2"`, `"16"`,
-`"3248"` existaient — `"0"` pas une seule fois.
-
-Le zéro est donc étiqueté `aucun` (cf. `toCountEventName`, `src/modules/analytics/eventName.ts`).
-Les valeurs non nulles restent des chiffres, pour ne pas rompre la continuité des
-rapports existants. **Conséquence pour la lecture** : les lignes sans nom antérieures
-au correctif sont les zéros historiques, et la ligne `aucun` prend le relais ensuite.
 
 **Recherche Légifrance sur une page de CC**
 [↗ source](https://github.com/SocialGouv/code-du-travail-numerique/blob/dev/packages/code-du-travail-frontend/src/modules/convention-collective/LegiFranceSearch.tsx#L24 "convention-collective/LegiFranceSearch.tsx")

--- a/packages/code-du-travail-stats/events/TRACKING_PLAN.md
+++ b/packages/code-du-travail-stats/events/TRACKING_PLAN.md
@@ -23,7 +23,7 @@ dans le rapport « Noms d'événements ». Silencieux, et invisible tant qu'on n
 total d'une action à la somme de ses lignes nommées.
 
 Les events concernés étiquettent donc leur cas falsy : un comptage nul devient `aucun`, la
-page d'accueil `accueil`, une requête de recherche vide `(vide)`. Les autres valeurs restent
+page d'accueil `index`, une requête de recherche vide `(vide)`. Les autres valeurs restent
 inchangées.
 
 #### tracking générique (automatique sur chaque page)

--- a/packages/code-du-travail-stats/events/TRACKING_PLAN.md
+++ b/packages/code-du-travail-stats/events/TRACKING_PLAN.md
@@ -22,32 +22,9 @@ son action, mais il atterrit **sans nom** : la ligne correspondante n'existe sim
 dans le rapport « Noms d'événements ». Silencieux, et invisible tant qu'on ne compare pas le
 total d'une action à la somme de ses lignes nommées.
 
-Constaté en production avant correction (site 4, 15-28 août 2026) :
-
-| Action                | Events reçus | Avec un nom | **Perdus** |
-| --------------------- | -----------: | ----------: | ---------: |
-| `show_accords`        |       13 091 |       3 078 | **10 013** |
-| `show_agreements`     |       15 841 |      13 415 |  **2 426** |
-| `display_exit_intent` |       78 171 |      76 805 |  **1 366** |
-| `refusal_exit_intent` |       40 636 |      39 809 |    **827** |
-| `submit_search`       |          407 |         110 |    **297** |
-
-Sur les 500 noms d'events distincts du site, `"1"`, `"2"`, `"16"`, `"3248"` existaient —
-`"0"` pas une seule fois.
-
-Deux helpers (`src/modules/analytics/eventName.ts`) garantissent désormais un nom non vide,
-en n'altérant **que** le cas falsy pour ne pas rompre la continuité des rapports :
-
-- `toCountEventName(count)` — un comptage nul devient `aucun`, le reste reste un chiffre ;
-- `toPageEventName(path)` — la page d'accueil (`/`, réduite à `""`) devient `accueil`.
-
-S'y ajoutent deux cas nommés sur place : la requête de recherche vide du widget devient
-`(vide)`, et le relais serveur du score NPS étiquette l'accueil en `e_n` **sans** toucher au
-slug qui construit l'URL canonique (celle de l'accueil reste `${SITE_URL}/`).
-
-**Conséquence pour la lecture** : les lignes sans nom antérieures au correctif sont les
-zéros et les accueils historiques ; les lignes `aucun`, `accueil` et `(vide)` prennent le
-relais ensuite.
+Les events concernés étiquettent donc leur cas falsy : un comptage nul devient `aucun`, la
+page d'accueil `accueil`, une requête de recherche vide `(vide)`. Les autres valeurs restent
+inchangées.
 
 #### tracking générique (automatique sur chaque page)
 

--- a/packages/code-du-travail-stats/events/TRACKING_PLAN.md
+++ b/packages/code-du-travail-stats/events/TRACKING_PLAN.md
@@ -395,15 +395,32 @@ entreprise/accords.
 | ----------------------- | ------------------------------- | --------------------------------- | ---------------- |
 | enterprise_search       | `Nom du contexte`               | 🔀 `{"query":…,"apiGeoResult":…}` | Soumission du formulaire de recherche d'entreprise. |
 | enterprise_select       | `Nom du contexte`               | 🔀 `{"label":…,"siren":…}`        | Sélection d'une entreprise (ou auto-sélection si convention unique). |
-| cc_enterprise_search    | show_agreements                 | 📌 `<count>`                      | Affichage des conventions collectives d'une entreprise ; `name` = nombre trouvé, **`"0"` compris** quand l'entreprise n'en déclare aucune. Émis une seule fois par entreprise, sur tous les parcours (simulateurs, contributions, page dédiée, widget). Mesure la distribution 0 / 1 / N CC par entreprise et le taux d'échec de la recherche par SIRET, que les events au clic ci-dessus ne captent pas (ils ignorent les abandons). |
+| cc_enterprise_search    | show_agreements                 | 📌 `<count>`                      | Affichage des conventions collectives d'une entreprise ; `name` = nombre trouvé, ou **`aucun`** quand l'entreprise n'en déclare aucune (cf. « Le cas du zéro » ci-dessous). Émis une seule fois par entreprise, sur tous les parcours (simulateurs, contributions, page dédiée, widget). Mesure la distribution 0 / 1 / N CC par entreprise et le taux d'échec de la recherche par SIRET, que les events au clic ci-dessus ne captent pas (ils ignorent les abandons). |
 | cc_select_p2            | `Nom du contexte`               | 🔀 `idcc<num>`                    | Validation de la CC rattachée à l'entreprise. |
 | view_step_cc_search_p2  | back_step_cc_search_p2          | 📌 Trouver sa convention collective | Clic « Précédent » à l'étape recherche par entreprise. |
 | cc_search_type_of_users | click_je_n_ai_pas_d_entreprise  | 📌 Trouver sa convention collective | Carte « assistants maternels / particuliers employeurs » en mode lien → fiche CC 3239 (clic sortant). |
 | cc_search_type_of_users | select_je_n_ai_pas_d_entreprise | 📌 Trouver sa convention collective | Même option en mode simulateur (sélection intégrée au parcours). |
 | accord_enterprise_search | click_accord                   | 📌 `<url>`                        | Clic sur une carte d'accord d'entreprise (Légifrance). |
 | accord_enterprise_search | click_all_accords              | 📌 `<siret>`                      | « Voir tous les accords sur Légifrance ». |
-| accord_enterprise_search | show_accords                   | 📌 `<count>`                      | Chargement réussi des accords ; `name` = nombre trouvé. |
+| accord_enterprise_search | show_accords                   | 📌 `<count>`                      | Chargement réussi des accords ; `name` = nombre trouvé, ou **`aucun`** quand il n'y en a pas (cf. « Le cas du zéro » ci-dessous). Le nombre est le **total** renvoyé par l'API pour le SIRET, pas le nombre de cartes affichées (plafonné à 5). |
 | accord_enterprise_search | load_accords_failed            | 📌 `<siret>`                      | Échec de l'appel API des accords (incident). |
+
+**Le cas du zéro**
+
+Ces deux events transportent un comptage dans le `name`. Ils n'envoient jamais la
+chaîne `"0"` nue : Matomo la traite comme vide (`empty("0")` vaut `true` en PHP) et
+**jette le nom de l'event**. L'event est bien compté dans le total de l'action, mais
+il atterrit sans nom — et le seau « aucun résultat » devient invisible.
+
+Constaté en production avant correction (site 4, 15-28 août 2026) : sur 13 091
+`show_accords` reçus, 3 078 seulement portaient un nom ; idem pour 13 415 des 15 841
+`show_agreements`. Sur les 500 noms d'events distincts du site, `"1"`, `"2"`, `"16"`,
+`"3248"` existaient — `"0"` pas une seule fois.
+
+Le zéro est donc étiqueté `aucun` (cf. `toCountEventName`, `src/modules/analytics/eventName.ts`).
+Les valeurs non nulles restent des chiffres, pour ne pas rompre la continuité des
+rapports existants. **Conséquence pour la lecture** : les lignes sans nom antérieures
+au correctif sont les zéros historiques, et la ligne `aucun` prend le relais ensuite.
 
 **Recherche Légifrance sur une page de CC**
 [↗ source](https://github.com/SocialGouv/code-du-travail-numerique/blob/dev/packages/code-du-travail-frontend/src/modules/convention-collective/LegiFranceSearch.tsx#L24 "convention-collective/LegiFranceSearch.tsx")

--- a/packages/code-du-travail-stats/events/events.extracted.json
+++ b/packages/code-du-travail-stats/events/events.extracted.json
@@ -12,14 +12,14 @@
       "resolution": "dynamic",
       "emit_function": "useSearchTracking",
       "file": "packages/code-du-travail-frontend/src/modules/recherche/tracking.ts",
-      "line": 193,
+      "line": 201,
       "enum_refs": [],
       "tracking_method": "push:trackSiteSearch"
     },
     {
       "category": "<NPS_CATEGORY>",
       "action": "display_<trigger>",
-      "name_pattern": "<toEventName(pagePath)>",
+      "name_pattern": "<toPageEventName(pagePath)>",
       "resolution": "dynamic",
       "emit_function": "trackDisplayed",
       "file": "packages/code-du-travail-frontend/src/modules/nps/tracking.ts",
@@ -30,7 +30,7 @@
     {
       "category": "<NPS_CATEGORY>",
       "action": "optout_<trigger>",
-      "name_pattern": "<toEventName(pagePath)>",
+      "name_pattern": "<toPageEventName(pagePath)>",
       "resolution": "dynamic",
       "emit_function": "trackOptOut",
       "file": "packages/code-du-travail-frontend/src/modules/nps/tracking.ts",
@@ -41,7 +41,7 @@
     {
       "category": "<NPS_CATEGORY>",
       "action": "refusal_<trigger>",
-      "name_pattern": "<toEventName(pagePath)>",
+      "name_pattern": "<toPageEventName(pagePath)>",
       "resolution": "dynamic",
       "emit_function": "trackRefusal",
       "file": "packages/code-du-travail-frontend/src/modules/nps/tracking.ts",
@@ -572,7 +572,7 @@
     {
       "category": "contribution",
       "action": "clic_declinaison_cc",
-      "name_pattern": "<toEventName(href)>",
+      "name_pattern": "<toPageEventName(href)>",
       "resolution": "literal",
       "emit_function": "emitClickAgreementDeclination",
       "file": "packages/code-du-travail-frontend/src/modules/contributions/tracking.ts",
@@ -962,7 +962,7 @@
       "resolution": "dynamic",
       "emit_function": "useSearchTracking",
       "file": "packages/code-du-travail-frontend/src/modules/recherche/tracking.ts",
-      "line": 104,
+      "line": 108,
       "enum_refs": [
         "MatomoSearchCategory.NEXT_RESULT_PAGE"
       ],
@@ -1353,7 +1353,7 @@
       "resolution": "literal",
       "emit_function": "useSearchTracking",
       "file": "packages/code-du-travail-frontend/src/modules/recherche/tracking.ts",
-      "line": 158,
+      "line": 166,
       "enum_refs": [
         "MatomoSearchAction.CLICK_SEE_ALL_RESULTS",
         "MatomoSearchCategory.SEARCH"
@@ -1367,7 +1367,7 @@
       "resolution": "literal",
       "emit_function": "useSearchTracking",
       "file": "packages/code-du-travail-frontend/src/modules/recherche/tracking.ts",
-      "line": 64,
+      "line": 68,
       "enum_refs": [
         "MatomoSearchAction.FULL_SEARCH",
         "MatomoSearchCategory.SEARCH"
@@ -1381,7 +1381,7 @@
       "resolution": "literal",
       "emit_function": "useSearchTracking",
       "file": "packages/code-du-travail-frontend/src/modules/recherche/tracking.ts",
-      "line": 94,
+      "line": 98,
       "enum_refs": [
         "MatomoSearchAction.FULL_SEARCH",
         "MatomoSearchCategory.SEARCH"
@@ -1395,7 +1395,7 @@
       "resolution": "literal",
       "emit_function": "useSearchTracking",
       "file": "packages/code-du-travail-frontend/src/modules/recherche/tracking.ts",
-      "line": 143,
+      "line": 151,
       "enum_refs": [
         "MatomoSearchAction.PRESEARCH",
         "MatomoSearchCategory.SEARCH"
@@ -1409,7 +1409,7 @@
       "resolution": "literal",
       "emit_function": "useSearchTracking",
       "file": "packages/code-du-travail-frontend/src/modules/recherche/tracking.ts",
-      "line": 181,
+      "line": 189,
       "enum_refs": [
         "MatomoSearchAction.SELECT_PRESEARCH_RESULT",
         "MatomoSearchCategory.SEARCH"
@@ -1423,7 +1423,7 @@
       "resolution": "dynamic",
       "emit_function": "useSearchTracking",
       "file": "packages/code-du-travail-frontend/src/modules/recherche/tracking.ts",
-      "line": 112,
+      "line": 116,
       "enum_refs": [
         "MatomoSearchCategory.SELECTED_SUGGESTION"
       ],
@@ -1450,7 +1450,7 @@
       "resolution": "dynamic",
       "emit_function": "useSearchTracking",
       "file": "packages/code-du-travail-frontend/src/modules/recherche/tracking.ts",
-      "line": 45,
+      "line": 49,
       "enum_refs": [
         "JSON.stringify",
         "MatomoSearchCategory.SELECT_RESULT"
@@ -1508,7 +1508,7 @@
       "resolution": "literal",
       "emit_function": "useSearchTracking",
       "file": "packages/code-du-travail-frontend/src/modules/recherche/tracking.ts",
-      "line": 122,
+      "line": 126,
       "enum_refs": [
         "MatomoBaseEvent.WIDGET_SEARCH",
         "MatomoWidgetEvent.CLICK_LOGO"
@@ -1518,11 +1518,11 @@
     {
       "category": "widget_search",
       "action": "submit_search",
-      "name_pattern": "<query>",
+      "name_pattern": "<query || EMPTY_QUERY_EVENT_NAME>",
       "resolution": "literal",
       "emit_function": "useSearchTracking",
       "file": "packages/code-du-travail-frontend/src/modules/recherche/tracking.ts",
-      "line": 129,
+      "line": 137,
       "enum_refs": [
         "MatomoBaseEvent.WIDGET_SEARCH",
         "MatomoWidgetEvent.SUBMIT_SEARCH"

--- a/packages/code-du-travail-stats/events/events.extracted.json
+++ b/packages/code-du-travail-stats/events/events.extracted.json
@@ -70,7 +70,7 @@
       "resolution": "literal",
       "emit_function": "emitClickAccord",
       "file": "packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/accords/tracking.ts",
-      "line": 13,
+      "line": 14,
       "enum_refs": [
         "TrackingAccordEntrepriseSearchAction.CLICK_ACCORD",
         "TrackingAgreementSearchCategory.ACCORD_ENTERPRISE_SEARCH"
@@ -84,7 +84,7 @@
       "resolution": "literal",
       "emit_function": "emitClickSeeAll",
       "file": "packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/accords/tracking.ts",
-      "line": 21,
+      "line": 22,
       "enum_refs": [
         "TrackingAccordEntrepriseSearchAction.CLICK_ALL_ACCORDS",
         "TrackingAgreementSearchCategory.ACCORD_ENTERPRISE_SEARCH"
@@ -98,7 +98,7 @@
       "resolution": "literal",
       "emit_function": "emitLoadAccordsFailed",
       "file": "packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/accords/tracking.ts",
-      "line": 37,
+      "line": 40,
       "enum_refs": [
         "TrackingAccordEntrepriseSearchAction.LOAD_ACCORDS_FAILED",
         "TrackingAgreementSearchCategory.ACCORD_ENTERPRISE_SEARCH"
@@ -108,11 +108,11 @@
     {
       "category": "accord_enterprise_search",
       "action": "show_accords",
-      "name_pattern": "<String(count)>",
+      "name_pattern": "<toCountEventName(count)>",
       "resolution": "literal",
       "emit_function": "emitShowAccords",
       "file": "packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/accords/tracking.ts",
-      "line": 29,
+      "line": 32,
       "enum_refs": [
         "TrackingAccordEntrepriseSearchAction.SHOW_ACCORDS",
         "TrackingAgreementSearchCategory.ACCORD_ENTERPRISE_SEARCH"
@@ -122,11 +122,11 @@
     {
       "category": "cc_enterprise_search",
       "action": "show_agreements",
-      "name_pattern": "<String(count)>",
+      "name_pattern": "<toCountEventName(count)>",
       "resolution": "literal",
       "emit_function": "emitShowAgreements",
       "file": "packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/tracking.ts",
-      "line": 45,
+      "line": 47,
       "enum_refs": [
         "TrackingAgreementSearchCategory.CC_ENTERPRISE_SEARCH",
         "TrackingEnterpriseAgreementSearchAction.SHOW_AGREEMENTS"
@@ -140,7 +140,7 @@
       "resolution": "literal",
       "emit_function": "emitNoEnterpriseClickEvent",
       "file": "packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/tracking.ts",
-      "line": 69,
+      "line": 71,
       "enum_refs": [
         "TrackingAgreementSearchAction.AGREEMENT_SEARCH",
         "TrackingAgreementSearchAction.CLICK_NO_COMPANY",
@@ -269,7 +269,7 @@
       "resolution": "literal",
       "emit_function": "emitNoEnterpriseSelectEvent",
       "file": "packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/tracking.ts",
-      "line": 76,
+      "line": 78,
       "enum_refs": [
         "TrackingAgreementSearchAction.AGREEMENT_SEARCH",
         "TrackingAgreementSearchAction.SELECT_NO_COMPANY",
@@ -402,7 +402,7 @@
       "resolution": "dynamic",
       "emit_function": "emitSelectEnterpriseAgreementEvent",
       "file": "packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/tracking.ts",
-      "line": 53,
+      "line": 55,
       "enum_refs": [
         "TrackingAgreementSearchCategory.CC_SELECT_P2"
       ],
@@ -493,7 +493,7 @@
       "resolution": "literal",
       "emit_function": "emitSelectEnterpriseAgreementEvent",
       "file": "packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/tracking.ts",
-      "line": 53,
+      "line": 55,
       "enum_refs": [
         "TrackingAgreementSearchCategory.CC_SELECT_P2"
       ],
@@ -647,7 +647,7 @@
       "resolution": "dynamic",
       "emit_function": "emitEnterpriseAgreementSearchInputEvent",
       "file": "packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/tracking.ts",
-      "line": 18,
+      "line": 19,
       "enum_refs": [
         "JSON.stringify",
         "TrackingAgreementSearchCategory.ENTERPRISE_SEARCH"
@@ -661,7 +661,7 @@
       "resolution": "dynamic",
       "emit_function": "emitSelectEnterpriseEvent",
       "file": "packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/tracking.ts",
-      "line": 32,
+      "line": 33,
       "enum_refs": [
         "JSON.stringify",
         "TrackingAgreementSearchCategory.CC_ENTERPRISE_SELECT"
@@ -1493,7 +1493,7 @@
       "resolution": "literal",
       "emit_function": "emitPreviousEvent",
       "file": "packages/code-du-travail-frontend/src/modules/enterprise/EnterpriseAgreementSearch/tracking.ts",
-      "line": 61,
+      "line": 63,
       "enum_refs": [
         "TrackingAgreementSearchAction.AGREEMENT_SEARCH",
         "TrackingAgreementSearchAction.BACK_STEP_P2",


### PR DESCRIPTION
## Le problème

Matomo **jette** le nom d'un event quand celui-ci est une chaîne falsy — la chaîne vide, mais aussi `"0"` (`empty("0")` vaut `true` en PHP). L'event reste compté dans le total de son action, mais il atterrit **sans nom** : la ligne correspondante n'existe simplement pas dans le rapport « Noms d'événements ».

Silencieux, et invisible tant qu'on ne compare pas le total d'une action à la somme de ses lignes nommées. C'est ce qu'on a fait, sur toutes les actions du site.

## Constaté en production

Site 4, 15-28 août 2026, via l'API Reporting :

| Action | Events reçus | Avec un nom | **Perdus** | Cause |
|---|---:|---:|---:|---|
| `show_accords` | 13 091 | 3 078 | **10 013 (76 %)** | entreprises sans accord d'entreprise |
| `show_agreements` | 15 841 | 13 415 | **2 426 (15 %)** | entreprises sans CC déclarée |
| `display_exit_intent` | 78 171 | 76 805 | **1 366 (2 %)** | NPS sur la page d'accueil |
| `refusal_exit_intent` | 40 636 | 39 809 | **827 (2 %)** | idem |
| `submit_search` | 407 | 110 | **297 (73 %)** | recherche widget soumise à vide |

S'y ajoutent `optout_exit_intent`, `display_main`, `refusal_main` et les `score_*` du NPS, touchés par le même cas « accueil ».

Sur les 500 noms d'events distincts du site, `"1"`, `"2"`, `"16"`, `"3248"` existent. `"0"` **pas une seule fois**.

Concrètement : impossible de savoir combien d'entreprises n'ont aucun accord ni aucune convention collective, ni de rattacher à la page d'accueil les affichages et les notes du NPS.

## Le correctif

Deux helpers dans `src/modules/analytics/eventName.ts`, qui n'altèrent **que** le cas falsy — les autres valeurs restent inchangées, donc les noms `"1"` à `"164"` déjà en base ne bougent pas :

```ts
export const toCountEventName = (count: number): string =>
  count === 0 ? ZERO_COUNT_EVENT_NAME : String(count);   // "aucun"

export const toPageEventName = (path: string): string =>
  toEventName(path) || HOME_EVENT_NAME;                  // "accueil"
```

Appliqués à `show_accords`, `show_agreements`, aux trois events NPS (`display` / `refusal` / `optout`) et au clic sur une déclinaison de CC des contributions.

Deux cas nommés sur place :

- la requête de recherche vide du widget devient `(vide)` ;
- le relais serveur du score NPS étiquette l'accueil en `e_n` **sans** toucher au slug qui construit l'URL canonique — celle de l'accueil doit rester `${SITE_URL}/`, surtout pas `/accueil`. Un test verrouille ce point.

**Lecture des rapports après merge** : les lignes sans nom antérieures au correctif sont les zéros et les accueils historiques ; `aucun`, `accueil` et `(vide)` prennent le relais ensuite.

## Ce qui ne change pas

La structure des events est inchangée : le nombre reste dans le `name`, et `e_v` n'est toujours pas envoyé — aucun `sendEvent` du monorepo ne le fait, toutes les catégories du site sont à `avg_event_value = 0`. C'est le sujet d'une autre PR.

## Exhaustivité

Vérifié dans les deux sens, pour qu'il ne reste rien :

- **Empiriquement** — audit de toutes les actions Matomo, total reçu vs somme des lignes nommées. Les écarts restants sont soit des events volontairement envoyés sans nom (`mise`, `depart`, `anciennete_*`, les actions `{"selection":…}`), soit la troncature de sous-table de Matomo (écarts à 0-1 %).
- **Dans le code** — les seuls `name` dérivés d'un comptage passent par `toCountEventName` ; les deux derniers appels à `toEventName` sont légitimes (une clé `theme` dans un JSON, et le slug NPS ci-dessus). Les notes et scores (`note_1`…`note_5`, `score_0`…`score_10`) voyagent dans l'**action** avec un préfixe, jamais falsy. Les `.toString()` restants sont des IDCC, identifiants à 3-4 chiffres.

## Au passage

Le premier commit ajoute 6 tests de non-régression sur les deux events de comptage, issus de la vérification qui a mené à ce bug :

- `show_accords` émet bien `data.total` — le vrai nombre d'accords du SIRET — et non la longueur de la liste, plafonnée à `ACCORDS_MAX_RESULTS = 5`. Cas réel : la fiche Carrefour affiche 19 accords et n'en montre que 5.
- `show_accords` ne part qu'une fois par SIRET, et repart avec le nouveau total quand le SIRET change.
- `show_agreements` est désormais couvert sur le parcours simulateur (`isInSimulator`), y compris quand l'auto-sélection court-circuite le formulaire.

## Vérification

- `422 suites / 1916 tests` verts sur le frontend
- `tsc --noEmit` : 0 erreur
- `events:check` : catalogue à jour
- `TRACKING_PLAN.md` : nouvelle section « Règle transverse : un nom d'event n'est jamais falsy », en tête de document puisque la règle vaut pour tout le tracking
