### PR TITLE
fix(contributions): hiérarchie de titres cassée sans réponse Code du travail

### DIFF
--- a/packages/code-du-travail-frontend/src/modules/contributions/ContributionAgreementDeclinations.tsx
+++ b/packages/code-du-travail-frontend/src/modules/contributions/ContributionAgreementDeclinations.tsx
@@ -12,6 +12,14 @@ export const AGREEMENT_DECLINATIONS_LABEL =
 type Props = {
   items: AgreementDeclination[];
   className?: string;
+  /**
+   * Niveau du titre de l'accordéon. Par défaut `h3` : le bloc est alors rendu
+   * sous la réponse Code du travail, qui porte le `h2` de la page. Sur une
+   * contribution sans réponse générique (`isNoCDT`) ce `h2` n'existe pas et la
+   * liste suit directement le `h1` : elle doit passer en `h2` pour ne pas
+   * casser la hiérarchie des titres (#7458).
+   */
+  titleAs?: "h2" | "h3";
 };
 
 /**
@@ -23,6 +31,7 @@ type Props = {
 export const ContributionAgreementDeclinations = ({
   items,
   className,
+  titleAs = "h3",
 }: Props) => {
   const { emitClickAgreementDeclination } = useContributionTracking();
 
@@ -33,7 +42,7 @@ export const ContributionAgreementDeclinations = ({
   return (
     <Accordion
       label={AGREEMENT_DECLINATIONS_LABEL}
-      titleAs="h3"
+      titleAs={titleAs}
       className={className}
     >
       <ListWithArrow

--- a/packages/code-du-travail-frontend/src/modules/contributions/ContributionGeneric.tsx
+++ b/packages/code-du-travail-frontend/src/modules/contributions/ContributionGeneric.tsx
@@ -145,10 +145,14 @@ export function ContributionGeneric({
           générique n'est pas rendu, la liste des déclinaisons par CC est donc
           affichée directement sous le formulaire de sélection. Elle ferme alors
           la page : `fr-mb-6w` reprend la marge basse que porte habituellement
-          le bloc générique, sans quoi l'accordéon colle au pied de page. */}
+          le bloc générique, sans quoi l'accordéon colle au pied de page.
+          Le `h2` de la réponse Code du travail étant absent, l'accordéon suit
+          directement le `h1` : son titre passe en `h2` pour que la hiérarchie
+          des titres reste valide (#7458). */}
       {isNoCDT && (
         <ContributionAgreementDeclinations
           items={agreementDeclinations}
+          titleAs="h2"
           className={fr.cx("fr-mt-6w", "fr-mb-6w")}
         />
       )}

--- a/packages/code-du-travail-frontend/src/modules/contributions/__tests__/ContributionAgreementDeclinations.test.tsx
+++ b/packages/code-du-travail-frontend/src/modules/contributions/__tests__/ContributionAgreementDeclinations.test.tsx
@@ -61,6 +61,28 @@ describe("<ContributionAgreementDeclinations />", () => {
     expect(getAllByRole("link")).toHaveLength(2);
   });
 
+  // #7458 : sur une contribution sans réponse générique, l'accordéon suit
+  // directement le h1 de la page — il doit alors porter un h2.
+  it("titre l'accordéon en h3 par défaut et en h2 sur demande", () => {
+    const { getByRole, unmount } = render(
+      <ContributionAgreementDeclinations items={items} />
+    );
+    expect(
+      getByRole("heading", { level: 3, name: AGREEMENT_DECLINATIONS_LABEL })
+    ).toBeInTheDocument();
+    unmount();
+
+    const { getByRole: getByRoleAsH2 } = render(
+      <ContributionAgreementDeclinations items={items} titleAs="h2" />
+    );
+    expect(
+      getByRoleAsH2("heading", {
+        level: 2,
+        name: AGREEMENT_DECLINATIONS_LABEL,
+      })
+    ).toBeInTheDocument();
+  });
+
   it("émet un event Matomo au clic sur une déclinaison", () => {
     const { getByText } = render(
       <ContributionAgreementDeclinations items={items} />

--- a/packages/code-du-travail-frontend/src/modules/contributions/__tests__/contributions.test.tsx
+++ b/packages/code-du-travail-frontend/src/modules/contributions/__tests__/contributions.test.tsx
@@ -289,8 +289,10 @@ describe("<ContributionLayout />", () => {
         />
       );
 
+      // Sans réponse Code du travail, aucun h2 ne précède l'accordéon : son
+      // titre est donc un h2, sous le h1 de la page (#7458).
       const accordionTitle = rendering.getByRole("heading", {
-        level: 3,
+        level: 2,
         name: ui.agreementDeclinationsLabel,
       });
       expect(accordionTitle).toBeInTheDocument();
@@ -302,6 +304,34 @@ describe("<ContributionLayout />", () => {
       expect(accordionTitle.closest("section")?.className).toContain(
         "fr-mb-6w"
       );
+    });
+
+    // #7458 : la hiérarchie doit rester continue (h1 → h2 → h3) dans les deux
+    // cas. Le formulaire « Personnalisez la réponse » ne porte qu'un
+    // `role="heading"`, il ne compte pas pour la validation HTML.
+    it("n'ouvre aucun niveau de titre sans son parent, avec ou sans réponse Code du travail", () => {
+      const levelsOf = (container: HTMLElement) =>
+        Array.from(container.querySelectorAll("h1, h2, h3, h4, h5, h6")).map(
+          (heading) => Number(heading.tagName[1])
+        );
+
+      for (const isNoCDT of [false, true]) {
+        const { container, unmount } = render(
+          <ContributionLayout
+            contribution={{ ...contribution, isNoCDT }}
+            agreementDeclinations={agreementDeclinations}
+          />
+        );
+
+        const levels = levelsOf(container);
+        expect(levels[0]).toBe(1);
+        levels.forEach((level, index) => {
+          if (index === 0) return;
+          expect(level).toBeLessThanOrEqual(levels[index - 1] + 1);
+        });
+
+        unmount();
+      }
     });
 
     it("n'affiche pas l'accordéon sur une page convention collective", () => {


### PR DESCRIPTION
Closes #7458

## Problème

Sur une contribution **sans réponse générique** (`isNoCDT`), la page n'affiche pas le bloc « Réponse d'après le Code du Travail » — donc **aucun `h2`** — et rend directement l'accordéon « Votre réponse en fonction de votre convention collective », dont le titre était figé en `h3`. La page enchaînait `h1` → `h3`, ce que la règle `heading-level` de `html-validate` refuse.

Le job e2e « HTML validation » échouait ([run 33343116552](https://github.com/SocialGouv/code-du-travail-numerique/actions/runs/33343116552)) sur 4 pages, toutes avec le même message : `[heading-level] Heading level can only increase by one, expected <h2> but got <h3>`.

Structure constatée sur le HTML servi en preprod :

```html
<h1 class="fr-mb-0">…</h1>
<p role="heading" aria-level="2" …>Personnalisez la réponse…</p>
<h3 class="fr-accordion__title">…</h3>   <!-- erreur -->
```

Le `<p role="heading" aria-level="2">` du formulaire ne comble pas le trou : vérifié en exécutant `html-validate@10.7.0`, la règle `heading-level` n'observe que les balises `h1`–`h6`, pas les rôles ARIA.

Pages en échec :
- `/contribution/quelles-sont-les-primes-prevues-par-la-convention-collective`
- `/contribution/le-salarie-peut-il-sabsenter-pour-rechercher-un-emploi-pendant-son-preavis`
- `/contribution/quand-le-salarie-a-t-il-droit-a-une-prime-danciennete-quel-est-son-montant`
- `/contribution/quelles-sont-les-conditions-dattribution-de-la-prime-pour-travaux-dangereux-et-de-la-prime-pour-travaux-insalubres`

## Correctif

Le niveau du titre de l'accordéon suit désormais le contexte de rendu :

- `ContributionAgreementDeclinations` accepte une prop optionnelle `titleAs?: "h2" | "h3"` (défaut `"h3"` — cas nominal, imbriqué sous la réponse Code du travail, inchangé) ;
- `ContributionGeneric` lui passe `titleAs="h2"` dans la branche `isNoCDT`, où l'accordéon suit directement le `h1`.

**Aucun changement visuel** : le DSFR fixe `.fr-accordion__title { font-size: unset }`, la taille du titre vient du conteneur et non de la balise.

## Tests

- `contributions.test.tsx` : le test « liste les déclinaisons sur une contribution sans réponse Code du travail » attend maintenant `level: 2`.
- `contributions.test.tsx` : nouveau test de régression qui, pour `isNoCDT` à `false` puis `true`, lit tous les `h1`–`h6` du rendu et vérifie qu'aucun niveau ne saute d'un cran — le garde-fou unitaire équivalent à la règle `heading-level`.
- `ContributionAgreementDeclinations.test.tsx` : test unitaire de la prop `titleAs` (`h3` par défaut, `h2` sur demande).

Contre-épreuve effectuée : en retirant `titleAs="h2"` de `ContributionGeneric.tsx`, le nouveau test de hiérarchie échoue bien (`Expected: <= 2 / Received: 3`).

`npx jest src/modules/contributions` : **95 tests passent**. Seule `queries.es.test.ts` ne tourne pas en local (dépendance workspace non construite dans le worktree) ; elle relève de `pnpm test:api`, pas de `test:frontend`.

La validation de bout en bout viendra du job e2e `validate-html-contributions.e2e.ts`, qui rejoue les URLs du sitemap via `validateHtml` une fois la branche déployée en preprod.

## Hors périmètre

La question produit posée en commentaire par @m-maillot (« est-ce qu'on ne met pas l'accordéon des CC visible directement dans tous les cas ? ») attend l'arbitrage de @Fantine-py. Ce correctif ne change pas le comportement d'affichage.